### PR TITLE
Add repo-hygiene pack: issue/PR templates, CODEOWNERS, CONTRIBUTING, README badges

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default reviewer for everything in this repo.
+*   @djankov

--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,64 @@
+name: Bug
+description: Report a defect in gmat-run.
+title: "<short summary>"
+labels: ["type:bug"]
+body:
+  - type: textarea
+    id: what_happened
+    attributes:
+      label: What happened
+      description: Observed behavior. Include error messages and tracebacks verbatim.
+    validations:
+      required: true
+  - type: textarea
+    id: what_expected
+    attributes:
+      label: What you expected
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproduction
+      description: Smallest snippet that triggers the bug. A `.script` fragment plus the Python that drives it is ideal.
+      render: python
+    validations:
+      required: true
+  - type: input
+    id: gmat_run_version
+    attributes:
+      label: gmat-run version
+      placeholder: "e.g. 0.1.0, or git sha"
+    validations:
+      required: true
+  - type: input
+    id: gmat_version
+    attributes:
+      label: GMAT version
+      placeholder: "e.g. R2026a"
+    validations:
+      required: true
+  - type: input
+    id: python_version
+    attributes:
+      label: Python version
+      placeholder: "e.g. 3.12.3"
+    validations:
+      required: true
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating system
+      options:
+        - Linux
+        - Windows
+        - macOS
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Relevant GMAT.log output, captured stderr, pytest output.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/chore.yml
+++ b/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,25 @@
+name: Chore
+description: Tooling, infra, hygiene, or other non-feature work.
+title: "<short summary>"
+labels: ["type:chore"]
+body:
+  - type: textarea
+    id: what
+    attributes:
+      label: What
+      description: What needs to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why
+      description: Why now. What's blocked or painful without it.
+    validations:
+      required: true
+  - type: textarea
+    id: done
+    attributes:
+      label: Definition of done
+      value: |
+        - [ ]

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question or discussion
+    url: https://github.com/astro-tools/gmat-run/discussions
+    about: Open a discussion for usage questions, ideas, or general chat.

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,39 @@
+name: Feature
+description: Propose a new capability or a non-trivial change.
+title: "<short summary>"
+labels: ["type:feature"]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One or two sentences describing what this feature is.
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why this matters. What can't users do today that they should be able to do?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Concrete, testable checkboxes. An outside reviewer should be able to read these and tell whether the feature is done.
+      value: |
+        - [ ]
+        - [ ]
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope / non-goals
+      description: What this issue deliberately does not cover. Helps keep scope honest.
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: Design notes, links to charter sections, references to prior art, open questions.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+<!--
+Thanks for contributing to gmat-run. Keep PRs small and scoped to one issue.
+-->
+
+## Summary
+
+<!-- One or two sentences: what this PR changes and why. -->
+
+Closes #
+
+## Changes
+
+<!-- Short bullet list of the substantive changes. Omit trivia (formatting, imports). -->
+
+-
+
+## Tested with
+
+<!-- Tick what you ran locally. CI will re-run on both Ubuntu and Windows. -->
+
+- [ ] `pytest`
+- [ ] `ruff check`
+- [ ] `mypy`
+- [ ] End-to-end smoke against a stock GMAT sample (if this PR touches the run/load path)
+
+## Breaking changes
+
+<!-- "None" if none. Otherwise: what breaks, who is affected, migration notes. -->
+
+None.
+
+## Notes for reviewers
+
+<!-- Optional. Things to look at first, known rough edges, questions for the reviewer. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing to gmat-run
+
+Thanks for your interest. This page is the one place to learn the workflow.
+
+## Getting set up
+
+```bash
+git clone https://github.com/astro-tools/gmat-run.git
+cd gmat-run
+uv sync --all-groups
+```
+
+You also need a local GMAT install to run the integration tests. gmat-run does not
+ship GMAT binaries. On Linux and Windows you can grab a build from
+[SourceForge](https://sourceforge.net/projects/gmat/files/GMAT/); R2026a is the
+primary development target.
+
+## Branches and PRs
+
+- One issue per branch. Branch names use a short prefix for type:
+  - `feat/<slug>` — new capability, tied to a `type:feature` issue.
+  - `fix/<slug>` — bug fix, tied to a `type:bug` issue.
+  - `chore/<slug>` — infra / tooling / hygiene.
+  - `docs/<slug>` — docs-only change.
+- Open a PR against `main`. Put `Closes #<N>` in the PR description so the issue
+  auto-closes on merge and the project board advances the card to Done.
+- Squash-merge is the only merge method. The PR title becomes the squash commit
+  subject — write it as a complete imperative sentence.
+
+## Local checks before pushing
+
+```bash
+uv run pytest           # unit tests (integration tests are gated behind a marker)
+uv run ruff check       # lint
+uv run mypy             # types
+```
+
+CI re-runs all three on Ubuntu and Windows. Integration tests run in CI against a
+cached GMAT install; you do not need to run them locally unless you are touching
+the run/load path.
+
+## Commit messages
+
+Keep them short and imperative. One subject line, optional body.
+
+- "Add `ReportFile` parser"
+- "Fix leap-second off-by-one in `UTCGregorian` epoch parsing"
+
+Do not include AI or tool attribution trailers in commits, PR titles, PR descriptions,
+or comments — see the repo-level convention.
+
+## Scope discipline
+
+gmat-run's scope is deliberately narrow: run an existing `.script` and return
+results as DataFrames. Before opening a feature issue, check the charter and the
+existing issues to make sure the work belongs here and not in a future repo.
+
+- **Building missions in Python →** [`gmatpyplus`](https://github.com/weasdown/gmatpyplus).
+- **Generating `.script` text from Python →** [`pygmat`](https://pypi.org/project/pygmat/).
+- **Parallel sweeps / Monte Carlo →** a future `astro-tools/gmat-sweep`.
+
+## Questions
+
+Open a [discussion](https://github.com/astro-tools/gmat-run/discussions) rather than
+an issue for open-ended questions, usage help, or brainstorming.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # gmat-run
 
+[![CI](https://github.com/astro-tools/gmat-run/actions/workflows/ci.yml/badge.svg)](https://github.com/astro-tools/gmat-run/actions/workflows/ci.yml)
+[![PyPI](https://img.shields.io/pypi/v/gmat-run.svg)](https://pypi.org/project/gmat-run/)
+[![Python versions](https://img.shields.io/pypi/pyversions/gmat-run.svg)](https://pypi.org/project/gmat-run/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+
 Run GMAT mission scripts from Python and get results as pandas DataFrames.
 
 > **Status:** pre-alpha. Scaffolding only — no public API yet.


### PR DESCRIPTION
## Summary

Lands the standard repo-hygiene pack so every subsequent issue and PR follows a template, and every contributor has one place to learn the workflow.

Closes #1.

## Changes

- \`.github/ISSUE_TEMPLATE/{feature,bug,chore}.yml\` — structured forms, each auto-applying its own \`type:*\` label.
- \`.github/ISSUE_TEMPLATE/config.yml\` — disables blank issues and points at Discussions for open-ended questions.
- \`.github/pull_request_template.md\` — \`Closes #N\` line, tested-with checklist, breaking-changes callout.
- \`.github/CODEOWNERS\` — \`@djankov\` as default reviewer.
- \`CONTRIBUTING.md\` — one-page workflow doc: branch naming, local checks, scope discipline, pointers to gmatpyplus / pygmat / future gmat-sweep for out-of-scope work.
- README badges for CI, PyPI, Python versions, and licence.

## Tested with

- [x] \`ruff check\`
- [x] \`mypy\`
- [x] \`pytest\` (existing smoke test still passes)
- n/a end-to-end — this PR is pure repo hygiene, no code paths touched.

## Breaking changes

None.

## Notes for reviewers

The CI badge points at a \`ci.yml\` workflow that does not exist yet — it will start rendering as "no status" for now and go green once issue #2 (CI workflow) lands. Same for the PyPI / Python-versions badges, which will fill in once we publish v0.1.