### PR TITLE
Add CI: install GMAT, run pytest + lint + typecheck on Ubuntu and Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,137 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  GMAT_VERSION: R2026a
+
+jobs:
+  test:
+    name: test (${{ matrix.os }}, py${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ['3.10', '3.11', '3.12']
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Restore GMAT cache
+        id: cache-gmat
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/gmat
+          key: gmat-${{ runner.os }}-${{ env.GMAT_VERSION }}-v1
+
+      - name: Download and extract GMAT (Linux)
+        if: runner.os == 'Linux' && steps.cache-gmat.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          url="https://sourceforge.net/projects/gmat/files/GMAT/GMAT-${GMAT_VERSION}/gmat-ubuntu-x64-${GMAT_VERSION}.tar.gz/download"
+          curl -fL --retry 3 --retry-delay 5 -o gmat.tar.gz "$url"
+          mkdir -p gmat-extract
+          tar -xzf gmat.tar.gz -C gmat-extract
+          api_script=$(find gmat-extract -name BuildApiStartupFile.py -print -quit)
+          if [ -z "$api_script" ]; then
+            echo "::error::Could not locate BuildApiStartupFile.py in extracted archive"
+            find gmat-extract -maxdepth 3 -type d
+            exit 1
+          fi
+          gmat_root=$(dirname "$(dirname "$api_script")")
+          mv "$gmat_root" "${RUNNER_TEMP}/gmat"
+          rm -rf gmat-extract gmat.tar.gz
+
+      - name: Download and extract GMAT (Windows)
+        if: runner.os == 'Windows' && steps.cache-gmat.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $url = "https://sourceforge.net/projects/gmat/files/GMAT/GMAT-$env:GMAT_VERSION/gmat-win-$env:GMAT_VERSION.zip/download"
+          Invoke-WebRequest -Uri $url -OutFile gmat.zip -UseBasicParsing
+          $extractDir = Join-Path $env:RUNNER_TEMP 'gmat-extract'
+          Expand-Archive -Path gmat.zip -DestinationPath $extractDir
+          $apiScript = Get-ChildItem -Path $extractDir -Recurse -Filter BuildApiStartupFile.py | Select-Object -First 1
+          if ($null -eq $apiScript) {
+            Write-Error "Could not locate BuildApiStartupFile.py in extracted archive"
+            Get-ChildItem -Path $extractDir -Recurse -Depth 2 -Directory | ForEach-Object { $_.FullName }
+            exit 1
+          }
+          $gmatRoot = Split-Path -Parent (Split-Path -Parent $apiScript.FullName)
+          Move-Item -Path $gmatRoot -Destination (Join-Path $env:RUNNER_TEMP 'gmat')
+          Remove-Item gmat.zip
+          Remove-Item $extractDir -Recurse -Force -ErrorAction SilentlyContinue
+
+      - name: Resolve GMAT_ROOT
+        shell: bash
+        run: |
+          set -euo pipefail
+          gmat_root="${RUNNER_TEMP}/gmat"
+          if [ ! -f "${gmat_root}/api/BuildApiStartupFile.py" ]; then
+            echo "::error::GMAT install incomplete at ${gmat_root}"
+            ls -la "${gmat_root}" || true
+            exit 1
+          fi
+          echo "GMAT_ROOT=${gmat_root}" >> "$GITHUB_ENV"
+
+      - name: Generate api_startup_file.txt
+        shell: bash
+        run: python "${GMAT_ROOT}/api/BuildApiStartupFile.py"
+
+      - name: Install project
+        run: uv sync --all-groups
+
+      - name: Run pytest
+        run: uv run pytest
+
+  lint:
+    name: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - run: uv sync --all-groups
+      - run: uv run ruff check
+
+  typecheck:
+    name: typecheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - run: uv sync --all-groups
+      - run: uv run mypy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,15 @@ jobs:
         run: |
           $ErrorActionPreference = 'Stop'
           $url = "https://sourceforge.net/projects/gmat/files/GMAT/GMAT-$env:GMAT_VERSION/gmat-win-$env:GMAT_VERSION.zip/download"
-          Invoke-WebRequest -Uri $url -OutFile gmat.zip -UseBasicParsing
+          # curl.exe ships with windows-latest runners; use it for parity with the Linux job
+          # and because Invoke-WebRequest does not reliably follow SourceForge's mirror redirects.
+          curl.exe -fL --retry 3 --retry-delay 5 -o gmat.zip $url
+          $size = (Get-Item gmat.zip).Length
+          Write-Host "Downloaded gmat.zip size: $size bytes"
+          if ($size -lt 100MB) {
+            Write-Error "Downloaded archive looks truncated ($size bytes); aborting"
+            exit 1
+          }
           $extractDir = Join-Path $env:RUNNER_TEMP 'gmat-extract'
           Expand-Archive -Path gmat.zip -DestinationPath $extractDir
           $apiScript = Get-ChildItem -Path $extractDir -Recurse -Filter BuildApiStartupFile.py | Select-Object -First 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,10 @@ jobs:
         run: |
           set -euo pipefail
           url="https://sourceforge.net/projects/gmat/files/GMAT/GMAT-${GMAT_VERSION}/gmat-ubuntu-x64-${GMAT_VERSION}.tar.gz/download"
-          curl -fL --retry 3 --retry-delay 5 -o gmat.tar.gz "$url"
+          # --retry-all-errors covers mid-stream connection drops from slow SourceForge mirrors
+          # (plain --retry only retries on initial connection failures).
+          curl -fL --retry 5 --retry-delay 10 --retry-all-errors --connect-timeout 30 \
+            -o gmat.tar.gz "$url"
           mkdir -p gmat-extract
           tar -xzf gmat.tar.gz -C gmat-extract
           api_script=$(find gmat-extract -name BuildApiStartupFile.py -print -quit)
@@ -70,10 +73,19 @@ jobs:
           $url = "https://sourceforge.net/projects/gmat/files/GMAT/GMAT-$env:GMAT_VERSION/gmat-win-$env:GMAT_VERSION.zip/download"
           # curl.exe ships with windows-latest runners; use it for parity with the Linux job
           # and because Invoke-WebRequest does not reliably follow SourceForge's mirror redirects.
-          curl.exe -fL --retry 3 --retry-delay 5 -o gmat.zip $url
+          # --retry-all-errors covers mid-stream connection drops on slow SourceForge mirrors;
+          # plain --retry only retries on initial connection failures, not partial downloads.
+          curl.exe -fL --retry 5 --retry-delay 10 --retry-all-errors --connect-timeout 30 `
+            -o gmat.zip $url
+          # PowerShell does not auto-check native exit codes; check explicitly.
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "curl exited with code $LASTEXITCODE"
+            exit 1
+          }
           $size = (Get-Item gmat.zip).Length
           Write-Host "Downloaded gmat.zip size: $size bytes"
-          if ($size -lt 100MB) {
+          # The R2026a Windows zip is ~403 MB; threshold is conservatively 380 MB.
+          if ($size -lt 380MB) {
             Write-Error "Downloaded archive looks truncated ($size bytes); aborting"
             exit 1
           }


### PR DESCRIPTION
## Summary

- New workflow `.github/workflows/ci.yml` runs on push to `main` and on all PRs.
- **test** job: matrix `{ubuntu-latest, windows-latest} × {3.10, 3.11, 3.12}`. Downloads GMAT R2026a from SourceForge, caches the extracted install per-OS keyed on `GMAT_VERSION`, generates `api_startup_file.txt`, then `uv sync --all-groups && uv run pytest`. 30-minute job timeout.
- **lint** and **typecheck** jobs: `ruff check` and `mypy` on Ubuntu / Python 3.12; no GMAT install needed (`gmatpy` is mypy-overridden in `pyproject.toml`).
- Concurrency cancels superseded PR runs but leaves `main` runs alone.
- Install/extract steps are intentionally inline so they can later be lifted into a reusable `astro-tools/setup-gmat` composite action (separate repo, separate issue, per the charter).

## Test plan

- [ ] First PR run on Ubuntu completes the GMAT download + extract + `BuildApiStartupFile.py` step on cache miss.
- [ ] First PR run on Windows completes the same path.
- [ ] Second run hits the GMAT cache on both OSes (no re-download).
- [ ] All 6 test-matrix legs pass against the existing smoke test.
- [ ] `lint` and `typecheck` jobs pass.
- [ ] Concurrency cancels a superseded PR run when a new commit is pushed.
- [ ] README CI badge resolves green.

## Out of scope (deferred per issue)

- macOS runner — v0.2.
- Reusable `setup-gmat` composite action — separate repo.

Closes #2