### PR TITLE
Add `bootstrap`: load gmatpy for a resolved GMAT install

### DIFF
--- a/src/gmat_run/__init__.py
+++ b/src/gmat_run/__init__.py
@@ -1,14 +1,17 @@
 """gmat-run: run GMAT mission scripts from Python and get results as pandas DataFrames."""
 
-from gmat_run.errors import GmatNotFoundError, GmatRunError
+from gmat_run.errors import GmatLoadError, GmatNotFoundError, GmatRunError
 from gmat_run.install import GmatInstall, locate_gmat
+from gmat_run.runtime import bootstrap
 
 __version__ = "0.0.0"
 
 __all__ = [
     "GmatInstall",
+    "GmatLoadError",
     "GmatNotFoundError",
     "GmatRunError",
     "__version__",
+    "bootstrap",
     "locate_gmat",
 ]

--- a/src/gmat_run/errors.py
+++ b/src/gmat_run/errors.py
@@ -8,6 +8,17 @@ class GmatRunError(Exception):
     """Base class for all gmat-run errors."""
 
 
+class GmatLoadError(GmatRunError):
+    """Raised when gmatpy cannot be loaded for a resolved GMAT install.
+
+    Covers unsupported Python versions (gmatpy ships per-Python-minor shared
+    libraries), missing shared libraries, failed generation of the API startup
+    file, and attempts to bootstrap a second install in one interpreter. The
+    triggering ``ImportError`` or ``CalledProcessError`` is chained via
+    ``__cause__``.
+    """
+
+
 class GmatNotFoundError(GmatRunError):
     """Raised when no usable GMAT install can be located.
 

--- a/src/gmat_run/runtime.py
+++ b/src/gmat_run/runtime.py
@@ -1,0 +1,107 @@
+"""Load gmatpy for a resolved GMAT install.
+
+The single public entry point is :func:`bootstrap`, which takes a
+:class:`~gmat_run.install.GmatInstall`, ensures the API startup file exists
+(generating it on first use via GMAT's ``BuildApiStartupFile.py``), adds the
+install's ``bin/`` directory to :data:`sys.path`, imports ``gmatpy``, calls
+``gmat.Setup(...)`` on the API startup file, and returns the imported module.
+
+Idempotent within a single interpreter. A second call requesting a different
+install raises :class:`~gmat_run.errors.GmatLoadError` — gmatpy cannot be
+cleanly reinitialised once loaded.
+"""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+import tempfile
+from types import ModuleType
+
+from gmat_run.errors import GmatLoadError
+from gmat_run.install import GmatInstall
+
+__all__ = ["bootstrap"]
+
+
+_bootstrapped: tuple[GmatInstall, ModuleType] | None = None
+
+
+def bootstrap(install: GmatInstall) -> ModuleType:
+    """Load gmatpy for ``install`` and return the imported module.
+
+    On first call: ensures ``<install.bin_dir>/api_startup_file.txt`` exists
+    (generating it via ``<install.api_dir>/BuildApiStartupFile.py`` if
+    missing), prepends the bin directory to :data:`sys.path`, imports
+    ``gmatpy``, and calls ``gmatpy.Setup(...)`` on the API startup file.
+
+    Subsequent calls with the same install return the cached module handle.
+    Calls with a different install raise — gmatpy cannot be reinitialised.
+
+    Raises:
+        GmatLoadError: gmatpy could not be imported for this install, the
+            API startup file could not be generated, or a second install
+            was requested.
+    """
+    global _bootstrapped
+
+    if _bootstrapped is not None:
+        cached_install, cached_module = _bootstrapped
+        if cached_install == install:
+            return cached_module
+        raise GmatLoadError(
+            "cannot bootstrap a second GMAT install in one interpreter; "
+            f"gmatpy is already bound to {cached_install.root}"
+        )
+
+    _ensure_api_startup_file(install)
+
+    bin_dir = str(install.bin_dir)
+    if bin_dir not in sys.path:
+        # insert(1, ...) matches GMAT's own load_gmat.py template, preserving
+        # index 0 (typically the current directory) ahead of the install bin.
+        sys.path.insert(1, bin_dir)
+
+    try:
+        gmat = importlib.import_module("gmatpy")
+    except ImportError as exc:
+        py = f"{sys.version_info.major}.{sys.version_info.minor}"
+        raise GmatLoadError(
+            f"could not import gmatpy from {install.bin_dir}; Python {py} "
+            "may not be supported by this GMAT install"
+        ) from exc
+
+    startup_file = install.bin_dir / "api_startup_file.txt"
+    gmat.Setup(str(startup_file))
+
+    _bootstrapped = (install, gmat)
+    return gmat
+
+
+def _ensure_api_startup_file(install: GmatInstall) -> None:
+    startup_file = install.bin_dir / "api_startup_file.txt"
+    if startup_file.is_file():
+        return
+
+    script = install.api_dir / "BuildApiStartupFile.py"
+    # BuildApiStartupFile.py writes api_startup_file.txt to bin/ via an
+    # absolute path, so cwd does not affect the real output. When a debug
+    # build exists, the script ALSO writes api_startup_file_d.txt via a
+    # relative path — a throwaway cwd keeps that stray file out of the
+    # caller's directory and the install tree.
+    with tempfile.TemporaryDirectory() as tmp:
+        try:
+            subprocess.run(
+                [sys.executable, str(script)],
+                check=True,
+                cwd=tmp,
+                capture_output=True,
+                text=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            raise GmatLoadError(
+                f"failed to generate {startup_file}: "
+                f"{script.name} exited with code {exc.returncode}\n"
+                f"{exc.stderr}"
+            ) from exc

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,215 @@
+"""Unit tests for gmat_run.runtime.
+
+All tests fabricate a fake install layout under ``tmp_path`` and a minimal
+fake ``gmatpy`` package; no real GMAT install is required.
+"""
+
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from gmat_run import runtime
+from gmat_run.errors import GmatLoadError
+from gmat_run.install import GmatInstall
+
+# --- fixtures & helpers -------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_runtime() -> Iterator[None]:
+    """Restore sys.path, sys.modules (gmatpy), and the module-level cache.
+
+    bootstrap() mutates all three. Without this fixture, state leaks between
+    tests and the fake gmatpy from one test is visible to the next.
+    """
+
+    def _drop_gmatpy() -> None:
+        for mod in [m for m in sys.modules if m == "gmatpy" or m.startswith("gmatpy.")]:
+            del sys.modules[mod]
+
+    path_snapshot = sys.path.copy()
+    runtime._bootstrapped = None
+    _drop_gmatpy()
+    yield
+    _drop_gmatpy()
+    sys.path[:] = path_snapshot
+    runtime._bootstrapped = None
+
+
+def _make_install(root: Path) -> GmatInstall:
+    """Fabricate a minimal GMAT install layout and return a GmatInstall."""
+    (root / "bin" / "gmatpy").mkdir(parents=True)
+    (root / "api").mkdir()
+    (root / "api" / "load_gmat.py").write_text("# fake load_gmat\n", encoding="utf-8")
+    return GmatInstall(
+        root=root,
+        bin_dir=root / "bin",
+        api_dir=root / "api",
+        output_dir=root / "output",
+        version="R2026a",
+    )
+
+
+def _write_fake_gmatpy(install: GmatInstall, *, import_error: str | None = None) -> None:
+    """Plant a fake gmatpy package in ``install.bin_dir/gmatpy``."""
+    init = install.bin_dir / "gmatpy" / "__init__.py"
+    if import_error is not None:
+        init.write_text(f"raise ImportError({import_error!r})\n", encoding="utf-8")
+    else:
+        init.write_text(
+            "SETUP_CALLS = []\n"
+            "def Setup(path):\n"
+            "    SETUP_CALLS.append(path)\n",
+            encoding="utf-8",
+        )
+
+
+def _write_fake_builder(
+    install: GmatInstall,
+    *,
+    exit_code: int = 0,
+    stderr_message: str = "builder failed",
+) -> Path:
+    """Write a stand-in for BuildApiStartupFile.py.
+
+    Happy-path variant writes ``<bin>/api_startup_file.txt`` and increments a
+    run counter (so tests can prove the builder ran exactly once). Failure
+    variant prints ``stderr_message`` and exits non-zero.
+    """
+    script = install.api_dir / "BuildApiStartupFile.py"
+    counter = install.root / "_builder_runs"
+    if exit_code == 0:
+        script.write_text(
+            "import os\n"
+            "here = os.path.dirname(os.path.abspath(__file__))\n"
+            "root = os.path.dirname(here)\n"
+            "with open(os.path.join(root, 'bin', 'api_startup_file.txt'), 'w') as f:\n"
+            "    f.write('# fake api startup\\n')\n"
+            f"counter = {str(counter)!r}\n"
+            "prev = 0\n"
+            "if os.path.isfile(counter):\n"
+            "    with open(counter) as f: prev = int(f.read() or '0')\n"
+            "with open(counter, 'w') as f: f.write(str(prev + 1))\n",
+            encoding="utf-8",
+        )
+    else:
+        script.write_text(
+            f"import sys\nprint({stderr_message!r}, file=sys.stderr)\nsys.exit({exit_code})\n",
+            encoding="utf-8",
+        )
+    return script
+
+
+def _builder_run_count(install: GmatInstall) -> int:
+    counter = install.root / "_builder_runs"
+    if not counter.is_file():
+        return 0
+    return int(counter.read_text() or "0")
+
+
+# --- happy path ---------------------------------------------------------------
+
+
+def test_bootstrap_returns_gmatpy_module_with_setup_called(tmp_path: Path) -> None:
+    install = _make_install(tmp_path / "gmat")
+    _write_fake_gmatpy(install)
+    (install.bin_dir / "api_startup_file.txt").write_text("# pre-existing\n")
+
+    gmat = runtime.bootstrap(install)
+
+    assert [str(install.bin_dir / "api_startup_file.txt")] == gmat.SETUP_CALLS
+    assert str(install.bin_dir) in sys.path
+
+
+def test_bootstrap_skips_builder_when_startup_file_exists(tmp_path: Path) -> None:
+    install = _make_install(tmp_path / "gmat")
+    _write_fake_gmatpy(install)
+    _write_fake_builder(install)
+    (install.bin_dir / "api_startup_file.txt").write_text("# pre-existing\n")
+
+    runtime.bootstrap(install)
+
+    assert _builder_run_count(install) == 0
+
+
+# --- startup file generation --------------------------------------------------
+
+
+def test_bootstrap_generates_startup_file_when_missing(tmp_path: Path) -> None:
+    install = _make_install(tmp_path / "gmat")
+    _write_fake_gmatpy(install)
+    _write_fake_builder(install)
+
+    runtime.bootstrap(install)
+
+    startup_file = install.bin_dir / "api_startup_file.txt"
+    assert startup_file.is_file()
+    assert _builder_run_count(install) == 1
+
+
+def test_bootstrap_raises_when_builder_fails(tmp_path: Path) -> None:
+    install = _make_install(tmp_path / "gmat")
+    _write_fake_gmatpy(install)
+    _write_fake_builder(install, exit_code=2, stderr_message="no startup file")
+
+    with pytest.raises(GmatLoadError) as excinfo:
+        runtime.bootstrap(install)
+
+    import subprocess
+
+    assert isinstance(excinfo.value.__cause__, subprocess.CalledProcessError)
+    assert "no startup file" in str(excinfo.value)
+    assert "BuildApiStartupFile.py" in str(excinfo.value)
+
+
+# --- idempotency & single-install invariant -----------------------------------
+
+
+def test_bootstrap_is_idempotent_for_same_install(tmp_path: Path) -> None:
+    install = _make_install(tmp_path / "gmat")
+    _write_fake_gmatpy(install)
+    _write_fake_builder(install)
+
+    first = runtime.bootstrap(install)
+    second = runtime.bootstrap(install)
+
+    assert first is second
+    # Setup called exactly once despite two bootstrap calls.
+    assert [str(install.bin_dir / "api_startup_file.txt")] == first.SETUP_CALLS
+    # Builder ran exactly once (startup file cached after the first call).
+    assert _builder_run_count(install) == 1
+
+
+def test_bootstrap_rejects_second_install(tmp_path: Path) -> None:
+    install_a = _make_install(tmp_path / "gmat-a")
+    install_b = _make_install(tmp_path / "gmat-b")
+    _write_fake_gmatpy(install_a)
+    _write_fake_gmatpy(install_b)
+    (install_a.bin_dir / "api_startup_file.txt").write_text("# a\n")
+    (install_b.bin_dir / "api_startup_file.txt").write_text("# b\n")
+
+    runtime.bootstrap(install_a)
+    with pytest.raises(GmatLoadError) as excinfo:
+        runtime.bootstrap(install_b)
+
+    assert str(install_a.root) in str(excinfo.value)
+    assert "second" in str(excinfo.value).lower()
+
+
+# --- gmatpy import failure ----------------------------------------------------
+
+
+def test_bootstrap_wraps_import_error_as_gmat_load_error(tmp_path: Path) -> None:
+    install = _make_install(tmp_path / "gmat")
+    _write_fake_gmatpy(install, import_error="py3.99 not supported")
+    (install.bin_dir / "api_startup_file.txt").write_text("# ok\n")
+
+    with pytest.raises(GmatLoadError) as excinfo:
+        runtime.bootstrap(install)
+
+    assert isinstance(excinfo.value.__cause__, ImportError)
+    assert str(install.bin_dir) in str(excinfo.value)
+    py = f"{sys.version_info.major}.{sys.version_info.minor}"
+    assert py in str(excinfo.value)


### PR DESCRIPTION
## Summary

- `gmat_run.runtime.bootstrap(install)` prepends the install's bin/ to `sys.path`, imports `gmatpy`, calls `gmat.Setup(...)` on the API startup file, and returns the module handle.
- Generates `<bin>/api_startup_file.txt` via GMAT's `BuildApiStartupFile.py` on first use when missing. The builder is invoked with `cwd` set to a `TemporaryDirectory` so the stray `api_startup_file_d.txt` that GMAT's script writes via a relative path (only when a `debug/` dir exists) lands in a throwaway location instead of the install tree or the caller's cwd.
- Idempotent: a repeat call for the same install returns the cached module; a call for a different install raises `GmatLoadError` — gmatpy cannot be cleanly reinitialised.
- New `GmatLoadError(GmatRunError)` covers unsupported Python versions, failed gmatpy imports, and failed API-startup-file generation. The triggering `ImportError` / `CalledProcessError` is chained via `__cause__`.
- `bootstrap` and `GmatLoadError` are re-exported from `gmat_run`.

## Known limitation

On Linux, `gmatpy/__init__.py` does not `dlopen` GMAT's shared libraries; the dynamic loader typically needs `LD_LIBRARY_PATH=<install>/bin` set before `python` launches, which cannot be fixed from within the running interpreter. `bootstrap` currently does not address this — a follow-up issue should document it or provide a wrapper entry point.

## Test plan

- [x] `uv run pytest` — 36 passed (7 new + 29 existing).
- [x] `uv run ruff check` — clean.
- [x] `uv run mypy` — clean under `--strict`.
- [x] CI passes on Ubuntu + Windows for py3.10 / 3.11 / 3.12, plus lint and typecheck jobs.
- [ ] Integration sanity check against the local R2026a install on WSL (manual, follow-up).

New unit tests cover:
- Happy path with pre-existing `api_startup_file.txt` (no builder invoked).
- Missing startup file → builder invoked → file generated.
- Builder failure → `GmatLoadError` with `CalledProcessError` chained and stderr in the message.
- Same-install idempotency: same module returned, `Setup` called once, builder ran once.
- Second-install rejection: clear error citing the first install's root.
- `gmatpy` import failure → `GmatLoadError` with `ImportError` chained, Python version in message.

Closes #4.