### PR TITLE
Add typed exception hierarchy in `errors.py`

### DIFF
--- a/src/gmat_run/__init__.py
+++ b/src/gmat_run/__init__.py
@@ -1,15 +1,25 @@
 """gmat-run: run GMAT mission scripts from Python and get results as pandas DataFrames."""
 
-from gmat_run.errors import GmatLoadError, GmatNotFoundError, GmatRunError
+from gmat_run.errors import (
+    GmatError,
+    GmatFieldError,
+    GmatLoadError,
+    GmatNotFoundError,
+    GmatOutputParseError,
+    GmatRunError,
+)
 from gmat_run.install import GmatInstall, locate_gmat
 from gmat_run.runtime import bootstrap
 
 __version__ = "0.0.0"
 
 __all__ = [
+    "GmatError",
+    "GmatFieldError",
     "GmatInstall",
     "GmatLoadError",
     "GmatNotFoundError",
+    "GmatOutputParseError",
     "GmatRunError",
     "__version__",
     "bootstrap",

--- a/src/gmat_run/errors.py
+++ b/src/gmat_run/errors.py
@@ -1,25 +1,22 @@
-"""Typed exception hierarchy for gmat-run."""
+"""Typed exception hierarchy for gmat-run.
+
+Every exception the library raises inherits from :class:`GmatError`, so
+downstream code can branch on failure mode without string-parsing GMAT's log
+output. Leaf classes carry the payload relevant to their failure mode as
+attributes (``attempts``, ``log``, ``path``, ``value``), never only as the
+formatted message.
+"""
 
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 
-class GmatRunError(Exception):
-    """Base class for all gmat-run errors."""
+class GmatError(Exception):
+    """Base class for every exception raised by gmat-run."""
 
 
-class GmatLoadError(GmatRunError):
-    """Raised when gmatpy cannot be loaded for a resolved GMAT install.
-
-    Covers unsupported Python versions (gmatpy ships per-Python-minor shared
-    libraries), missing shared libraries, failed generation of the API startup
-    file, and attempts to bootstrap a second install in one interpreter. The
-    triggering ``ImportError`` or ``CalledProcessError`` is chained via
-    ``__cause__``.
-    """
-
-
-class GmatNotFoundError(GmatRunError):
+class GmatNotFoundError(GmatError):
     """Raised when no usable GMAT install can be located.
 
     The ``attempts`` attribute records each search step that ran, the path that was
@@ -40,3 +37,54 @@ class GmatNotFoundError(GmatRunError):
             location = str(path) if path is not None else "(none)"
             lines.append(f"  - {step}: {location}: {reason}")
         return "\n".join(lines)
+
+
+class GmatLoadError(GmatError):
+    """Raised when gmatpy cannot be loaded for a resolved GMAT install.
+
+    Covers unsupported Python versions (gmatpy ships per-Python-minor shared
+    libraries), missing shared libraries, failed generation of the API startup
+    file, and attempts to bootstrap a second install in one interpreter. The
+    triggering ``ImportError`` or ``CalledProcessError`` is chained via
+    ``__cause__``.
+    """
+
+
+class GmatRunError(GmatError):
+    """Raised when a GMAT mission sequence fails at run time.
+
+    The ``log`` attribute carries GMAT's own stderr / log content captured during
+    the run, so callers can surface GMAT's diagnostic verbatim without re-reading
+    the log file.
+    """
+
+    def __init__(self, message: str, log: str) -> None:
+        self.log = log
+        super().__init__(message)
+
+
+class GmatOutputParseError(GmatError):
+    """Raised when a GMAT output file cannot be parsed into a DataFrame.
+
+    The ``path`` attribute points to the offending file, so callers can inspect
+    it or surface it in error messages without re-deriving the path.
+    """
+
+    def __init__(self, message: str, path: Path) -> None:
+        self.path = path
+        super().__init__(message)
+
+
+class GmatFieldError(GmatError):
+    """Raised when a dotted-path field access fails.
+
+    Covers unknown paths, type mismatches on write, and unresolvable parent
+    objects. The ``path`` attribute carries the offending dotted-path key; the
+    ``value`` attribute carries the value the caller attempted to write (or
+    ``None`` for a read), verbatim.
+    """
+
+    def __init__(self, message: str, path: str, value: Any = None) -> None:
+        self.path = path
+        self.value = value
+        super().__init__(message)

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,0 +1,95 @@
+"""Unit tests for gmat_run.errors.
+
+Raise-site tests for ``GmatNotFoundError`` and ``GmatLoadError`` live with
+their respective entry points in ``test_install.py`` and ``test_runtime.py``.
+Raise-site tests for the remaining three classes will be added alongside
+their entry points (mission / parsers / field access), which are separate
+issues. These tests cover the hierarchy shape and the attribute contract.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from gmat_run.errors import (
+    GmatError,
+    GmatFieldError,
+    GmatLoadError,
+    GmatNotFoundError,
+    GmatOutputParseError,
+    GmatRunError,
+)
+
+_CONCRETE_CLASSES = [
+    GmatNotFoundError,
+    GmatLoadError,
+    GmatRunError,
+    GmatOutputParseError,
+    GmatFieldError,
+]
+
+
+# --- hierarchy invariants -----------------------------------------------------
+
+
+def test_base_is_exception_subclass() -> None:
+    assert issubclass(GmatError, Exception)
+
+
+@pytest.mark.parametrize("cls", _CONCRETE_CLASSES)
+def test_every_concrete_class_subclasses_gmat_error(cls: type[GmatError]) -> None:
+    assert issubclass(cls, GmatError)
+    assert issubclass(cls, Exception)
+
+
+@pytest.mark.parametrize("cls", [GmatError, *_CONCRETE_CLASSES])
+def test_every_class_has_a_docstring(cls: type[GmatError]) -> None:
+    assert cls.__doc__ is not None
+    assert cls.__doc__.strip()
+
+
+# --- GmatRunError -------------------------------------------------------------
+
+
+def test_gmat_run_error_preserves_log_attribute() -> None:
+    log = "GMAT: targeter diverged\n  last DV = 1.234 km/s\n"
+    exc = GmatRunError("mission sequence failed", log)
+    assert exc.log == log
+    assert str(exc) == "mission sequence failed"
+
+
+def test_gmat_run_error_accepts_empty_log() -> None:
+    exc = GmatRunError("failed with no captured output", "")
+    assert exc.log == ""
+
+
+# --- GmatOutputParseError -----------------------------------------------------
+
+
+def test_gmat_output_parse_error_preserves_path_attribute(tmp_path: Path) -> None:
+    offending = tmp_path / "ReportFile1.txt"
+    exc = GmatOutputParseError("unexpected column count on line 3", offending)
+    assert exc.path == offending
+    assert str(exc) == "unexpected column count on line 3"
+
+
+# --- GmatFieldError -----------------------------------------------------------
+
+
+def test_gmat_field_error_preserves_path_and_value() -> None:
+    exc = GmatFieldError("unknown field", "Sat.NoSuchField", 7000.0)
+    assert exc.path == "Sat.NoSuchField"
+    assert exc.value == 7000.0
+    assert str(exc) == "unknown field"
+
+
+def test_gmat_field_error_defaults_value_to_none_for_reads() -> None:
+    exc = GmatFieldError("unknown field on read", "Sat.NoSuchField")
+    assert exc.path == "Sat.NoSuchField"
+    assert exc.value is None
+
+
+@pytest.mark.parametrize("value", ["a-string", 42, 3.14, True, None, [1, 2], {"k": "v"}])
+def test_gmat_field_error_preserves_arbitrary_value_types(value: object) -> None:
+    exc = GmatFieldError("type mismatch", "Sat.SMA", value)
+    assert exc.value == value


### PR DESCRIPTION
## Summary

- Introduce `GmatError` as the common base and give `gmat_run.errors` the full five-class hierarchy downstream code needs to branch on.
- Rebase existing `GmatNotFoundError` / `GmatLoadError` onto `GmatError`; their payload and raise sites are unchanged.
- Add `GmatRunError` (mission-run failures, carries `log`), `GmatOutputParseError` (parse failures, carries `path`), and `GmatFieldError` (dotted-path failures, carries `path` + `value`).
- Semantic break: `GmatRunError` was the base class, now it's a leaf. Package is `0.0.0` pre-alpha with no releases, so no compatibility shim.

Raise-site coverage for the three new classes will land with the modules that raise them (mission / parsers / field access) in follow-on issues. `test_errors.py` here covers hierarchy invariants, docstrings, and attribute round-trips.

## Test plan

- [x] `uv run pytest` — 60 passed locally
- [x] `uv run ruff check` — clean
- [x] `uv run mypy` — clean
- [x] CI green on Ubuntu and Windows

Closes #5