### PR TITLE
Add `ReportFile` parser: whitespace-aligned text to pandas DataFrame

### DIFF
--- a/src/gmat_run/parsers/__init__.py
+++ b/src/gmat_run/parsers/__init__.py
@@ -1,0 +1,6 @@
+"""Parsers for GMAT output files.
+
+Each parser exposes a ``parse(path) -> pandas.DataFrame`` function and depends
+only on the file layout — no ``gmatpy`` import, no GMAT install required. This
+lets parser logic be unit-tested against fixture files alone.
+"""

--- a/src/gmat_run/parsers/reportfile.py
+++ b/src/gmat_run/parsers/reportfile.py
@@ -1,0 +1,110 @@
+"""Parse a GMAT ``ReportFile`` output into a :class:`pandas.DataFrame`.
+
+GMAT writes ``ReportFile`` as whitespace-aligned text: a header row whose tokens
+are resource-qualified field names (e.g. ``Sat.Earth.SMA``), followed by data
+rows with the same column layout. Column separators are runs of two or more
+whitespace characters; values never contain two consecutive whitespace
+characters, so a ``\\s{2,}`` split cleanly handles both the numeric columns and
+the space-bearing ``UTCGregorian`` epoch format
+(``26 Nov 2026 12:00:00.000``).
+
+GMAT re-emits the header line at mission-sequence segment boundaries; those
+repeats are skipped. Duplicate *data* rows are preserved — a faithful
+round-trip is part of the acceptance contract, and distinct report events at
+the same epoch are legitimate.
+
+Epoch columns are intentionally not promoted here — ``UTCGregorian`` stays
+``str``, and ``*ModJulian`` stays ``float`` — because epoch detection belongs to
+the datetime-parsing layer (see issue #7).
+"""
+
+import os
+import re
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from gmat_run.errors import GmatOutputParseError
+
+__all__ = ["parse"]
+
+# Two-or-more whitespace: the column separator GMAT uses. A single space can
+# appear *inside* a value (``UTCGregorian``), so \s+ would shred epoch columns.
+_COLUMN_SEP = re.compile(r"\s{2,}")
+
+
+def parse(path: str | os.PathLike[str]) -> pd.DataFrame:
+    """Parse a GMAT ``ReportFile`` into a :class:`pandas.DataFrame`.
+
+    Column names are taken verbatim from the header row (dots preserved, e.g.
+    ``Sat.Earth.SMA``). Each column is coerced to ``int64`` or ``float64`` if
+    every value parses as numeric; otherwise the column stays ``object``/``str``.
+
+    Args:
+        path: Path to the ``ReportFile`` on disk.
+
+    Returns:
+        A DataFrame with one row per report event and one column per header
+        field, in header order.
+
+    Raises:
+        GmatOutputParseError: The file is empty, or a data row's column count
+            does not match the header.
+    """
+    path = Path(path)
+
+    # utf-8-sig strips an optional UTF-8 BOM; newline=None gives universal-newline
+    # translation so CRLF and LF files produce identical splits.
+    with path.open(encoding="utf-8-sig", newline=None) as fh:
+        lines = fh.read().splitlines()
+
+    header_lineno, header_line = _find_header(lines, path)
+    header_stripped = header_line.strip()
+    column_names = _COLUMN_SEP.split(header_stripped)
+
+    rows: list[list[str]] = []
+    for offset, raw_line in enumerate(lines[header_lineno:], start=header_lineno + 1):
+        stripped = raw_line.strip()
+        if not stripped:
+            continue
+        if stripped == header_stripped:
+            continue
+        tokens = _COLUMN_SEP.split(stripped)
+        if len(tokens) != len(column_names):
+            raise GmatOutputParseError(
+                f"expected {len(column_names)} columns, got {len(tokens)} on line {offset}",
+                path,
+            )
+        rows.append(tokens)
+
+    df = pd.DataFrame(rows, columns=column_names)
+    for column in df.columns:
+        df[column] = _coerce_numeric(df[column])
+    return df
+
+
+def _find_header(lines: list[str], path: Path) -> tuple[int, str]:
+    """Return ``(index, line)`` of the first non-blank line in ``lines``.
+
+    Index is 0-based over the file so the caller can slice ``lines[index:]``
+    and enumerate from there.
+    """
+    for index, line in enumerate(lines):
+        if line.strip():
+            return index, line
+    raise GmatOutputParseError("file is empty", path)
+
+
+def _coerce_numeric(series: "pd.Series[Any]") -> "pd.Series[Any]":
+    """Return ``series`` as numeric if every value parses; otherwise unchanged.
+
+    ``pd.to_numeric`` picks the narrowest dtype that fits: ``int64`` when every
+    value is an integer literal, ``float64`` otherwise (including any scientific
+    notation or decimal point). One non-numeric value leaves the column as
+    strings.
+    """
+    try:
+        return pd.to_numeric(series)
+    except (ValueError, TypeError):
+        return series

--- a/tests/test_parsers_reportfile.py
+++ b/tests/test_parsers_reportfile.py
@@ -1,0 +1,185 @@
+"""Unit tests for :func:`gmat_run.parsers.reportfile.parse`.
+
+Fixture content is written inline via ``tmp_path`` rather than checked-in
+files, so encoding and line-ending details stay explicit at each call site.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gmat_run.errors import GmatOutputParseError
+from gmat_run.parsers.reportfile import parse
+
+# --- helpers -----------------------------------------------------------------
+
+
+def _write(path: Path, content: str, encoding: str = "utf-8", newline: str = "\n") -> Path:
+    """Write ``content`` verbatim with the requested encoding and line ending."""
+    path.write_bytes(content.replace("\n", newline).encode(encoding))
+    return path
+
+
+# A three-column happy-path sample mirroring GMAT's R2026a layout: Gregorian
+# epoch, a float field, a scientific-notation field, and an integer mass.
+_HEADER = (
+    "Sat.UTCGregorian          Sat.Earth.SMA             "
+    "Sat.Earth.ECC             Sat.TotalMass"
+)
+_ROW_1 = "26 Nov 2026 12:00:00.000  6578.136299999994         9.999999999964634e-05     1300000"
+_ROW_2 = "26 Nov 2026 12:01:00.000  6578.137326507367         0.0001451202385349637     1300000"
+_BASIC = f"{_HEADER}\n{_ROW_1}\n{_ROW_2}\n"
+
+
+# --- happy path --------------------------------------------------------------
+
+
+def test_parses_header_columns_verbatim(tmp_path: Path) -> None:
+    df = parse(_write(tmp_path / "basic.report", _BASIC))
+    assert list(df.columns) == [
+        "Sat.UTCGregorian",
+        "Sat.Earth.SMA",
+        "Sat.Earth.ECC",
+        "Sat.TotalMass",
+    ]
+
+
+def test_row_count_matches_data_lines(tmp_path: Path) -> None:
+    df = parse(_write(tmp_path / "basic.report", _BASIC))
+    assert len(df) == 2
+
+
+def test_gregorian_epoch_stays_string(tmp_path: Path) -> None:
+    """UTCGregorian is non-numeric and must survive as strings at this layer."""
+    df = parse(_write(tmp_path / "basic.report", _BASIC))
+    assert not pd.api.types.is_numeric_dtype(df["Sat.UTCGregorian"])
+    assert df["Sat.UTCGregorian"].iloc[0] == "26 Nov 2026 12:00:00.000"
+    assert df["Sat.UTCGregorian"].iloc[1] == "26 Nov 2026 12:01:00.000"
+
+
+def test_float_column_is_float64(tmp_path: Path) -> None:
+    df = parse(_write(tmp_path / "basic.report", _BASIC))
+    assert df["Sat.Earth.SMA"].dtype == np.float64
+    assert df["Sat.Earth.SMA"].iloc[0] == pytest.approx(6578.136299999994)
+
+
+def test_scientific_notation_parses_as_float(tmp_path: Path) -> None:
+    df = parse(_write(tmp_path / "basic.report", _BASIC))
+    assert df["Sat.Earth.ECC"].dtype == np.float64
+    assert df["Sat.Earth.ECC"].iloc[0] == pytest.approx(9.999999999964634e-05)
+
+
+def test_integer_column_is_int64(tmp_path: Path) -> None:
+    """All-integer column should be inferred as int, not float."""
+    df = parse(_write(tmp_path / "basic.report", _BASIC))
+    assert df["Sat.TotalMass"].dtype == np.int64
+    assert df["Sat.TotalMass"].iloc[0] == 1300000
+
+
+# --- encoding / line endings -------------------------------------------------
+
+
+def test_utf8_bom_is_stripped(tmp_path: Path) -> None:
+    path = tmp_path / "bom.report"
+    path.write_bytes(b"\xef\xbb\xbf" + _BASIC.encode("utf-8"))
+    df = parse(path)
+    # First column must not carry a U+FEFF prefix from the BOM.
+    assert next(iter(df.columns)) == "Sat.UTCGregorian"
+
+
+@pytest.mark.parametrize("newline", ["\n", "\r\n"])
+def test_line_endings_produce_identical_frame(tmp_path: Path, newline: str) -> None:
+    path = _write(tmp_path / f"ln_{newline!r}.report", _BASIC, newline=newline)
+    df = parse(path)
+    reference = parse(_write(tmp_path / "lf.report", _BASIC, newline="\n"))
+    pd.testing.assert_frame_equal(df, reference)
+
+
+# --- repeated header blocks --------------------------------------------------
+
+
+def test_repeated_header_is_skipped(tmp_path: Path) -> None:
+    """GMAT re-emits the header at mission-sequence segment boundaries."""
+    content = f"{_HEADER}\n{_ROW_1}\n{_HEADER}\n{_ROW_2}\n"
+    df = parse(_write(tmp_path / "segments.report", content))
+    assert len(df) == 2
+
+
+def test_duplicate_data_row_is_preserved(tmp_path: Path) -> None:
+    """Segment-initial state repeats look like duplicated data — keep them."""
+    content = f"{_HEADER}\n{_ROW_1}\n{_HEADER}\n{_ROW_1}\n{_ROW_2}\n"
+    df = parse(_write(tmp_path / "dupdata.report", content))
+    assert len(df) == 3
+    assert df["Sat.UTCGregorian"].iloc[0] == df["Sat.UTCGregorian"].iloc[1]
+
+
+# --- edge cases --------------------------------------------------------------
+
+
+def test_single_column_report(tmp_path: Path) -> None:
+    content = "Sat.TotalMass\n1300000\n1300001\n"
+    df = parse(_write(tmp_path / "onecol.report", content))
+    assert list(df.columns) == ["Sat.TotalMass"]
+    assert df["Sat.TotalMass"].tolist() == [1300000, 1300001]
+
+
+def test_blank_lines_are_skipped(tmp_path: Path) -> None:
+    content = f"\n{_HEADER}\n\n{_ROW_1}\n\n{_ROW_2}\n\n"
+    df = parse(_write(tmp_path / "blanks.report", content))
+    assert len(df) == 2
+
+
+def test_trailing_whitespace_is_tolerated(tmp_path: Path) -> None:
+    """GMAT pads data rows with trailing spaces; the parser must not break."""
+    padded = f"{_HEADER}   \n{_ROW_1}     \n{_ROW_2}\t\n"
+    df = parse(_write(tmp_path / "padded.report", padded))
+    assert len(df) == 2
+    assert df["Sat.TotalMass"].iloc[0] == 1300000
+
+
+# --- round-trip --------------------------------------------------------------
+
+
+def test_round_trip_numeric_values_match_file(tmp_path: Path) -> None:
+    """Parsed numeric values must round-trip to the exact source tokens."""
+    df = parse(_write(tmp_path / "rt.report", _BASIC))
+    assert repr(float(df["Sat.Earth.SMA"].iloc[0])) == "6578.136299999994"
+    assert repr(float(df["Sat.Earth.ECC"].iloc[0])) == "9.999999999964634e-05"
+    assert int(df["Sat.TotalMass"].iloc[0]) == 1300000
+
+
+# --- malformed input ---------------------------------------------------------
+
+
+def test_column_count_mismatch_raises_with_line_number(tmp_path: Path) -> None:
+    bad_row = "26 Nov 2026 12:02:00.000  6578.13"  # two tokens instead of four
+    content = f"{_HEADER}\n{_ROW_1}\n{bad_row}\n"
+    path = _write(tmp_path / "badcols.report", content)
+    with pytest.raises(GmatOutputParseError) as excinfo:
+        parse(path)
+    assert "line 3" in str(excinfo.value)
+    assert "expected 4 columns" in str(excinfo.value)
+    assert excinfo.value.path == path
+
+
+def test_empty_file_raises(tmp_path: Path) -> None:
+    path = _write(tmp_path / "empty.report", "")
+    with pytest.raises(GmatOutputParseError) as excinfo:
+        parse(path)
+    assert "empty" in str(excinfo.value).lower()
+    assert excinfo.value.path == path
+
+
+def test_only_blank_lines_raises(tmp_path: Path) -> None:
+    path = _write(tmp_path / "blanks_only.report", "\n\n  \n\t\n")
+    with pytest.raises(GmatOutputParseError):
+        parse(path)
+
+
+def test_accepts_str_path(tmp_path: Path) -> None:
+    """``path`` must accept both ``str`` and ``os.PathLike`` — string form."""
+    path = _write(tmp_path / "strpath.report", _BASIC)
+    df = parse(str(path))
+    assert len(df) == 2

--- a/tests/test_parsers_reportfile.py
+++ b/tests/test_parsers_reportfile.py
@@ -89,11 +89,15 @@ def test_utf8_bom_is_stripped(tmp_path: Path) -> None:
     assert next(iter(df.columns)) == "Sat.UTCGregorian"
 
 
-@pytest.mark.parametrize("newline", ["\n", "\r\n"])
-def test_line_endings_produce_identical_frame(tmp_path: Path, newline: str) -> None:
-    path = _write(tmp_path / f"ln_{newline!r}.report", _BASIC, newline=newline)
+@pytest.mark.parametrize(
+    ("newline", "label"), [("\n", "lf"), ("\r\n", "crlf")], ids=["lf", "crlf"]
+)
+def test_line_endings_produce_identical_frame(
+    tmp_path: Path, newline: str, label: str
+) -> None:
+    path = _write(tmp_path / f"{label}.report", _BASIC, newline=newline)
     df = parse(path)
-    reference = parse(_write(tmp_path / "lf.report", _BASIC, newline="\n"))
+    reference = parse(_write(tmp_path / "reference.report", _BASIC, newline="\n"))
     pd.testing.assert_frame_equal(df, reference)
 
 


### PR DESCRIPTION
## Summary

- New `gmat_run.parsers.reportfile.parse(path) -> pandas.DataFrame` reads GMAT's whitespace-aligned `ReportFile` into a typed DataFrame — dotted column names preserved verbatim, int64 / float64 inferred column-wise, Gregorian epochs left as strings for the datetime layer (#7) to promote.
- Handles `UTCGregorian`'s internal single spaces by splitting on `\s{2,}`, re-emitted segment-boundary headers by skipping any data line that matches the header verbatim, and UTF-8 BOM + mixed CRLF/LF via `utf-8-sig` + universal newlines.
- Malformed rows (column-count mismatch, empty file) raise `GmatOutputParseError` carrying the line number in the message and the offending path on `.path`.

## Test plan

- [x] `uv run pytest` — 79 passed (19 new, on `tests/test_parsers_reportfile.py`).
- [x] `uv run ruff check` — clean.
- [x] `uv run mypy` — clean.
- [x] CI on Ubuntu + Windows, Python 3.10 / 3.11 / 3.12.

Closes #6.