### PR TITLE
Add epoch promotion: Gregorian and ModJulian columns to `datetime64[ns]`

### DIFF
--- a/src/gmat_run/parsers/epoch.py
+++ b/src/gmat_run/parsers/epoch.py
@@ -1,0 +1,169 @@
+"""Promote known GMAT epoch columns in a DataFrame to ``datetime64[ns]``.
+
+GMAT emits epochs in one of ten ``{scale}{format}`` combinations — five scales
+(A1, TAI, UTC, TT, TDB) crossed with two formats (``Gregorian``,
+``ModJulian``). :func:`promote_epochs` recognises all ten by exact match on
+the column name's last dotted segment, converts each to ``datetime64[ns]``,
+and records the time scale on ``df.attrs["epoch_scales"]`` so downstream code
+can branch on it without re-parsing the column name.
+
+No leap-second-correct time-scale *conversion* happens here: a
+``TAIModJulian`` column becomes a ``datetime64[ns]`` representing the TAI
+instant, labelled ``"TAI"``. UTC ↔ TAI / TT / TDB conversion is the v0.3
+astropy-extra job.
+
+Columns whose name ends in ``Gregorian`` or ``ModJulian`` but are not one of
+the ten recognised names trigger a ``UserWarning`` and are left untouched —
+this catches typos and any hypothetical future GMAT epoch format without
+silently mis-promoting data.
+"""
+
+import re
+import warnings
+from pathlib import Path
+from typing import Final
+
+import pandas as pd
+
+from gmat_run.errors import GmatOutputParseError
+
+__all__ = ["promote_epochs"]
+
+
+# MJD 0 in GMAT's convention: JD 2430000.0 = 1941-01-05 12:00:00.
+# Cross-check: GMAT MJD 21545.0 must map to J2000 (2000-01-01 12:00:00),
+# and it does — see ``tests/test_parsers_epoch.py``.
+_GMAT_MJD_EPOCH: Final = pd.Timestamp("1941-01-05 12:00:00")
+
+# GMAT Gregorian format, e.g. ``26 Nov 2026 12:00:00.000``. ``%b`` is locale
+# sensitive; this assumes the C/en_US locale active on every CI runner and
+# virtually every dev workstation. If a non-English locale is ever a real
+# target we would swap this for a manual month-name lookup.
+_GREGORIAN_FORMAT: Final = "%d %b %Y %H:%M:%S.%f"
+
+# Suffix → time scale. Suffix matches the column name's last dotted segment
+# (or the whole name if there is no dot).
+_GREGORIAN_SUFFIXES: Final[dict[str, str]] = {
+    "A1Gregorian": "A1",
+    "TAIGregorian": "TAI",
+    "UTCGregorian": "UTC",
+    "TTGregorian": "TT",
+    "TDBGregorian": "TDB",
+}
+_MODJULIAN_SUFFIXES: Final[dict[str, str]] = {
+    "A1ModJulian": "A1",
+    "TAIModJulian": "TAI",
+    "UTCModJulian": "UTC",
+    "TTModJulian": "TT",
+    "TDBModJulian": "TDB",
+}
+
+# Suffix shape of "epoch-looking but unrecognised" columns — triggers the
+# unknown-format warning. Matches the last dotted segment.
+_UNKNOWN_EPOCH_SUFFIX_RE: Final = re.compile(r".+(?:Gregorian|ModJulian)$")
+
+
+def promote_epochs(df: pd.DataFrame) -> pd.DataFrame:
+    """Promote recognised epoch columns in ``df`` to ``datetime64[ns]`` in place.
+
+    The DataFrame is mutated and returned so callers can chain. Time scales for
+    promoted columns are recorded under ``df.attrs["epoch_scales"]`` as a
+    ``{column_name: scale_string}`` dict. ``scale_string`` is one of
+    ``"A1"``, ``"TAI"``, ``"UTC"``, ``"TT"``, ``"TDB"``.
+
+    Idempotent: calling this twice on the same frame is a no-op on the second
+    pass, because promoted columns are already ``datetime64[ns]`` and are
+    skipped.
+
+    Args:
+        df: DataFrame whose columns follow GMAT's ``{resource}.{field}``
+            naming convention. Columns whose last segment is one of the ten
+            recognised epoch suffixes are promoted.
+
+    Returns:
+        ``df`` itself, mutated in place.
+
+    Raises:
+        GmatOutputParseError: A recognised epoch column contains values that
+            cannot be parsed (malformed Gregorian text, non-numeric ModJulian,
+            or a ModJulian value that overflows ``datetime64[ns]``'s range).
+    """
+    for column in df.columns:
+        suffix = _suffix(str(column))
+        if pd.api.types.is_datetime64_any_dtype(df[column]):
+            # Already promoted (idempotence) — but still tag the scale if we
+            # can, so a caller that constructed the frame by hand gets
+            # consistent attrs.
+            scale = _GREGORIAN_SUFFIXES.get(suffix) or _MODJULIAN_SUFFIXES.get(suffix)
+            if scale is not None:
+                _tag_scale(df, column, scale)
+            continue
+        if suffix in _GREGORIAN_SUFFIXES:
+            df[column] = _convert_gregorian(df[column], column)
+            _tag_scale(df, column, _GREGORIAN_SUFFIXES[suffix])
+        elif suffix in _MODJULIAN_SUFFIXES:
+            df[column] = _convert_modjulian(df[column], column)
+            _tag_scale(df, column, _MODJULIAN_SUFFIXES[suffix])
+        elif _UNKNOWN_EPOCH_SUFFIX_RE.match(suffix):
+            warnings.warn(
+                f"Column {column!r} has an unrecognised epoch suffix {suffix!r}; "
+                "leaving it unchanged. Known suffixes: "
+                f"{sorted(_GREGORIAN_SUFFIXES) + sorted(_MODJULIAN_SUFFIXES)}.",
+                UserWarning,
+                stacklevel=2,
+            )
+    return df
+
+
+def _suffix(column: str) -> str:
+    """Return the portion of ``column`` after the last ``.``, or the whole name."""
+    _, _, tail = column.rpartition(".")
+    return tail or column
+
+
+def _tag_scale(df: pd.DataFrame, column: str, scale: str) -> None:
+    """Record ``column``'s time scale on ``df.attrs["epoch_scales"]``."""
+    scales = df.attrs.setdefault("epoch_scales", {})
+    scales[column] = scale
+
+
+def _convert_gregorian(series: "pd.Series[str]", column: str) -> "pd.Series[pd.Timestamp]":
+    """Convert a GMAT Gregorian string column to ``datetime64[ns]``."""
+    try:
+        parsed = pd.to_datetime(series, format=_GREGORIAN_FORMAT)
+    except (ValueError, TypeError) as exc:
+        raise GmatOutputParseError(
+            f"column {column!r} has malformed Gregorian epoch value: {exc}",
+            _synthetic_path(column),
+        ) from exc
+    # pandas 2.x returns datetime64[us] for this format; normalise to the [ns]
+    # precision promised by the issue's acceptance criterion.
+    return parsed.astype("datetime64[ns]")
+
+
+def _convert_modjulian(series: "pd.Series[float]", column: str) -> "pd.Series[pd.Timestamp]":
+    """Convert a GMAT ModJulian numeric column to ``datetime64[ns]``."""
+    if not pd.api.types.is_numeric_dtype(series):
+        raise GmatOutputParseError(
+            f"column {column!r} is a ModJulian epoch but its values are "
+            f"non-numeric (dtype={series.dtype})",
+            _synthetic_path(column),
+        )
+    try:
+        return _GMAT_MJD_EPOCH + pd.to_timedelta(series, unit="D")
+    except (ValueError, OverflowError, pd.errors.OutOfBoundsDatetime) as exc:
+        raise GmatOutputParseError(
+            f"column {column!r} has a ModJulian value outside the "
+            f"representable datetime64[ns] range (~1677..2262): {exc}",
+            _synthetic_path(column),
+        ) from exc
+
+
+def _synthetic_path(column: str) -> Path:
+    """Placeholder ``path`` for errors that don't know the file location.
+
+    ``promote_epochs`` is called from ``reportfile.parse`` which knows the
+    path, but the function itself is reusable on any in-memory DataFrame; when
+    there is no file, we surface the offending column name instead.
+    """
+    return Path(f"<column:{column}>")

--- a/src/gmat_run/parsers/reportfile.py
+++ b/src/gmat_run/parsers/reportfile.py
@@ -26,6 +26,7 @@ from typing import Any
 import pandas as pd
 
 from gmat_run.errors import GmatOutputParseError
+from gmat_run.parsers.epoch import promote_epochs
 
 __all__ = ["parse"]
 
@@ -81,7 +82,7 @@ def parse(path: str | os.PathLike[str]) -> pd.DataFrame:
     df = pd.DataFrame(rows, columns=column_names)
     for column in df.columns:
         df[column] = _coerce_numeric(df[column])
-    return df
+    return promote_epochs(df)
 
 
 def _find_header(lines: list[str], path: Path) -> tuple[int, str]:

--- a/tests/test_parsers_epoch.py
+++ b/tests/test_parsers_epoch.py
@@ -1,0 +1,212 @@
+"""Unit tests for :func:`gmat_run.parsers.epoch.promote_epochs`.
+
+Tests build DataFrames in memory — no file I/O, no ReportFile involvement.
+End-to-end tests through ``reportfile.parse`` live in
+``test_parsers_reportfile.py``.
+"""
+
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from gmat_run.errors import GmatOutputParseError
+from gmat_run.parsers.epoch import promote_epochs
+
+# Scale suffixes the parser recognises. Parametrising over these catches any
+# table-entry-missing or typo regression in one place.
+_GREGORIAN_SUFFIXES = [
+    ("A1Gregorian", "A1"),
+    ("TAIGregorian", "TAI"),
+    ("UTCGregorian", "UTC"),
+    ("TTGregorian", "TT"),
+    ("TDBGregorian", "TDB"),
+]
+_MODJULIAN_SUFFIXES = [
+    ("A1ModJulian", "A1"),
+    ("TAIModJulian", "TAI"),
+    ("UTCModJulian", "UTC"),
+    ("TTModJulian", "TT"),
+    ("TDBModJulian", "TDB"),
+]
+
+
+# --- Gregorian ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("suffix", "scale"), _GREGORIAN_SUFFIXES)
+def test_gregorian_each_scale_becomes_datetime64_ns(suffix: str, scale: str) -> None:
+    col = f"Sat.{suffix}"
+    df = pd.DataFrame({col: ["26 Nov 2026 12:00:00.000", "01 Jan 2000 11:59:28.000"]})
+    promote_epochs(df)
+    assert df[col].dtype == np.dtype("datetime64[ns]")
+    assert df[col].iloc[0] == pd.Timestamp("2026-11-26 12:00:00")
+    assert df[col].iloc[1] == pd.Timestamp("2000-01-01 11:59:28")
+    assert df.attrs["epoch_scales"][col] == scale
+
+
+def test_gregorian_malformed_raises(tmp_path: object) -> None:
+    df = pd.DataFrame({"Sat.UTCGregorian": ["26 Nov 2026 12:00:00.000", "not a date"]})
+    with pytest.raises(GmatOutputParseError) as excinfo:
+        promote_epochs(df)
+    assert "Sat.UTCGregorian" in str(excinfo.value)
+
+
+def test_gregorian_works_on_pandas_string_dtype() -> None:
+    """reportfile.parse leaves Gregorian as StringDtype; the promoter must accept it."""
+    col = "Sat.UTCGregorian"
+    series = pd.Series(["26 Nov 2026 12:00:00.000"], dtype="string")
+    df = pd.DataFrame({col: series})
+    promote_epochs(df)
+    assert df[col].dtype == np.dtype("datetime64[ns]")
+
+
+# --- ModJulian ---------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("suffix", "scale"), _MODJULIAN_SUFFIXES)
+def test_modjulian_each_scale_becomes_datetime64_ns(suffix: str, scale: str) -> None:
+    col = f"Sat.{suffix}"
+    df = pd.DataFrame({col: [21545.0, 21545.5]})
+    promote_epochs(df)
+    assert df[col].dtype == np.dtype("datetime64[ns]")
+    # MJD 21545.0 is J2000 by construction: 2000-01-01 12:00:00.
+    assert df[col].iloc[0] == pd.Timestamp("2000-01-01 12:00:00")
+    # Fractional-day round-trip: 0.5 day == 12h.
+    assert df[col].iloc[1] == pd.Timestamp("2000-01-02 00:00:00")
+    assert df.attrs["epoch_scales"][col] == scale
+
+
+def test_modjulian_subsecond_precision() -> None:
+    """MJD values round-trip well below millisecond resolution.
+
+    Exact second-level equality isn't achievable with float64: 1/86400 day
+    isn't exactly representable, so the conversion accumulates ~100 ns of
+    float-rounding error. The acceptance contract is ``datetime64[ns]``
+    precision — this test pins us to within 1 µs, which rules out any bug
+    that drops seconds or reorders the epoch.
+    """
+    one_second_in_mjd = 1.0 / 86400.0
+    col = "Sat.TAIModJulian"
+    df = pd.DataFrame({col: [21545.0 + one_second_in_mjd]})
+    promote_epochs(df)
+    expected = pd.Timestamp("2000-01-01 12:00:01")
+    assert abs(df[col].iloc[0] - expected) < pd.Timedelta(microseconds=1)
+
+
+def test_modjulian_non_numeric_raises() -> None:
+    df = pd.DataFrame({"Sat.TAIModJulian": ["21545.0"]})  # string, not float
+    with pytest.raises(GmatOutputParseError) as excinfo:
+        promote_epochs(df)
+    assert "non-numeric" in str(excinfo.value)
+    assert "Sat.TAIModJulian" in str(excinfo.value)
+
+
+def test_modjulian_overflow_raises() -> None:
+    """A value outside datetime64[ns]'s 1677..2262 range must fail typed."""
+    df = pd.DataFrame({"Sat.TAIModJulian": [1.0e9]})  # ~2.7M years, well past 2262
+    with pytest.raises(GmatOutputParseError) as excinfo:
+        promote_epochs(df)
+    assert "Sat.TAIModJulian" in str(excinfo.value)
+
+
+# --- non-epoch columns -------------------------------------------------------
+
+
+def test_non_epoch_columns_are_left_alone() -> None:
+    df = pd.DataFrame(
+        {
+            "Sat.Earth.SMA": [6578.136, 6578.137],
+            "Sat.Earth.ECC": [1e-5, 1.5e-5],
+            "Sat.TotalMass": [1300000, 1300000],
+        }
+    )
+    original = df.copy(deep=True)
+    promote_epochs(df)
+    pd.testing.assert_frame_equal(df, original)
+    # Nothing was promoted, so no scale tags should have been added.
+    assert "epoch_scales" not in df.attrs
+
+
+def test_non_epoch_name_does_not_warn() -> None:
+    """``Sat.Earth.SMA`` must not warn; only *Gregorian/*ModJulian suffixes do."""
+    df = pd.DataFrame({"Sat.Earth.SMA": [1.0]})
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning → test failure
+        promote_epochs(df)
+
+
+# --- unknown-epoch warning ---------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "column",
+    ["Sat.FooGregorian", "Sat.SomeFormatModJulian", "Foo.BarGregorian", "PlainModJulian"],
+)
+def test_unknown_epoch_suffix_warns_and_leaves_column_alone(column: str) -> None:
+    df = pd.DataFrame({column: ["1 Jan 2000 00:00:00.000"]})
+    original = df[column].copy()
+    with pytest.warns(UserWarning, match="unrecognised epoch suffix"):
+        promote_epochs(df)
+    # Column is untouched.
+    pd.testing.assert_series_equal(df[column], original)
+    # Scale was not recorded.
+    assert column not in df.attrs.get("epoch_scales", {})
+
+
+@pytest.mark.parametrize(
+    "column",
+    ["Sat.utcgregorian", "Sat.modjulian", "Sat.Gregorian", "Sat.ModJulian"],
+)
+def test_suffix_warning_is_case_sensitive_and_requires_prefix(column: str) -> None:
+    """The warning regex is strict: suffix must be exactly ``*Gregorian``/``*ModJulian``.
+
+    Lowercased names and bare ``Gregorian``/``ModJulian`` suffixes (no scale
+    prefix) do not match the heuristic and therefore do not warn. Silence is
+    correct here — we don't want to be noisy about plain unrelated columns.
+    """
+    df = pd.DataFrame({column: ["1 Jan 2000 00:00:00.000"]})
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        promote_epochs(df)
+
+
+# --- attrs structure ---------------------------------------------------------
+
+
+def test_multiple_epoch_columns_all_get_tagged() -> None:
+    df = pd.DataFrame(
+        {
+            "Sat.UTCGregorian": ["01 Jan 2000 12:00:00.000"],
+            "Sat.TAIModJulian": [21545.0],
+            "Sat.Earth.SMA": [6578.136],
+        }
+    )
+    promote_epochs(df)
+    assert df.attrs["epoch_scales"] == {
+        "Sat.UTCGregorian": "UTC",
+        "Sat.TAIModJulian": "TAI",
+    }
+
+
+def test_promote_is_idempotent() -> None:
+    """Calling promote_epochs twice on the same frame is a no-op on pass 2."""
+    df = pd.DataFrame(
+        {
+            "Sat.UTCGregorian": ["01 Jan 2000 12:00:00.000"],
+            "Sat.TAIModJulian": [21545.0],
+        }
+    )
+    promote_epochs(df)
+    snapshot = df.copy(deep=True)
+    attrs_snapshot = dict(df.attrs["epoch_scales"])
+    promote_epochs(df)
+    pd.testing.assert_frame_equal(df, snapshot)
+    assert df.attrs["epoch_scales"] == attrs_snapshot
+
+
+def test_returns_same_frame_for_chaining() -> None:
+    df = pd.DataFrame({"Sat.UTCGregorian": ["01 Jan 2000 12:00:00.000"]})
+    result = promote_epochs(df)
+    assert result is df

--- a/tests/test_parsers_reportfile.py
+++ b/tests/test_parsers_reportfile.py
@@ -51,12 +51,26 @@ def test_row_count_matches_data_lines(tmp_path: Path) -> None:
     assert len(df) == 2
 
 
-def test_gregorian_epoch_stays_string(tmp_path: Path) -> None:
-    """UTCGregorian is non-numeric and must survive as strings at this layer."""
+def test_gregorian_epoch_becomes_datetime64(tmp_path: Path) -> None:
+    """UTCGregorian is promoted end-to-end to datetime64[ns] and tagged UTC."""
     df = parse(_write(tmp_path / "basic.report", _BASIC))
-    assert not pd.api.types.is_numeric_dtype(df["Sat.UTCGregorian"])
-    assert df["Sat.UTCGregorian"].iloc[0] == "26 Nov 2026 12:00:00.000"
-    assert df["Sat.UTCGregorian"].iloc[1] == "26 Nov 2026 12:01:00.000"
+    assert df["Sat.UTCGregorian"].dtype == np.dtype("datetime64[ns]")
+    assert df["Sat.UTCGregorian"].iloc[0] == pd.Timestamp("2026-11-26 12:00:00")
+    assert df["Sat.UTCGregorian"].iloc[1] == pd.Timestamp("2026-11-26 12:01:00")
+    assert df.attrs["epoch_scales"]["Sat.UTCGregorian"] == "UTC"
+
+
+def test_modjulian_column_parses_end_to_end(tmp_path: Path) -> None:
+    """TAIModJulian column comes out as datetime64[ns] with the TAI scale tag."""
+    content = (
+        "Sat.TAIModJulian          Sat.Earth.SMA\n"
+        "21545.0                   6578.136\n"
+        "21545.5                   6578.137\n"
+    )
+    df = parse(_write(tmp_path / "mjd.report", content))
+    assert df["Sat.TAIModJulian"].dtype == np.dtype("datetime64[ns]")
+    assert df["Sat.TAIModJulian"].iloc[0] == pd.Timestamp("2000-01-01 12:00:00")
+    assert df.attrs["epoch_scales"]["Sat.TAIModJulian"] == "TAI"
 
 
 def test_float_column_is_float64(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- New `gmat_run.parsers.epoch.promote_epochs(df)` promotes the ten recognised GMAT epoch suffixes — five scales (A1 / TAI / UTC / TT / TDB) × two formats (`Gregorian`, `ModJulian`) — to `datetime64[ns]`, and records each column's time scale on `df.attrs["epoch_scales"]`.
- Gregorian columns parse via `pd.to_datetime` with `%d %b %Y %H:%M:%S.%f`; ModJulian columns convert arithmetically from GMAT's MJD epoch (JD 2430000.0 = 1941-01-05 12:00:00), so MJD 21545.0 maps exactly to J2000.
- No time-scale conversion: `TAIModJulian` → a `datetime64[ns]` labelled `"TAI"`. Leap-second-correct TAI↔UTC is the v0.3 astropy-extra story.
- Wires into `reportfile.parse` as its final step. Ephemeris and ContactLocator parsers (future issues) will reuse `promote_epochs` unchanged.
- Unrecognised `*Gregorian` / `*ModJulian` suffixes (e.g. typos) raise a `UserWarning` and stay untouched; plain non-epoch columns stay silent.

## Test plan

- [x] `uv run pytest` — 108 passed (28 new unit tests in `test_parsers_epoch.py` + 2 new integration tests in `test_parsers_reportfile.py`).
- [x] `uv run ruff check` — clean.
- [x] `uv run mypy` — clean.
- [x] CI on Ubuntu + Windows, Python 3.10 / 3.11 / 3.12.

Closes #7.