### PR TITLE
Add `Results` object with lazy parser dispatch

### DIFF
--- a/src/gmat_run/__init__.py
+++ b/src/gmat_run/__init__.py
@@ -9,6 +9,7 @@ from gmat_run.errors import (
     GmatRunError,
 )
 from gmat_run.install import GmatInstall, locate_gmat
+from gmat_run.results import Results
 from gmat_run.runtime import bootstrap
 
 __version__ = "0.0.0"
@@ -21,6 +22,7 @@ __all__ = [
     "GmatNotFoundError",
     "GmatOutputParseError",
     "GmatRunError",
+    "Results",
     "__version__",
     "bootstrap",
     "locate_gmat",

--- a/src/gmat_run/results.py
+++ b/src/gmat_run/results.py
@@ -1,0 +1,173 @@
+"""In-memory aggregate of every output file GMAT wrote during a run.
+
+:class:`Results` is the return value of :meth:`Mission.run`. It exposes three
+keyed views over those outputs — :attr:`Results.reports`,
+:attr:`Results.ephemerides`, and :attr:`Results.contacts` — each typed as a
+``Mapping[str, pandas.DataFrame]`` and keyed by the GMAT resource name as
+declared in the ``.script``.
+
+Parsing is lazy. A ``ReportFile`` listed in :attr:`Results.reports` is read
+from disk and converted to a DataFrame only on first access, then cached for
+the life of the :class:`Results` instance — opening a notebook on a long run
+without touching every report should not pay the parse cost for the ones it
+does not look at.
+
+The ``.eph`` ephemeris and ``ContactLocator`` parsers are scheduled for v0.2.
+For v0.1 the corresponding mappings still expose their keys (so callers can
+discover what GMAT wrote without branching on the version), but accessing a
+value raises :class:`NotImplementedError` pointing at the parallel
+:attr:`Results.ephemeris_paths` / :attr:`Results.contact_paths` mappings, which
+hand back the raw :class:`pathlib.Path`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from pathlib import Path
+from types import MappingProxyType
+
+import pandas as pd
+
+from gmat_run.parsers.reportfile import parse as _parse_reportfile
+
+__all__ = ["Results"]
+
+
+class _LazyReports(Mapping[str, pd.DataFrame]):
+    """Mapping view over ``ReportFile`` outputs that parses on first access.
+
+    The DataFrame for a given key is materialised by
+    :func:`gmat_run.parsers.reportfile.parse` on the first ``__getitem__`` and
+    cached on the instance; subsequent accesses return the same object. The
+    parser is *not* invoked at construction, so building :class:`Results` is
+    cheap even when the underlying files are large or absent.
+    """
+
+    def __init__(self, paths: Mapping[str, Path]) -> None:
+        self._paths: dict[str, Path] = dict(paths)
+        self._cache: dict[str, pd.DataFrame] = {}
+
+    def __getitem__(self, key: str) -> pd.DataFrame:
+        if key in self._cache:
+            return self._cache[key]
+        if key not in self._paths:
+            raise KeyError(key)
+        frame = _parse_reportfile(self._paths[key])
+        self._cache[key] = frame
+        return frame
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._paths)
+
+    def __len__(self) -> int:
+        return len(self._paths)
+
+    def __contains__(self, key: object) -> bool:
+        # Override the Mapping default — it calls __getitem__ and would parse.
+        return key in self._paths
+
+
+class _DeferredMapping(Mapping[str, pd.DataFrame]):
+    """Mapping view whose keys are populated but value access is unimplemented.
+
+    Used for output formats whose parsers are scheduled for a later release:
+    the keys reflect what GMAT wrote so callers can iterate, ``len``, and
+    membership-test as normal, but ``__getitem__`` raises
+    :class:`NotImplementedError` directing the caller at the parallel
+    ``*_paths`` mapping for the raw file path.
+    """
+
+    def __init__(
+        self,
+        paths: Mapping[str, Path],
+        *,
+        format_label: str,
+        target_release: str,
+        paths_attr: str,
+    ) -> None:
+        self._paths: dict[str, Path] = dict(paths)
+        self._format_label = format_label
+        self._target_release = target_release
+        self._paths_attr = paths_attr
+
+    def __getitem__(self, key: str) -> pd.DataFrame:
+        if key not in self._paths:
+            raise KeyError(key)
+        raise NotImplementedError(
+            f"{self._format_label} parsing lands in {self._target_release}; "
+            f"use Results.{self._paths_attr}[{key!r}] for the file path"
+        )
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._paths)
+
+    def __len__(self) -> int:
+        return len(self._paths)
+
+    def __contains__(self, key: object) -> bool:
+        # Override the Mapping default — it calls __getitem__ and would raise
+        # NotImplementedError for known keys.
+        return key in self._paths
+
+
+class Results:
+    """Aggregate of every output file GMAT wrote during a single run.
+
+    Construct one per call to :meth:`Mission.run`. Each path mapping is keyed
+    by the resource name declared in the ``.script`` (``"ReportFile1"``,
+    ``"EphemerisFile1"``, ``"ContactLocator1"``, …). Path mappings are
+    defensively copied and re-exposed as read-only views, so callers cannot
+    mutate the run record after the fact.
+
+    Args:
+        output_dir: The working directory GMAT used for this run. Surfaced
+            so callers can locate any output file gmat-run did not aggregate
+            itself.
+        log: GMAT's stdout and stderr captured during the run, joined into a
+            single string.
+        report_paths: ``{name: path}`` for every ``ReportFile`` resource.
+            Defaults to empty.
+        ephemeris_paths: ``{name: path}`` for every ``EphemerisFile``
+            resource. Defaults to empty.
+        contact_paths: ``{name: path}`` for every ``ContactLocator``
+            resource. Defaults to empty.
+    """
+
+    output_dir: Path
+    log: str
+    reports: Mapping[str, pd.DataFrame]
+    ephemerides: Mapping[str, pd.DataFrame]
+    ephemeris_paths: Mapping[str, Path]
+    contacts: Mapping[str, pd.DataFrame]
+    contact_paths: Mapping[str, Path]
+
+    def __init__(
+        self,
+        *,
+        output_dir: Path,
+        log: str,
+        report_paths: Mapping[str, Path] | None = None,
+        ephemeris_paths: Mapping[str, Path] | None = None,
+        contact_paths: Mapping[str, Path] | None = None,
+    ) -> None:
+        self.output_dir = output_dir
+        self.log = log
+
+        eph_paths: dict[str, Path] = dict(ephemeris_paths or {})
+        con_paths: dict[str, Path] = dict(contact_paths or {})
+
+        self.reports = _LazyReports(report_paths or {})
+        self.ephemeris_paths = MappingProxyType(eph_paths)
+        self.contact_paths = MappingProxyType(con_paths)
+        self.ephemerides = _DeferredMapping(
+            eph_paths,
+            format_label=".eph ephemeris",
+            target_release="v0.2",
+            paths_attr="ephemeris_paths",
+        )
+        self.contacts = _DeferredMapping(
+            con_paths,
+            format_label="ContactLocator",
+            target_release="v0.2",
+            paths_attr="contact_paths",
+        )

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -1,0 +1,253 @@
+"""Unit tests for :class:`gmat_run.results.Results`.
+
+The lazy-materialisation contract is exercised by pointing the constructor at
+``ReportFile`` paths that may or may not exist on disk and observing when (and
+how often) the parser actually reads them.
+"""
+
+from collections.abc import Mapping
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from gmat_run.results import Results
+
+# --- helpers -----------------------------------------------------------------
+
+_HEADER = "Sat.UTCGregorian          Sat.Earth.SMA"
+_ROW = "26 Nov 2026 12:00:00.000  6578.136"
+_REPORT = f"{_HEADER}\n{_ROW}\n"
+
+
+def _write_report(path: Path) -> Path:
+    path.write_text(_REPORT, encoding="utf-8")
+    return path
+
+
+def _empty(tmp_path: Path) -> Results:
+    """A Results with no outputs, just an output_dir and log."""
+    return Results(output_dir=tmp_path, log="ok")
+
+
+# --- constructor / attributes ------------------------------------------------
+
+
+def test_output_dir_and_log_round_trip(tmp_path: Path) -> None:
+    result = Results(output_dir=tmp_path, log="hello\nworld")
+    assert result.output_dir == tmp_path
+    assert result.log == "hello\nworld"
+
+
+def test_default_mappings_are_empty(tmp_path: Path) -> None:
+    result = _empty(tmp_path)
+    assert len(result.reports) == 0
+    assert len(result.ephemerides) == 0
+    assert len(result.ephemeris_paths) == 0
+    assert len(result.contacts) == 0
+    assert len(result.contact_paths) == 0
+
+
+def test_path_mappings_are_read_only(tmp_path: Path) -> None:
+    """Path mappings are MappingProxyType views — assignment must fail."""
+    result = Results(
+        output_dir=tmp_path,
+        log="",
+        ephemeris_paths={"E1": tmp_path / "E1.eph"},
+        contact_paths={"C1": tmp_path / "C1.txt"},
+    )
+    with pytest.raises(TypeError):
+        result.ephemeris_paths["E2"] = tmp_path / "E2.eph"  # type: ignore[index]
+    with pytest.raises(TypeError):
+        result.contact_paths["C2"] = tmp_path / "C2.txt"  # type: ignore[index]
+
+
+def test_input_mappings_are_defensively_copied(tmp_path: Path) -> None:
+    """Mutating the caller's dict after construction must not affect Results."""
+    eph_in: dict[str, Path] = {"E1": tmp_path / "E1.eph"}
+    con_in: dict[str, Path] = {"C1": tmp_path / "C1.txt"}
+    rep_in: dict[str, Path] = {"R1": _write_report(tmp_path / "R1.txt")}
+    result = Results(
+        output_dir=tmp_path,
+        log="",
+        report_paths=rep_in,
+        ephemeris_paths=eph_in,
+        contact_paths=con_in,
+    )
+
+    eph_in["E2"] = tmp_path / "E2.eph"
+    con_in["C2"] = tmp_path / "C2.txt"
+    rep_in["R2"] = tmp_path / "R2.txt"
+
+    assert list(result.ephemeris_paths) == ["E1"]
+    assert list(result.contact_paths) == ["C1"]
+    assert list(result.reports) == ["R1"]
+
+
+# --- reports: happy path -----------------------------------------------------
+
+
+def test_reports_keyed_by_resource_name(tmp_path: Path) -> None:
+    result = Results(
+        output_dir=tmp_path,
+        log="",
+        report_paths={"ReportFile1": _write_report(tmp_path / "ReportFile1.txt")},
+    )
+    assert list(result.reports) == ["ReportFile1"]
+    assert "ReportFile1" in result.reports
+    assert len(result.reports) == 1
+
+
+def test_report_access_returns_dataframe(tmp_path: Path) -> None:
+    result = Results(
+        output_dir=tmp_path,
+        log="",
+        report_paths={"ReportFile1": _write_report(tmp_path / "ReportFile1.txt")},
+    )
+    df = result.reports["ReportFile1"]
+    assert isinstance(df, pd.DataFrame)
+    assert list(df.columns) == ["Sat.UTCGregorian", "Sat.Earth.SMA"]
+    assert len(df) == 1
+
+
+# --- reports: lazy materialisation -------------------------------------------
+
+
+def test_construction_does_not_read_files(tmp_path: Path) -> None:
+    """Pointing at a non-existent path must not raise — the parser is lazy."""
+    missing = tmp_path / "never_written.txt"
+    result = Results(
+        output_dir=tmp_path,
+        log="",
+        report_paths={"R1": missing},
+    )
+    # All mapping ops that don't touch the value must work fine.
+    assert "R1" in result.reports
+    assert list(result.reports) == ["R1"]
+    assert len(result.reports) == 1
+
+
+def test_value_access_on_missing_file_raises(tmp_path: Path) -> None:
+    """First access is where the parser actually runs — and where I/O fails."""
+    result = Results(
+        output_dir=tmp_path,
+        log="",
+        report_paths={"R1": tmp_path / "never_written.txt"},
+    )
+    with pytest.raises(FileNotFoundError):
+        _ = result.reports["R1"]
+
+
+def test_repeated_access_is_cached(tmp_path: Path) -> None:
+    """Same DataFrame object on every access — the parser runs once."""
+    result = Results(
+        output_dir=tmp_path,
+        log="",
+        report_paths={"R1": _write_report(tmp_path / "R1.txt")},
+    )
+    first = result.reports["R1"]
+    second = result.reports["R1"]
+    assert first is second
+
+
+def test_cache_survives_underlying_file_deletion(tmp_path: Path) -> None:
+    """Once parsed, the DataFrame is independent of the source file."""
+    path = _write_report(tmp_path / "R1.txt")
+    result = Results(output_dir=tmp_path, log="", report_paths={"R1": path})
+    df = result.reports["R1"]
+    path.unlink()
+    again = result.reports["R1"]
+    assert again is df
+
+
+def test_unknown_report_key_raises(tmp_path: Path) -> None:
+    result = _empty(tmp_path)
+    with pytest.raises(KeyError) as excinfo:
+        _ = result.reports["does_not_exist"]
+    assert excinfo.value.args == ("does_not_exist",)
+
+
+# --- ephemerides / contacts (v0.1 stub) --------------------------------------
+
+
+def test_ephemeris_paths_round_trip(tmp_path: Path) -> None:
+    eph = tmp_path / "E1.eph"
+    result = Results(output_dir=tmp_path, log="", ephemeris_paths={"E1": eph})
+    assert result.ephemeris_paths["E1"] == eph
+    assert list(result.ephemerides) == ["E1"]
+    assert "E1" in result.ephemerides
+    assert len(result.ephemerides) == 1
+
+
+def test_ephemeris_value_access_is_unimplemented(tmp_path: Path) -> None:
+    result = Results(
+        output_dir=tmp_path,
+        log="",
+        ephemeris_paths={"E1": tmp_path / "E1.eph"},
+    )
+    with pytest.raises(NotImplementedError) as excinfo:
+        _ = result.ephemerides["E1"]
+    message = str(excinfo.value)
+    assert ".eph" in message
+    assert "v0.2" in message
+    assert "ephemeris_paths" in message
+    assert "'E1'" in message
+
+
+def test_ephemerides_unknown_key_raises_keyerror_not_notimplemented(tmp_path: Path) -> None:
+    """Membership check must distinguish unknown keys from unimplemented values."""
+    result = _empty(tmp_path)
+    with pytest.raises(KeyError):
+        _ = result.ephemerides["nope"]
+
+
+def test_contact_paths_round_trip(tmp_path: Path) -> None:
+    con = tmp_path / "C1.txt"
+    result = Results(output_dir=tmp_path, log="", contact_paths={"C1": con})
+    assert result.contact_paths["C1"] == con
+    assert list(result.contacts) == ["C1"]
+    assert "C1" in result.contacts
+    assert len(result.contacts) == 1
+
+
+def test_contact_value_access_is_unimplemented(tmp_path: Path) -> None:
+    result = Results(
+        output_dir=tmp_path,
+        log="",
+        contact_paths={"C1": tmp_path / "C1.txt"},
+    )
+    with pytest.raises(NotImplementedError) as excinfo:
+        _ = result.contacts["C1"]
+    message = str(excinfo.value)
+    assert "ContactLocator" in message
+    assert "v0.2" in message
+    assert "contact_paths" in message
+    assert "'C1'" in message
+
+
+def test_contacts_unknown_key_raises_keyerror_not_notimplemented(tmp_path: Path) -> None:
+    result = _empty(tmp_path)
+    with pytest.raises(KeyError):
+        _ = result.contacts["nope"]
+
+
+# --- mapping protocol --------------------------------------------------------
+
+
+@pytest.mark.parametrize("attr", ["reports", "ephemerides", "contacts"])
+def test_mapping_attrs_are_mappings(tmp_path: Path, attr: str) -> None:
+    """The three keyed views must satisfy ``Mapping`` at runtime, not just typing."""
+    result = _empty(tmp_path)
+    assert isinstance(getattr(result, attr), Mapping)
+
+
+def test_iteration_preserves_insertion_order(tmp_path: Path) -> None:
+    """dict ordering is part of the contract — ``Mission.run`` will hand keys
+    in declaration order and downstream code shouldn't have to re-sort."""
+    paths = {
+        "ReportC": _write_report(tmp_path / "C.txt"),
+        "ReportA": _write_report(tmp_path / "A.txt"),
+        "ReportB": _write_report(tmp_path / "B.txt"),
+    }
+    result = Results(output_dir=tmp_path, log="", report_paths=paths)
+    assert list(result.reports) == ["ReportC", "ReportA", "ReportB"]


### PR DESCRIPTION
## Summary

- New `gmat_run.Results` — the in-memory aggregate `Mission.run()` will return — exposes the eight attributes from the issue: `output_dir`, `log`, the keyed views `reports` / `ephemerides` / `contacts`, and the parallel `ephemeris_paths` / `contact_paths`. Constructed by keyword from per-resource `{name: Path}` mappings; the mission-layer issue (separate) will own discovery and pass them in.
- `Results.reports` is a lazy `Mapping[str, DataFrame]` view backed by `parsers.reportfile.parse`: parsing happens on first `__getitem__` and the DataFrame is cached for the life of the `Results`. Construction never reads files, so building a `Results` over a long run is free.
- `Results.ephemerides` and `Results.contacts` keep their keys exposed (so iteration / `len` / `in` work without branching on release) but raise `NotImplementedError` on value access pointing at the parallel `*_paths` mapping — `.eph` and `ContactLocator` parsers are scheduled for v0.2.
- Path mappings are defensively copied and re-exposed via `MappingProxyType`, so the run record can't be mutated post-construction.

## Test plan

- [x] `uv run pytest` — 148 passed (21 new in `tests/test_results.py`, covering construction, lazy materialisation, caching across underlying-file deletion, unknown-key behaviour, the deferred mappings' `NotImplementedError` shape, and `__contains__` / iteration / order).
- [x] `uv run ruff check` — clean.
- [x] `uv run mypy` — clean.

Closes #8.