### PR TITLE
Add `Results.persist` to copy artefacts out of the temp workspace

### DIFF
--- a/src/gmat_run/mission.py
+++ b/src/gmat_run/mission.py
@@ -176,7 +176,9 @@ class Mission:
                 creates a fresh :class:`tempfile.TemporaryDirectory` whose
                 lifetime is tied to the returned :class:`Results` — the
                 directory survives until the caller drops the result, so lazy
-                report parsing keeps working without a context manager.
+                report parsing keeps working without a context manager. Call
+                :meth:`Results.persist` before that to copy the artefacts to a
+                permanent location.
 
         Raises:
             GmatRunError: ``RunScript`` returned a non-success status or

--- a/src/gmat_run/results.py
+++ b/src/gmat_run/results.py
@@ -12,6 +12,11 @@ the life of the :class:`Results` instance — opening a notebook on a long run
 without touching every report should not pay the parse cost for the ones it
 does not look at.
 
+When :meth:`Mission.run` was called without a ``working_dir``, the artefacts
+live under a :class:`tempfile.TemporaryDirectory` that is cleaned up when this
+:class:`Results` is garbage-collected. Call :meth:`Results.persist` to copy
+the artefacts to a permanent location before the temp dir disappears.
+
 The ``.eph`` ephemeris and ``ContactLocator`` parsers are scheduled for v0.2.
 For v0.1 the corresponding mappings still expose their keys (so callers can
 discover what GMAT wrote without branching on the version), but accessing a
@@ -22,6 +27,8 @@ hand back the raw :class:`pathlib.Path`.
 
 from __future__ import annotations
 
+import os
+import shutil
 import tempfile
 from collections.abc import Iterator, Mapping
 from pathlib import Path
@@ -67,6 +74,12 @@ class _LazyReports(Mapping[str, pd.DataFrame]):
         # Override the Mapping default — it calls __getitem__ and would parse.
         return key in self._paths
 
+    def _rebase(self, paths: Mapping[str, Path]) -> None:
+        # Replace the underlying path mapping in place. Already-cached
+        # DataFrames are kept — they're independent of the on-disk files once
+        # parsed.
+        self._paths = dict(paths)
+
 
 class _DeferredMapping(Mapping[str, pd.DataFrame]):
     """Mapping view whose keys are populated but value access is unimplemented.
@@ -109,6 +122,9 @@ class _DeferredMapping(Mapping[str, pd.DataFrame]):
         # Override the Mapping default — it calls __getitem__ and would raise
         # NotImplementedError for known keys.
         return key in self._paths
+
+    def _rebase(self, paths: Mapping[str, Path]) -> None:
+        self._paths = dict(paths)
 
 
 class Results:
@@ -179,3 +195,62 @@ class Results:
             target_release="v0.2",
             paths_attr="contact_paths",
         )
+
+    def persist(self, path: str | os.PathLike[str]) -> Results:
+        """Copy every output artefact under :attr:`output_dir` into ``path``.
+
+        Mutates the :class:`Results` in place so future report/ephemeris/contact
+        access reads from the persisted location instead of the (potentially
+        soon-to-be-cleaned) workspace. The :class:`tempfile.TemporaryDirectory`
+        backing a default-workspace run is released as part of the call. Run
+        with an explicit ``working_dir``: that directory is left intact —
+        ``persist`` is a copy, never a move.
+
+        Path mappings are rewritten so any path that lived under the old
+        ``output_dir`` now points at the matching file under ``path``.
+        Absolute filenames the user pinned outside the workspace via
+        ``ReportFile.Filename = "/abs/elsewhere.txt"`` are kept as-is — the
+        user chose that destination and we honour it. Already-parsed
+        DataFrames stay cached; they are independent of the on-disk files.
+
+        Calling ``persist`` again later moves the artefacts to the new
+        destination. A no-op fast path applies when the destination already
+        equals the current ``output_dir``.
+
+        Args:
+            path: Directory to copy artefacts into. Created if missing.
+
+        Returns:
+            ``self``, so the call composes with ``Mission.run().persist(...)``.
+        """
+        dest = Path(path).expanduser()
+        if self.output_dir.exists() and dest.resolve() == self.output_dir.resolve():
+            return self
+        dest.mkdir(parents=True, exist_ok=True)
+        if self.output_dir.exists() and self.output_dir.is_dir():
+            shutil.copytree(self.output_dir, dest, dirs_exist_ok=True)
+
+        old_dir = self.output_dir
+
+        def _migrate(p: Path) -> Path:
+            try:
+                rel = p.relative_to(old_dir)
+            except ValueError:
+                return p
+            return dest / rel
+
+        new_reports = {n: _migrate(p) for n, p in self.reports._paths.items()}  # type: ignore[attr-defined]
+        new_eph = {n: _migrate(p) for n, p in self.ephemeris_paths.items()}
+        new_con = {n: _migrate(p) for n, p in self.contact_paths.items()}
+
+        self.reports._rebase(new_reports)  # type: ignore[attr-defined]
+        self.ephemerides._rebase(new_eph)  # type: ignore[attr-defined]
+        self.contacts._rebase(new_con)  # type: ignore[attr-defined]
+        self.ephemeris_paths = MappingProxyType(new_eph)
+        self.contact_paths = MappingProxyType(new_con)
+
+        self.output_dir = dest
+        if self._workspace is not None:
+            self._workspace.cleanup()
+            self._workspace = None
+        return self

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -11,6 +11,7 @@ without needing a real GMAT install.
 
 from __future__ import annotations
 
+import gc
 from collections.abc import Iterator
 from pathlib import Path
 from types import ModuleType
@@ -833,6 +834,60 @@ class TestMissionRun:
         assert len(result.contact_paths) == 0
         # Log was still captured.
         assert result.log == "fake gmat log\n"
+
+    def test_run_does_not_pollute_cwd(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Stand the harness up under a fresh CWD with a relative-Filename
+        # subscriber. A naïve run would land "rel.txt" right next to where
+        # the user is sitting; the rewrite must redirect it into the
+        # workspace, leaving CWD untouched.
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+        before = set(cwd.iterdir())
+
+        rf = _report_file("RF", "rel.txt")
+        mission, _ = _run_mission(tmp_path / "gmat", objects={"RF": rf})
+        result = mission.run()
+
+        after = set(cwd.iterdir())
+        assert after == before, f"new files in CWD: {after - before}"
+        # The captured path is absolute and lives inside the workspace, not
+        # CWD — the only way no-pollution is actually upheld.
+        report_path = result.reports._paths["RF"]  # type: ignore[attr-defined]
+        assert report_path.is_absolute()
+        assert report_path.parent == result.output_dir
+
+    def test_run_default_temp_dir_cleaned_up_when_results_dropped(
+        self, tmp_path: Path
+    ) -> None:
+        # The TemporaryDirectory parked on Results runs its finaliser when GC
+        # collects the instance, so the workspace disappears with the result.
+        mission, _ = _run_mission(tmp_path / "gmat")
+        result = mission.run()
+        workspace = result.output_dir
+        assert workspace.is_dir()
+
+        del result
+        gc.collect()
+
+        assert not workspace.is_dir()
+
+    def test_run_explicit_working_dir_survives_results_drop(
+        self, tmp_path: Path
+    ) -> None:
+        # The opt-in path: when the caller pinned working_dir, the directory
+        # is theirs and gmat-run leaves it alone on Results cleanup.
+        custom = tmp_path / "user-output"
+        mission, _ = _run_mission(tmp_path / "gmat")
+        result = mission.run(working_dir=custom)
+        assert custom.is_dir()
+
+        del result
+        gc.collect()
+
+        assert custom.is_dir()
 
     def test_run_unknown_engine_exception_still_wrapped(self, tmp_path: Path) -> None:
         # If a non-APIException leaks out of RunScript (programmer bug, plugin

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -5,6 +5,7 @@ The lazy-materialisation contract is exercised by pointing the constructor at
 how often) the parser actually reads them.
 """
 
+import tempfile
 from collections.abc import Mapping
 from pathlib import Path
 
@@ -251,3 +252,165 @@ def test_iteration_preserves_insertion_order(tmp_path: Path) -> None:
     }
     result = Results(output_dir=tmp_path, log="", report_paths=paths)
     assert list(result.reports) == ["ReportC", "ReportA", "ReportB"]
+
+
+# --- persist ----------------------------------------------------------------
+
+
+def _result_with_workspace(
+    tmp_path: Path,
+    *,
+    rel_report: str = "r1.txt",
+    rel_eph: str = "e1.eph",
+    rel_con: str = "c1.txt",
+) -> tuple[Results, Path]:
+    """A Results pointing at a populated workspace dir, no temp-dir handle.
+
+    Returns ``(result, workspace_dir)``. The workspace contains a parseable
+    report, an ephemeris file, a contact file, and a log — same layout
+    ``Mission.run`` produces.
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _write_report(workspace / rel_report)
+    (workspace / rel_eph).write_text("eph data\n", encoding="utf-8")
+    (workspace / rel_con).write_text("contact data\n", encoding="utf-8")
+    (workspace / "GmatLog.txt").write_text("log\n", encoding="utf-8")
+    result = Results(
+        output_dir=workspace,
+        log="log\n",
+        report_paths={"R1": workspace / rel_report},
+        ephemeris_paths={"E1": workspace / rel_eph},
+        contact_paths={"C1": workspace / rel_con},
+    )
+    return result, workspace
+
+
+class TestPersist:
+    def test_copies_artefacts_into_dest(self, tmp_path: Path) -> None:
+        result, _ = _result_with_workspace(tmp_path)
+        dest = tmp_path / "persisted"
+
+        result.persist(dest)
+
+        assert (dest / "r1.txt").exists()
+        assert (dest / "e1.eph").read_text(encoding="utf-8") == "eph data\n"
+        assert (dest / "c1.txt").read_text(encoding="utf-8") == "contact data\n"
+        assert (dest / "GmatLog.txt").read_text(encoding="utf-8") == "log\n"
+
+    def test_updates_output_dir_and_path_mappings(self, tmp_path: Path) -> None:
+        result, _ = _result_with_workspace(tmp_path)
+        dest = tmp_path / "persisted"
+
+        result.persist(dest)
+
+        assert result.output_dir == dest
+        assert result.ephemeris_paths["E1"] == dest / "e1.eph"
+        assert result.contact_paths["C1"] == dest / "c1.txt"
+        # Reports' underlying path mapping is rebased too.
+        assert result.reports._paths["R1"] == dest / "r1.txt"  # type: ignore[attr-defined]
+
+    def test_returns_self_for_chaining(self, tmp_path: Path) -> None:
+        result, _ = _result_with_workspace(tmp_path)
+        assert result.persist(tmp_path / "dest") is result
+
+    def test_lazy_report_reads_from_persisted_path(self, tmp_path: Path) -> None:
+        result, workspace = _result_with_workspace(tmp_path)
+        dest = tmp_path / "persisted"
+
+        result.persist(dest)
+        # Wipe the original to confirm the lazy parse hits the new location.
+        for f in workspace.iterdir():
+            f.unlink()
+        df = result.reports["R1"]
+        assert list(df.columns) == ["Sat.UTCGregorian", "Sat.Earth.SMA"]
+
+    def test_preserves_already_cached_dataframes(self, tmp_path: Path) -> None:
+        result, _ = _result_with_workspace(tmp_path)
+        df_before = result.reports["R1"]
+
+        result.persist(tmp_path / "persisted")
+
+        df_after = result.reports["R1"]
+        assert df_after is df_before
+
+    def test_releases_temp_workspace(self, tmp_path: Path) -> None:
+        # Stand up a real TemporaryDirectory so persist exercises the cleanup
+        # path, mirroring what Mission.run() builds for the default case.
+        tmpdir = tempfile.TemporaryDirectory(prefix="gmat-run-test-")
+        workspace = Path(tmpdir.name)
+        _write_report(workspace / "r1.txt")
+        result = Results(
+            output_dir=workspace,
+            log="",
+            report_paths={"R1": workspace / "r1.txt"},
+        )
+        result._workspace = tmpdir
+
+        result.persist(tmp_path / "persisted")
+
+        assert result._workspace is None
+        assert not workspace.is_dir()
+
+    def test_explicit_working_dir_is_not_deleted(self, tmp_path: Path) -> None:
+        # _workspace stays None when the run had a user-supplied working_dir.
+        # persist must not touch that directory.
+        result, workspace = _result_with_workspace(tmp_path)
+        assert result._workspace is None
+
+        result.persist(tmp_path / "persisted")
+
+        assert workspace.is_dir()
+        assert (workspace / "r1.txt").exists()
+
+    def test_absolute_paths_outside_workspace_are_not_migrated(
+        self, tmp_path: Path
+    ) -> None:
+        # A ReportFile.Filename like "/abs/elsewhere/report.txt" lands outside
+        # the workspace and was not rewritten by Mission.run. persist must
+        # leave that path intact rather than silently relocating it.
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        external = tmp_path / "elsewhere" / "report.txt"
+        external.parent.mkdir()
+        external.write_text(_REPORT, encoding="utf-8")
+        result = Results(
+            output_dir=workspace,
+            log="",
+            report_paths={"Inside": _write_report(workspace / "in.txt")},
+            ephemeris_paths={"Outside": external},
+        )
+
+        result.persist(tmp_path / "persisted")
+
+        assert result.ephemeris_paths["Outside"] == external
+        assert result.reports._paths["Inside"] == tmp_path / "persisted" / "in.txt"  # type: ignore[attr-defined]
+
+    def test_idempotent_when_dest_equals_output_dir(self, tmp_path: Path) -> None:
+        result, workspace = _result_with_workspace(tmp_path)
+        result.persist(workspace)
+        # Path mappings are unchanged.
+        assert result.output_dir == workspace
+        assert result.reports._paths["R1"] == workspace / "r1.txt"  # type: ignore[attr-defined]
+
+    def test_creates_missing_destination(self, tmp_path: Path) -> None:
+        result, _ = _result_with_workspace(tmp_path)
+        dest = tmp_path / "nested" / "deep" / "persisted"
+        assert not dest.exists()
+
+        result.persist(dest)
+
+        assert dest.is_dir()
+        assert (dest / "r1.txt").exists()
+
+    def test_can_persist_twice(self, tmp_path: Path) -> None:
+        result, _ = _result_with_workspace(tmp_path)
+        first = tmp_path / "first"
+        second = tmp_path / "second"
+
+        result.persist(first)
+        result.persist(second)
+
+        assert result.output_dir == second
+        assert (second / "r1.txt").exists()
+        assert result.reports._paths["R1"] == second / "r1.txt"  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

- New `Results.persist(path) -> Results` copies every file under `output_dir` into `path`, rebases the report / ephemeris / contact path mappings onto the new location, updates `output_dir`, and (for default-temp-dir runs) releases the parked `TemporaryDirectory`. Documented escape hatch for keeping artefacts past the `Results` lifetime.
- Path migration is contained: paths under the old `output_dir` are rewritten; absolute filenames the user pinned outside the workspace are preserved untouched. Already-cached DataFrames stay cached.
- Three new `TestMissionRun` tests pin the lifetime contract: no CWD pollution after a run, the default temp dir is GC'd with `Results`, and an explicit `working_dir` survives `Results` drop.
- `TestPersist` covers the new method end to end (11 cases incl. real-`TemporaryDirectory` cleanup, idempotent same-dest, back-to-back persist, absolute-path preservation, lazy parse from the persisted file).

## Test plan

- [x] `pytest -q` — 223 passed (95 in the touched modules).
- [x] `ruff check src tests` — clean.
- [x] `mypy --strict src` — clean.
- [x] CI green on Ubuntu and Windows across 3.10 / 3.11 / 3.12.

Closes #11