### PR TITLE
Add MkDocs-Material docs site with auto-deploy on tag

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     tags: ['v*']
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: docs-${{ github.workflow }}-${{ github.ref }}
@@ -30,7 +31,9 @@ jobs:
   deploy:
     name: deploy
     needs: build
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) ||
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,54 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+
+concurrency:
+  group: docs-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - run: uv sync --all-groups
+      - run: uv run mkdocs build --strict
+
+  deploy:
+    name: deploy
+    needs: build
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - run: uv sync --all-groups
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      - run: uv run mkdocs gh-deploy --force --no-history

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # gmat-run
 
 [![CI](https://github.com/astro-tools/gmat-run/actions/workflows/ci.yml/badge.svg)](https://github.com/astro-tools/gmat-run/actions/workflows/ci.yml)
+[![Docs](https://github.com/astro-tools/gmat-run/actions/workflows/docs.yml/badge.svg)](https://astro-tools.github.io/gmat-run/)
 [![PyPI](https://img.shields.io/pypi/v/gmat-run.svg)](https://pypi.org/project/gmat-run/)
 [![Python versions](https://img.shields.io/pypi/pyversions/gmat-run.svg)](https://pypi.org/project/gmat-run/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
@@ -47,6 +48,13 @@ git clone https://github.com/astro-tools/gmat-run.git
 cd gmat-run
 uv sync --all-groups
 ```
+
+## Documentation
+
+Full docs at **<https://astro-tools.github.io/gmat-run/>**, including a
+[getting-started guide](https://astro-tools.github.io/gmat-run/getting-started/),
+[GMAT install instructions](https://astro-tools.github.io/gmat-run/install-gmat/),
+and the [API reference](https://astro-tools.github.io/gmat-run/reference/).
 
 ## Licence
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,90 @@
+# Getting started
+
+## Requirements
+
+- Python 3.10, 3.11, or 3.12.
+- A local GMAT install (R2022a or later; R2026a is the primary development target).
+  See [Install GMAT](install-gmat.md).
+
+## Install gmat-run
+
+Once v0.1.0 ships:
+
+```bash
+pip install gmat-run
+```
+
+Until then, install from the repository:
+
+```bash
+pip install git+https://github.com/astro-tools/gmat-run.git
+```
+
+## Quick start
+
+```python
+from gmat_run import Mission
+
+mission = Mission.load("flyby.script")
+mission["Sat.SMA"] = 7000
+result = mission.run()
+result.reports["ReportFile1"].plot(x="UTCGregorian", y="Sat.Earth.Altitude")
+```
+
+[`Mission.load`][gmat_run.Mission.load] discovers a local GMAT install, bootstraps
+`gmatpy`, and parses the `.script` into the live GMAT object graph.
+
+Subscript access reads and writes fields against that graph. Reads return
+Python-typed values; writes coerce to the GMAT-expected type:
+
+```python
+mission["Sat.SMA"]              # 7000.0  (read)
+mission["Sat.SMA"] = 6878.0     # write through SetField
+mission["DefaultProp.InitialStepSize"] = 60
+```
+
+[`mission.run()`][gmat_run.Mission.run] executes the mission sequence headlessly
+and returns a [`Results`][gmat_run.Results] object keyed by the resource names
+declared in the script. Parsing is lazy — a DataFrame is materialised on first
+access and cached:
+
+```python
+df = result.reports["ReportFile1"]
+df["UTCGregorian"]              # already parsed as datetime64[ns]
+df.plot(x="UTCGregorian", y="Sat.Earth.Altitude")
+```
+
+## Pointing at a specific GMAT install
+
+If you have multiple GMAT installs, or your install is in a non-standard location,
+override discovery:
+
+```python
+mission = Mission.load("flyby.script", gmat_root="/opt/gmat-R2026a")
+```
+
+Or set `GMAT_ROOT` in the environment:
+
+```bash
+export GMAT_ROOT=/opt/gmat-R2026a
+```
+
+## Working directory
+
+By default, `mission.run()` writes GMAT outputs into a fresh temporary directory whose
+lifetime is tied to the returned [`Results`][gmat_run.Results] — the directory survives
+until you drop the result, so lazy DataFrame access still works after the run returns.
+Pass `working_dir=...` to write into a permanent location instead.
+
+## Errors
+
+Every exception gmat-run raises inherits from [`GmatError`][gmat_run.GmatError]. Branch
+on the leaf type when you need to react to a specific failure:
+
+| Exception                                                  | When                                                                |
+| ---------------------------------------------------------- | ------------------------------------------------------------------- |
+| [`GmatNotFoundError`][gmat_run.GmatNotFoundError]          | No usable GMAT install on this machine.                             |
+| [`GmatLoadError`][gmat_run.GmatLoadError]                  | gmatpy could not be imported (e.g. wrong Python minor version).     |
+| [`GmatRunError`][gmat_run.GmatRunError]                    | The mission sequence itself failed; GMAT's log is on `.log`.        |
+| [`GmatFieldError`][gmat_run.GmatFieldError]                | A dotted-path field access failed (unknown path or type mismatch).  |
+| [`GmatOutputParseError`][gmat_run.GmatOutputParseError]    | An output file could not be parsed into a DataFrame.                |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,36 @@
+# gmat-run
+
+Run GMAT mission scripts from Python and get results as pandas DataFrames.
+
+!!! warning "Pre-alpha"
+    The public API is not yet stable. Pin a specific version when depending on `gmat-run`.
+
+## What this is
+
+A thin, Pythonic wrapper around NASA GMAT's own `gmatpy` runtime. You bring a working
+`.script`; gmat-run loads it, lets you override fields from Python, runs the mission
+headlessly, and returns `ReportFile` / ephemeris / `ContactLocator` output as pandas
+DataFrames.
+
+```python
+from gmat_run import Mission
+
+mission = Mission.load("flyby.script")
+mission["Sat.SMA"] = 7000
+result = mission.run()
+result.reports["ReportFile1"].plot(x="UTCGregorian", y="Sat.Earth.Altitude")
+```
+
+## What this is not
+
+- **Not** a way to build GMAT missions from scratch in Python — see
+  [gmatpyplus](https://github.com/weasdown/gmatpyplus) for that.
+- **Not** a `.script` text generator — see [pygmat](https://pypi.org/project/pygmat/).
+- **Not** a parallel sweep runner — that's a future astro-tools project (`gmat-sweep`)
+  built on top of gmat-run.
+
+## Where to next
+
+- [Getting started](getting-started.md) — install gmat-run and run your first mission.
+- [Install GMAT](install-gmat.md) — get the GMAT engine on your machine.
+- [API reference](reference.md) — the public Python API.

--- a/docs/install-gmat.md
+++ b/docs/install-gmat.md
@@ -1,0 +1,69 @@
+# Install GMAT
+
+gmat-run does not ship GMAT binaries. Install GMAT separately from
+[gmat.gsfc.nasa.gov](https://gmat.gsfc.nasa.gov/) or directly from
+[SourceForge](https://sourceforge.net/projects/gmat/files/GMAT/).
+
+## Supported versions
+
+| GMAT version    | Status                                                                  |
+| --------------- | ----------------------------------------------------------------------- |
+| R2026a          | Primary development target; exercised in CI on every PR.                |
+| R2024a, R2025a  | Supported; exercised in release CI.                                     |
+| R2022a, R2023a  | Supported on a best-effort basis.                                       |
+| Earlier         | Not supported. gmatpy ships per-Python-minor shared libraries, and    |
+|                 | older releases may not match Python 3.10+.                              |
+
+## Windows
+
+1. Download the Windows zip from
+   [SourceForge](https://sourceforge.net/projects/gmat/files/GMAT/) (e.g.
+   `gmat-win-R2026a.zip`).
+2. Extract anywhere — `C:\Program Files\GMAT-R2026a\` is typical.
+3. gmat-run discovers installs under `C:\Program Files\GMAT*` and
+   `C:\Program Files (x86)\GMAT*` automatically.
+
+## Linux
+
+1. Download the Linux tarball (e.g. `gmat-ubuntu-x64-R2026a.tar.gz`).
+2. Extract anywhere — `~/gmat-R2026a/` or `/opt/gmat-R2026a/` is typical.
+3. gmat-run discovers installs matching `~/gmat-*` and `/opt/gmat-*` automatically.
+
+## macOS
+
+1. Download the macOS package from SourceForge.
+2. Install into `/Applications/GMAT-R2026a/` or similar.
+3. gmat-run discovers installs under `/Applications/GMAT*` automatically.
+
+## Custom location
+
+If your install lives elsewhere, point gmat-run at it explicitly:
+
+```python
+mission = Mission.load("flyby.script", gmat_root="/path/to/gmat-R2026a")
+```
+
+Or set the `GMAT_ROOT` environment variable, which gmat-run honours globally:
+
+```bash
+export GMAT_ROOT=/path/to/gmat-R2026a
+```
+
+## Verifying the install
+
+```python
+from gmat_run import locate_gmat
+
+install = locate_gmat()
+print(install.root, install.version)
+```
+
+If discovery fails, [`GmatNotFoundError`][gmat_run.GmatNotFoundError] lists every
+search location it tried and why each was rejected — paste that output verbatim
+when filing an install issue.
+
+## API startup file
+
+On first use, gmat-run generates `<install>/bin/api_startup_file.txt` by running
+`<install>/api/BuildApiStartupFile.py`. This is automatic — no manual step is
+needed.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,41 @@
+# API reference
+
+The public surface of gmat-run is small and stable across the package's top-level
+namespace. Everything below is re-exported from `gmat_run`; import from the top
+level rather than from submodules.
+
+```python
+from gmat_run import Mission, Results, GmatError, locate_gmat
+```
+
+## `gmat_run.Mission`
+
+::: gmat_run.Mission
+
+## `gmat_run.Results`
+
+::: gmat_run.Results
+
+## Install discovery
+
+::: gmat_run.locate_gmat
+
+::: gmat_run.GmatInstall
+
+## Runtime bootstrap
+
+::: gmat_run.bootstrap
+
+## Exceptions
+
+::: gmat_run.GmatError
+
+::: gmat_run.GmatNotFoundError
+
+::: gmat_run.GmatLoadError
+
+::: gmat_run.GmatRunError
+
+::: gmat_run.GmatFieldError
+
+::: gmat_run.GmatOutputParseError

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,76 @@
+site_name: gmat-run
+site_description: Run GMAT mission scripts from Python and get results as pandas DataFrames.
+site_url: https://astro-tools.github.io/gmat-run/
+repo_url: https://github.com/astro-tools/gmat-run
+repo_name: astro-tools/gmat-run
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  features:
+    - content.code.copy
+    - navigation.instant
+    - navigation.sections
+    - navigation.top
+    - search.highlight
+    - search.suggest
+    - toc.follow
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+nav:
+  - Home: index.md
+  - Getting started: getting-started.md
+  - Install GMAT: install-gmat.md
+  - API reference: reference.md
+
+plugins:
+  - search
+  - mkdocstrings:
+      default_handler: python
+      handlers:
+        python:
+          paths: [src]
+          options:
+            show_source: false
+            show_root_heading: true
+            show_root_full_path: false
+            show_symbol_type_heading: true
+            show_symbol_type_toc: true
+            members_order: source
+            separate_signature: true
+            show_signature_annotations: true
+            signature_crossrefs: true
+            docstring_style: google
+            merge_init_into_class: true
+            filters: ["!^_"]
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - tables
+  - toc:
+      permalink: true
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/astro-tools/gmat-run


### PR DESCRIPTION
## Summary

- New MkDocs-Material site under `docs/` with four pages: Home, Getting started, Install GMAT, and an auto-generated API reference via `mkdocstrings[python]`.
- New `.github/workflows/docs.yml`: builds `mkdocs --strict` on every PR; deploys to the `gh-pages` branch via `mkdocs gh-deploy --force --no-history` on `v*` tag push or manual `workflow_dispatch`.
- README gains a Docs CI badge and a Documentation section linking to <https://astro-tools.github.io/gmat-run/>.

## Bootstrap after merge

Pages can't pick `gh-pages` as a source until the branch exists, and the branch doesn't exist until a deploy runs. The deploy job has `workflow_dispatch` for exactly this:

1. After this PR merges, dispatch the **Docs** workflow from the Actions tab (run from `main`). This creates `gh-pages`.
2. Repo Settings → Pages → **Source:** Deploy from a branch → **Branch:** `gh-pages` / `/ (root)`.
3. Site goes live at <https://astro-tools.github.io/gmat-run/>.

From then on, every `v*` tag refreshes the site automatically. `workflow_dispatch` stays for off-cycle docs fixes.

## Test plan

- [x] `uv run mkdocs build --strict` succeeds locally with zero warnings.
- [x] `uv run ruff check` passes.
- [x] `uv run mypy` passes.
- [x] Visual smoke test of all four pages via `mkdocs serve`.
- [x] Docs CI green on this PR (build job; deploy job is skipped on PRs by design).
- [ ] After merge: `workflow_dispatch` run creates `gh-pages` and the site renders.

Closes #13