### PR TITLE
Add release workflow with PyPI trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,74 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: build sdist + wheel
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: astral-sh/setup-uv@v4
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - run: uv build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  publish-pypi:
+    name: publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: pypi
+      url: https://pypi.org/p/gmat-run
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          skip-existing: true
+
+  github-release:
+    name: github release
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --title "${GITHUB_REF_NAME}" \
+            --generate-notes \
+            dist/*


### PR DESCRIPTION
## Summary

- New `.github/workflows/release.yml` triggered by `v*` tag push.
- Three sequential jobs:
  - **build** — `uv build` produces wheel + sdist, uploaded as a workflow artifact.
  - **publish-pypi** — runs in environment `pypi`, downloads the artifact, and publishes via `pypa/gh-action-pypi-publish@release/v1` using OIDC trusted publishing. No long-lived API token. `skip-existing: true` for idempotent re-runs.
  - **github-release** — creates the GitHub Release with auto-generated notes and attaches both files.

## Action required after merge

Two manual settings need to be in place before the v0.1.0 tag fires (#15):

1. **PyPI pending publisher** must match this workflow exactly (you already configured this per AC1; double-check):
   - Project: `gmat-run`
   - Owner: `astro-tools`
   - Repository: `gmat-run`
   - Workflow filename: `release.yml`
   - Environment name: `pypi`

2. **GitHub environment `pypi`** must exist with you as a required reviewer (this is AC3, the human-approval gate):
   - Repo Settings → Environments → New environment → name `pypi`.
   - Enable "Required reviewers" → add yourself.
   - This makes every PyPI publish pause for a manual click in the Actions UI.

## Test plan

- [x] `uv build` succeeds locally and produces both `gmat_run-0.0.0-py3-none-any.whl` and `gmat_run-0.0.0.tar.gz`.
- [x] Workflow YAML reviewed visually for OIDC permissions, environment binding, job ordering, and `skip-existing` safety.
- [x] CI on this PR — the workflow itself doesn't fire on PR, only on `v*` tag, so this PR exercises only the existing `ci.yml` / `docs.yml` checks.
- [ ] Real end-to-end test happens on the v0.1.0 tag in #15. We deliberately do not push a sacrificial tag against PyPI, since version 0.0.0 is not what we want to claim on PyPI.

## Out of scope

- Test-PyPI publishing.
- Sigstore signing of artifacts.
- Tag/`pyproject.toml` version-consistency check (#15 owns the version bump).
- Release-notes label-grouping (#15).
- Automated changelog / Release Please.

Closes #14