### PR TITLE
Bring v0.1 DoD checks green: ruff format, CI gate, README polish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,7 @@ jobs:
           cache-dependency-glob: uv.lock
       - run: uv sync --all-groups
       - run: uv run ruff check
+      - run: uv run ruff format --check
 
   typecheck:
     name: typecheck

--- a/README.md
+++ b/README.md
@@ -16,15 +16,6 @@ A thin, Pythonic wrapper around NASA GMAT's own `gmatpy` runtime. You bring a wo
 gmat-run loads it, lets you override fields from Python, runs the mission headlessly, and returns
 `ReportFile` / ephemeris / `ContactLocator` output as pandas DataFrames.
 
-```python
-from gmat_run import Mission
-
-mission = Mission.load("flyby.script")
-mission["Sat.SMA"] = 7000
-result = mission.run()
-result.reports["ReportFile1"].plot(x="UTCGregorian", y="Sat.Earth.Altitude")
-```
-
 ## What this is not
 
 - **Not** a way to build GMAT missions from scratch in Python — see
@@ -35,9 +26,21 @@ result.reports["ReportFile1"].plot(x="UTCGregorian", y="Sat.Earth.Altitude")
 ## Requirements
 
 - Python 3.10, 3.11, or 3.12.
-- A local GMAT install (R2022a or later; R2026a is the primary development target). gmat-run
-  does not ship GMAT binaries — install GMAT separately from
+- A local GMAT install. gmat-run does not ship GMAT binaries — install GMAT separately from
   [gmat.gsfc.nasa.gov](https://gmat.gsfc.nasa.gov/).
+
+### Supported GMAT versions
+
+| GMAT release | Status | CI |
+|---|---|---|
+| R2026a | Primary development target | Exercised on every PR (Ubuntu + Windows) |
+| R2025a | Expected to work | Not exercised in CI for v0.1 |
+| R2024a | Expected to work | Not exercised in CI for v0.1 |
+| R2023a | Expected to work | Not exercised in CI for v0.1 |
+| R2022a | Expected to work | Not exercised in CI for v0.1 |
+
+A wider CI matrix is planned for a follow-up release; report any version-specific breakage as
+an issue and we'll add a CI cell for it.
 
 ## Installation
 
@@ -48,6 +51,27 @@ git clone https://github.com/astro-tools/gmat-run.git
 cd gmat-run
 uv sync --all-groups
 ```
+
+## Quick start
+
+Load a script, override a field, run the mission, and read the resulting `ReportFile` as a
+pandas DataFrame:
+
+```python
+from gmat_run import Mission
+
+mission = Mission.load("flyby.script")
+mission["Sat.SMA"] = 7000
+result = mission.run()
+result.reports["ReportFile1"].plot(x="UTCGregorian", y="Sat.Earth.Altitude")
+```
+
+`Mission.load` discovers a local GMAT install (honouring the `GMAT_ROOT` environment variable
+or a `gmat_root=` argument), bootstraps `gmatpy`, and parses the script into the live GMAT
+object graph. Subscript access reads and writes fields against that graph with type coercion.
+`mission.run()` executes the mission sequence headlessly, captures GMAT's log, and returns a
+`Results` whose `reports` mapping parses each `ReportFile` to a DataFrame on first access —
+with `UTCGregorian` and `*ModJulian` epoch columns promoted to `datetime64[ns]`.
 
 ## Documentation
 

--- a/src/gmat_run/mission.py
+++ b/src/gmat_run/mission.py
@@ -196,9 +196,7 @@ class Mission:
         # has been parsed: the resolved absolute path is cached on each
         # subscriber, and overriding the Filename field is the only setting
         # the engine consults at write time.
-        report_paths, ephemeris_paths, contact_paths = self._rewrite_output_paths(
-            workspace_path
-        )
+        report_paths, ephemeris_paths, contact_paths = self._rewrite_output_paths(workspace_path)
         self._gmat.UseLogFile(str(log_path))
 
         api_exception = _get_api_exception(self._gmat)
@@ -352,8 +350,10 @@ class Mission:
             return [float(x) for x in obj.GetVector(field)]
         if kind == "rmatrix":
             matrix = obj.GetMatrix(field)
-            return [[float(matrix.GetElement(i, j)) for j in range(matrix.GetNumColumns())]
-                    for i in range(matrix.GetNumRows())]
+            return [
+                [float(matrix.GetElement(i, j)) for j in range(matrix.GetNumColumns())]
+                for i in range(matrix.GetNumRows())
+            ]
         # STRING_TYPE, FILENAME_TYPE, OBJECT_TYPE, ENUMERATION_TYPE, and
         # anything we did not classify — fall back to the string form.
         return str(obj.GetField(field))
@@ -387,10 +387,14 @@ class Mission:
                 raise self._type_mismatch(dotted, value, "a list of numbers")
             return [float(x) for x in value]
         if kind == "rmatrix":
-            if not isinstance(value, (list, tuple)) or not value or any(
-                not isinstance(row, (list, tuple))
-                or any(isinstance(x, bool) or not isinstance(x, (int, float)) for x in row)
-                for row in value
+            if (
+                not isinstance(value, (list, tuple))
+                or not value
+                or any(
+                    not isinstance(row, (list, tuple))
+                    or any(isinstance(x, bool) or not isinstance(x, (int, float)) for x in row)
+                    for row in value
+                )
             ):
                 raise self._type_mismatch(dotted, value, "a list of lists of numbers")
             return [[float(x) for x in row] for row in value]

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -83,9 +83,7 @@ def test_gmat_root_argument_accepts_string(tmp_path: Path) -> None:
     assert result.root == root
 
 
-def test_gmat_root_argument_expands_user(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_gmat_root_argument_expands_user(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     root = _make_install(tmp_path / "gmat-R2026a")
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("USERPROFILE", str(tmp_path))
@@ -196,9 +194,7 @@ def test_glob_patterns_per_platform(platform: str, expected_pattern_substr: str)
 # --- PATH ---------------------------------------------------------------------
 
 
-def test_path_discovery_via_gmat_console(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_path_discovery_via_gmat_console(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     root = _make_install(tmp_path / "gmat-R2026a")
     binary = root / "bin" / "GmatConsole"
     binary.touch()
@@ -210,9 +206,7 @@ def test_path_discovery_via_gmat_console(
     assert locate_gmat().root == root
 
 
-def test_path_discovery_skips_invalid_root(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_path_discovery_skips_invalid_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     # Binary on PATH but its parent.parent is not a real install.
     bogus_bin = tmp_path / "elsewhere" / "bin"
     bogus_bin.mkdir(parents=True)

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -198,9 +198,7 @@ def _make_fake_gmat(
 
     class _FakeModerator:
         def GetListOfObjects(self, type_id: int) -> list[str]:
-            kind = next(
-                (k for k, v in _OBJECT_TYPE_IDS.items() if v == type_id), None
-            )
+            kind = next((k for k, v in _OBJECT_TYPE_IDS.items() if v == type_id), None)
             if kind is None:
                 return []
             return [
@@ -253,38 +251,38 @@ def _make_install(root: Path) -> GmatInstall:
 def _spacecraft(name: str = "Sat") -> _FakeObject:
     """Spacecraft with a representative slice of fields per type code."""
     fields: dict[str, tuple[int, Any, bool]] = {
-        "SMA":              (_TYPE_CODES["REAL_TYPE"],         7000.0,                False),
-        "DryMass":          (_TYPE_CODES["REAL_TYPE"],         50.0,                  False),
-        "OrbitColor":       (_TYPE_CODES["INTEGER_TYPE"],      255,                   False),
-        "DisplayStateType": (_TYPE_CODES["ENUMERATION_TYPE"],  "Keplerian",           False),
-        "DateFormat":       (_TYPE_CODES["STRING_TYPE"],       "UTCGregorian",        False),
-        "CoordinateSystem": (_TYPE_CODES["OBJECT_TYPE"],       "EarthMJ2000Eq",       False),
-        "Tanks":            (_TYPE_CODES["STRINGARRAY_TYPE"],  ["MainTank"],          False),
-        "CartesianX":       (_TYPE_CODES["REAL_TYPE"],         -999.999,              True),
-        "Covariance":       (_TYPE_CODES["RMATRIX_TYPE"],      [[1.0, 0.0], [0.0, 2.0]], False),
-        "EulerAngles":      (_TYPE_CODES["RVECTOR_TYPE"],      [10.0, 20.0, 30.0],    False),
+        "SMA": (_TYPE_CODES["REAL_TYPE"], 7000.0, False),
+        "DryMass": (_TYPE_CODES["REAL_TYPE"], 50.0, False),
+        "OrbitColor": (_TYPE_CODES["INTEGER_TYPE"], 255, False),
+        "DisplayStateType": (_TYPE_CODES["ENUMERATION_TYPE"], "Keplerian", False),
+        "DateFormat": (_TYPE_CODES["STRING_TYPE"], "UTCGregorian", False),
+        "CoordinateSystem": (_TYPE_CODES["OBJECT_TYPE"], "EarthMJ2000Eq", False),
+        "Tanks": (_TYPE_CODES["STRINGARRAY_TYPE"], ["MainTank"], False),
+        "CartesianX": (_TYPE_CODES["REAL_TYPE"], -999.999, True),
+        "Covariance": (_TYPE_CODES["RMATRIX_TYPE"], [[1.0, 0.0], [0.0, 2.0]], False),
+        "EulerAngles": (_TYPE_CODES["RVECTOR_TYPE"], [10.0, 20.0, 30.0], False),
     }
     return _FakeObject("Spacecraft", name, fields)
 
 
 def _propagator(name: str = "DefaultProp") -> _FakeObject:
     fields: dict[str, tuple[int, Any, bool]] = {
-        "InitialStepSize": (_TYPE_CODES["REAL_TYPE"],     60.0,            False),
-        "Accuracy":        (_TYPE_CODES["REAL_TYPE"],     1e-12,           False),
-        "Type":            (_TYPE_CODES["STRING_TYPE"],   "PrinceDormand78", False),
-        "StopIfAccuracyIsViolated": (_TYPE_CODES["BOOLEAN_TYPE"], True,    False),
+        "InitialStepSize": (_TYPE_CODES["REAL_TYPE"], 60.0, False),
+        "Accuracy": (_TYPE_CODES["REAL_TYPE"], 1e-12, False),
+        "Type": (_TYPE_CODES["STRING_TYPE"], "PrinceDormand78", False),
+        "StopIfAccuracyIsViolated": (_TYPE_CODES["BOOLEAN_TYPE"], True, False),
     }
     return _FakeObject("Propagator", name, fields)
 
 
 def _impulsive_burn(name: str = "TOI") -> _FakeObject:
     fields: dict[str, tuple[int, Any, bool]] = {
-        "Element1":         (_TYPE_CODES["REAL_TYPE"],         0.0,             False),
-        "Element2":         (_TYPE_CODES["REAL_TYPE"],         0.0,             False),
-        "Element3":         (_TYPE_CODES["REAL_TYPE"],         0.0,             False),
-        "CoordinateSystem": (_TYPE_CODES["OBJECT_TYPE"],       "EarthMJ2000Eq", False),
-        "Axes":             (_TYPE_CODES["ENUMERATION_TYPE"],  "VNB",           False),
-        "DecrementMass":    (_TYPE_CODES["BOOLEAN_TYPE"],      False,           False),
+        "Element1": (_TYPE_CODES["REAL_TYPE"], 0.0, False),
+        "Element2": (_TYPE_CODES["REAL_TYPE"], 0.0, False),
+        "Element3": (_TYPE_CODES["REAL_TYPE"], 0.0, False),
+        "CoordinateSystem": (_TYPE_CODES["OBJECT_TYPE"], "EarthMJ2000Eq", False),
+        "Axes": (_TYPE_CODES["ENUMERATION_TYPE"], "VNB", False),
+        "DecrementMass": (_TYPE_CODES["BOOLEAN_TYPE"], False, False),
     }
     return _FakeObject("ImpulsiveBurn", name, fields)
 
@@ -756,9 +754,7 @@ class TestMissionRun:
         assert custom.is_dir()
         assert result.output_dir == custom
 
-    def test_run_default_workspace_is_temp_dir_tied_to_results(
-        self, tmp_path: Path
-    ) -> None:
+    def test_run_default_workspace_is_temp_dir_tied_to_results(self, tmp_path: Path) -> None:
         mission, _ = _run_mission(tmp_path)
         result = mission.run()
         # The workspace is a TemporaryDirectory parked on Results so lazy
@@ -859,9 +855,7 @@ class TestMissionRun:
         assert report_path.is_absolute()
         assert report_path.parent == result.output_dir
 
-    def test_run_default_temp_dir_cleaned_up_when_results_dropped(
-        self, tmp_path: Path
-    ) -> None:
+    def test_run_default_temp_dir_cleaned_up_when_results_dropped(self, tmp_path: Path) -> None:
         # The TemporaryDirectory parked on Results runs its finaliser when GC
         # collects the instance, so the workspace disappears with the result.
         mission, _ = _run_mission(tmp_path / "gmat")
@@ -874,9 +868,7 @@ class TestMissionRun:
 
         assert not workspace.is_dir()
 
-    def test_run_explicit_working_dir_survives_results_drop(
-        self, tmp_path: Path
-    ) -> None:
+    def test_run_explicit_working_dir_survives_results_drop(self, tmp_path: Path) -> None:
         # The opt-in path: when the caller pinned working_dir, the directory
         # is theirs and gmat-run leaves it alone on Results cleanup.
         custom = tmp_path / "user-output"

--- a/tests/test_parsers_reportfile.py
+++ b/tests/test_parsers_reportfile.py
@@ -25,8 +25,7 @@ def _write(path: Path, content: str, encoding: str = "utf-8", newline: str = "\n
 # A three-column happy-path sample mirroring GMAT's R2026a layout: Gregorian
 # epoch, a float field, a scientific-notation field, and an integer mass.
 _HEADER = (
-    "Sat.UTCGregorian          Sat.Earth.SMA             "
-    "Sat.Earth.ECC             Sat.TotalMass"
+    "Sat.UTCGregorian          Sat.Earth.SMA             Sat.Earth.ECC             Sat.TotalMass"
 )
 _ROW_1 = "26 Nov 2026 12:00:00.000  6578.136299999994         9.999999999964634e-05     1300000"
 _ROW_2 = "26 Nov 2026 12:01:00.000  6578.137326507367         0.0001451202385349637     1300000"
@@ -103,12 +102,8 @@ def test_utf8_bom_is_stripped(tmp_path: Path) -> None:
     assert next(iter(df.columns)) == "Sat.UTCGregorian"
 
 
-@pytest.mark.parametrize(
-    ("newline", "label"), [("\n", "lf"), ("\r\n", "crlf")], ids=["lf", "crlf"]
-)
-def test_line_endings_produce_identical_frame(
-    tmp_path: Path, newline: str, label: str
-) -> None:
+@pytest.mark.parametrize(("newline", "label"), [("\n", "lf"), ("\r\n", "crlf")], ids=["lf", "crlf"])
+def test_line_endings_produce_identical_frame(tmp_path: Path, newline: str, label: str) -> None:
     path = _write(tmp_path / f"{label}.report", _BASIC, newline=newline)
     df = parse(path)
     reference = parse(_write(tmp_path / "reference.report", _BASIC, newline="\n"))

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -363,9 +363,7 @@ class TestPersist:
         assert workspace.is_dir()
         assert (workspace / "r1.txt").exists()
 
-    def test_absolute_paths_outside_workspace_are_not_migrated(
-        self, tmp_path: Path
-    ) -> None:
+    def test_absolute_paths_outside_workspace_are_not_migrated(self, tmp_path: Path) -> None:
         # A ReportFile.Filename like "/abs/elsewhere/report.txt" lands outside
         # the workspace and was not rewritten by Mission.run. persist must
         # leave that path intact rather than silently relocating it.

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -59,9 +59,7 @@ def _write_fake_gmatpy(install: GmatInstall, *, import_error: str | None = None)
         init.write_text(f"raise ImportError({import_error!r})\n", encoding="utf-8")
     else:
         init.write_text(
-            "SETUP_CALLS = []\n"
-            "def Setup(path):\n"
-            "    SETUP_CALLS.append(path)\n",
+            "SETUP_CALLS = []\ndef Setup(path):\n    SETUP_CALLS.append(path)\n",
             encoding="utf-8",
         )
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,4 +1,5 @@
 """Smoke tests — the package imports and exposes its version."""
+
 import gmat_run
 
 


### PR DESCRIPTION
## Summary

- Apply `ruff format` to seven files that had drifted from the formatter
  (`src/gmat_run/mission.py` plus six test modules). Style only —
  no behaviour change. The drift was not caught because the `lint` job
  ran `ruff check` only.
- Add `uv run ruff format --check` as a step in the `lint` CI job so
  the formatter cannot drift again silently.
- README: split the load → override → run → DataFrame snippet out of
  `## What this is` into a labelled `## Quick start` section, and
  replace the one-line GMAT-version note with an explicit supported
  versions matrix (R2022a–R2026a, with R2026a as the only version
  currently exercised in CI). Closes the last v0.1 DoD gaps before
  #15.

## Test plan

- [x] `uv run ruff check` clean.
- [x] `uv run ruff format --check` clean.
- [x] `uv run mypy` clean.
- [x] `uv run pytest -q` — 222 passed, 3 deselected (integration tests
      run in CI against the cached GMAT install).
- [x] Coverage unchanged — parsers 100%, overall 94%.

Closes #32