### PR TITLE
Cut v0.1.0: bump version, drop pre-alpha, port version matrix to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 
 Run GMAT mission scripts from Python and get results as pandas DataFrames.
 
-> **Status:** pre-alpha. Scaffolding only — no public API yet.
-
 ## What this is
 
 A thin, Pythonic wrapper around NASA GMAT's own `gmatpy` runtime. You bring a working `.script`;

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,8 +3,21 @@
 ## Requirements
 
 - Python 3.10, 3.11, or 3.12.
-- A local GMAT install (R2022a or later; R2026a is the primary development target).
-  See [Install GMAT](install-gmat.md).
+- A local GMAT install. See [Install GMAT](install-gmat.md). gmat-run does not ship
+  GMAT binaries.
+
+### Supported GMAT versions
+
+| GMAT release | Status                       | CI                                            |
+| ------------ | ---------------------------- | --------------------------------------------- |
+| R2026a       | Primary development target   | Exercised on every PR (Ubuntu + Windows)      |
+| R2025a       | Expected to work             | Not exercised in CI for v0.1                  |
+| R2024a       | Expected to work             | Not exercised in CI for v0.1                  |
+| R2023a       | Expected to work             | Not exercised in CI for v0.1                  |
+| R2022a       | Expected to work             | Not exercised in CI for v0.1                  |
+
+A wider CI matrix is planned for a follow-up release; report any version-specific
+breakage as an issue and we'll add a CI cell for it.
 
 ## Install gmat-run
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,9 +2,6 @@
 
 Run GMAT mission scripts from Python and get results as pandas DataFrames.
 
-!!! warning "Pre-alpha"
-    The public API is not yet stable. Pin a specific version when depending on `gmat-run`.
-
 ## What this is
 
 A thin, Pythonic wrapper around NASA GMAT's own `gmatpy` runtime. You bring a working

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gmat-run"
-version = "0.0.0"
+version = "0.1.0"
 description = "Run GMAT mission scripts from Python and get results as pandas DataFrames."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -13,7 +13,7 @@ license-files = ["LICENSE"]
 authors = [{ name = "Dimitrije Jankovic" }]
 keywords = ["gmat", "astrodynamics", "orbital-mechanics", "mission-analysis", "space"]
 classifiers = [
-  "Development Status :: 2 - Pre-Alpha",
+  "Development Status :: 3 - Alpha",
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: MIT License",
   "Operating System :: POSIX :: Linux",

--- a/src/gmat_run/__init__.py
+++ b/src/gmat_run/__init__.py
@@ -13,7 +13,7 @@ from gmat_run.mission import Mission
 from gmat_run.results import Results
 from gmat_run.runtime import bootstrap
 
-__version__ = "0.0.0"
+__version__ = "0.1.0"
 
 __all__ = [
     "GmatError",

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -4,4 +4,4 @@ import gmat_run
 
 
 def test_import() -> None:
-    assert gmat_run.__version__ == "0.0.0"
+    assert gmat_run.__version__ == "0.1.0"

--- a/uv.lock
+++ b/uv.lock
@@ -405,7 +405,7 @@ wheels = [
 
 [[package]]
 name = "gmat-run"
-version = "0.0.0"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

- Bump `__version__` and `pyproject.toml` `version` from `0.0.0` to `0.1.0`,
  promote the `Development Status` classifier from `2 - Pre-Alpha` to
  `3 - Alpha`, and update the smoke test pin.
- Drop the "Status: pre-alpha" line from the README and the matching
  `!!! warning "Pre-alpha"` admonition from `docs/index.md`. The
  `3 - Alpha` classifier and the badge row carry the maturity signal.
- Port the supported-GMAT-versions matrix from the README into
  `docs/getting-started.md` so the docs site carries the same version
  context as the README, per the updated #15 acceptance criteria.

This is the source-side of v0.1.0. After merge, the release is cut by
pushing a `v0.1.0` tag, which fires `release.yml` (sdist + wheel build,
PyPI trusted publishing, GitHub Release with auto-generated notes) and
`docs.yml` (rebuild + deploy to Pages under the tag). PyPI trusted
publisher binding is already configured.

## Test plan

- [x] `uv run ruff check` clean.
- [x] `uv run ruff format --check` clean.
- [x] `uv run mypy --strict` clean (23 source files).
- [x] `uv run pytest -q` — 222 passed, 3 deselected (integration in CI).
- [x] `uv build` produces `gmat_run-0.1.0.tar.gz` + `gmat_run-0.1.0-py3-none-any.whl`.

Closes #15