### PR TITLE
Cut v0.1.1: fix stale install instructions in README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,8 @@ an issue and we'll add a CI cell for it.
 
 ## Installation
 
-Not yet on PyPI. To work on gmat-run itself:
-
 ```bash
-git clone https://github.com/astro-tools/gmat-run.git
-cd gmat-run
-uv sync --all-groups
+pip install gmat-run
 ```
 
 ## Quick start
@@ -77,6 +73,18 @@ Full docs at **<https://astro-tools.github.io/gmat-run/>**, including a
 [getting-started guide](https://astro-tools.github.io/gmat-run/getting-started/),
 [GMAT install instructions](https://astro-tools.github.io/gmat-run/install-gmat/),
 and the [API reference](https://astro-tools.github.io/gmat-run/reference/).
+
+## Development
+
+To work on gmat-run itself:
+
+```bash
+git clone https://github.com/astro-tools/gmat-run.git
+cd gmat-run
+uv sync --all-groups
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full branch / PR / test workflow.
 
 ## Licence
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,16 +21,8 @@ breakage as an issue and we'll add a CI cell for it.
 
 ## Install gmat-run
 
-Once v0.1.0 ships:
-
 ```bash
 pip install gmat-run
-```
-
-Until then, install from the repository:
-
-```bash
-pip install git+https://github.com/astro-tools/gmat-run.git
 ```
 
 ## Quick start

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gmat-run"
-version = "0.1.0"
+version = "0.1.1"
 description = "Run GMAT mission scripts from Python and get results as pandas DataFrames."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/gmat_run/__init__.py
+++ b/src/gmat_run/__init__.py
@@ -13,7 +13,7 @@ from gmat_run.mission import Mission
 from gmat_run.results import Results
 from gmat_run.runtime import bootstrap
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 
 __all__ = [
     "GmatError",

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -4,4 +4,4 @@ import gmat_run
 
 
 def test_import() -> None:
-    assert gmat_run.__version__ == "0.1.0"
+    assert gmat_run.__version__ == "0.1.1"

--- a/uv.lock
+++ b/uv.lock
@@ -405,7 +405,7 @@ wheels = [
 
 [[package]]
 name = "gmat-run"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

The v0.1.0 README shipped with *"Not yet on PyPI. To work on gmat-run
itself: …"* — true when the README was written, false the moment the
v0.1.0 tag triggered the PyPI publish. The project page at
https://pypi.org/project/gmat-run/ now tells first-time visitors the
package isn't published yet. Description-only patch release fixes
that.

- README `## Installation` section now reads `pip install gmat-run`.
  The contributor-side `git clone` + `uv sync` instructions move to a
  new `## Development` section that defers to `CONTRIBUTING.md` for
  the full PR/test workflow.
- `docs/getting-started.md` `## Install gmat-run` section drops the
  "Once v0.1.0 ships" / "Until then, install from the repository"
  conditional and shows the simple `pip install gmat-run` command.
- Version bump: `__version__`, `pyproject.toml`, smoke test pin, and
  `uv.lock` all `0.1.0 → 0.1.1`.

Source code in `src/gmat_run/` is unchanged. After merge, push the
`v0.1.1` tag to fire `release.yml` and `docs.yml` so PyPI and Pages
pick up the corrected text.

## Test plan

- [x] `uv run ruff check` clean.
- [x] `uv run ruff format --check` clean.
- [x] `uv run mypy --strict` clean (23 source files).
- [x] `uv run pytest -q` — 222 passed, 3 deselected.
- [x] `uv build` produces `gmat_run-0.1.1.tar.gz` + `gmat_run-0.1.1-py3-none-any.whl`.

Closes #35