### PR TITLE
Add example notebook: parameter sweep across Sat.SMA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,7 @@ jobs:
         run: |
           uv sync --all-groups --extra examples
           uv run jupyter execute docs/examples/01_load_run_plot.ipynb
+          uv run jupyter execute docs/examples/02_parameter_sweep.ipynb
 
   lint:
     name: lint

--- a/docs/examples/02_parameter_sweep.ipynb
+++ b/docs/examples/02_parameter_sweep.ipynb
@@ -1,0 +1,489 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "683c4ada",
+   "metadata": {},
+   "source": [
+    "# Sweep a parameter and tabulate\n",
+    "\n",
+    "This notebook layers the *override + multi-run* pattern on top of the load → run → DataFrame loop from [notebook 1](01_load_run_plot.ipynb):\n",
+    "\n",
+    "1. Load a small mission script once per run.\n",
+    "2. Override `Sat.SMA` from Python before each run.\n",
+    "3. Collect a scalar of interest (terminal altitude) into a tidy DataFrame.\n",
+    "4. Plot the trend with matplotlib.\n",
+    "\n",
+    "We drive a minimal LEO mission script that ships next to this notebook (`leo_keplerian.script` — Keplerian initial state, point-mass Earth, 1 hour of propagation, single `ReportFile` writing position). Sweeping **`Sat.SMA`** scales the orbit; the plot below should walk linearly with the input grid.\n",
+    "\n",
+    "**Prerequisites.** A local GMAT install (R2026a is the primary development target) and `pip install gmat-run[examples]` for the matplotlib dependency."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f960ae92",
+   "metadata": {},
+   "source": [
+    "## Set up the run\n",
+    "\n",
+    "Resolve the GMAT install once and confirm the script is where we expect it. The script lives next to this notebook so the path is machine-independent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "26afc46b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-26T17:20:51.348426Z",
+     "iopub.status.busy": "2026-04-26T17:20:51.348262Z",
+     "iopub.status.idle": "2026-04-26T17:20:54.962430Z",
+     "shell.execute_reply": "2026-04-26T17:20:54.961332Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GMAT version: R2026a\n",
+      "Script:       leo_keplerian.script\n",
+      "Exists:       True\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "from gmat_run import Mission, locate_gmat\n",
+    "\n",
+    "install = locate_gmat()\n",
+    "script_path = Path(\"leo_keplerian.script\").resolve()\n",
+    "\n",
+    "print(f\"GMAT version: {install.version}\")\n",
+    "print(f\"Script:       {script_path.name}\")\n",
+    "print(f\"Exists:       {script_path.exists()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6987d9a",
+   "metadata": {},
+   "source": [
+    "## Define the sweep grid\n",
+    "\n",
+    "Eight semi-major-axis values from 7000 km (~622 km altitude) up to 8400 km (~2022 km altitude). The exact grid is incidental — the point is that *every* one of these runs reuses the same script with a single field overridden from Python."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "712aaf64",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-26T17:20:54.964064Z",
+     "iopub.status.busy": "2026-04-26T17:20:54.963830Z",
+     "iopub.status.idle": "2026-04-26T17:20:54.970331Z",
+     "shell.execute_reply": "2026-04-26T17:20:54.969326Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([7000., 7200., 7400., 7600., 7800., 8000., 8200., 8400.])"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sma_values = np.linspace(7000.0, 8400.0, 8)\n",
+    "sma_values"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0a2be8e4",
+   "metadata": {},
+   "source": [
+    "## Run the sweep\n",
+    "\n",
+    "One `Mission.load` per run keeps each iteration independent — the spacecraft state is freshly parsed from the script before the override, so a write in one run can't leak into the next. The override goes through dotted-path subscript access, the same way the [Getting started guide](https://astro-tools.github.io/gmat-run/getting-started/) writes individual fields.\n",
+    "\n",
+    "After each run we lazy-parse the `ReportFile` to a DataFrame, derive altitude from $\\sqrt{X^2 + Y^2 + Z^2} - R_\\oplus$, and grab the last row's altitude as the per-run scalar of interest."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "8db52fdd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-26T17:20:54.971767Z",
+     "iopub.status.busy": "2026-04-26T17:20:54.971609Z",
+     "iopub.status.idle": "2026-04-26T17:20:57.240825Z",
+     "shell.execute_reply": "2026-04-26T17:20:57.239723Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>SMA_km</th>\n",
+       "      <th>TerminalAltitude_km</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>7000.0</td>\n",
+       "      <td>627.039064</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>7200.0</td>\n",
+       "      <td>827.892956</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>7400.0</td>\n",
+       "      <td>1028.594123</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>7600.0</td>\n",
+       "      <td>1229.148749</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>7800.0</td>\n",
+       "      <td>1429.566322</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>8000.0</td>\n",
+       "      <td>1629.858161</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>8200.0</td>\n",
+       "      <td>1830.036378</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>8400.0</td>\n",
+       "      <td>2030.113166</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   SMA_km  TerminalAltitude_km\n",
+       "0  7000.0           627.039064\n",
+       "1  7200.0           827.892956\n",
+       "2  7400.0          1028.594123\n",
+       "3  7600.0          1229.148749\n",
+       "4  7800.0          1429.566322\n",
+       "5  8000.0          1629.858161\n",
+       "6  8200.0          1830.036378\n",
+       "7  8400.0          2030.113166"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "EARTH_RADIUS_KM = 6378.137  # WGS-84 equatorial radius\n",
+    "\n",
+    "summary_rows = []\n",
+    "per_run_frames = []\n",
+    "for sma in sma_values:\n",
+    "    mission = Mission.load(script_path)\n",
+    "    mission[\"Sat.SMA\"] = float(sma)\n",
+    "    result = mission.run()\n",
+    "\n",
+    "    df = result.reports[\"RF\"].copy()\n",
+    "    position = df[[\"Sat.X\", \"Sat.Y\", \"Sat.Z\"]]\n",
+    "    df[\"Altitude_km\"] = (position**2).sum(axis=1) ** 0.5 - EARTH_RADIUS_KM\n",
+    "    df[\"SMA_km\"] = float(sma)\n",
+    "    per_run_frames.append(df)\n",
+    "\n",
+    "    summary_rows.append(\n",
+    "        {\n",
+    "            \"SMA_km\": float(sma),\n",
+    "            \"TerminalAltitude_km\": float(df[\"Altitude_km\"].iloc[-1]),\n",
+    "        }\n",
+    "    )\n",
+    "\n",
+    "summary = pd.DataFrame(summary_rows)\n",
+    "combined = pd.concat(per_run_frames, ignore_index=True)\n",
+    "summary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fbfa9aad",
+   "metadata": {},
+   "source": [
+    "`combined` is the long-form DataFrame with one row per (run × timestep) — useful for overlay plots and group-by analyses. The `SMA_km` column is the run-id."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "ff657373",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-26T17:20:57.242368Z",
+     "iopub.status.busy": "2026-04-26T17:20:57.242177Z",
+     "iopub.status.idle": "2026-04-26T17:20:57.250837Z",
+     "shell.execute_reply": "2026-04-26T17:20:57.249839Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Sat.UTCGregorian</th>\n",
+       "      <th>Sat.X</th>\n",
+       "      <th>Sat.Y</th>\n",
+       "      <th>Sat.Z</th>\n",
+       "      <th>Altitude_km</th>\n",
+       "      <th>SMA_km</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2026-01-01 12:00:00.000</td>\n",
+       "      <td>-5936.162915</td>\n",
+       "      <td>1590.590059</td>\n",
+       "      <td>3336.771210</td>\n",
+       "      <td>614.863000</td>\n",
+       "      <td>7000.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2026-01-01 12:01:00.000</td>\n",
+       "      <td>-6040.931768</td>\n",
+       "      <td>1149.786937</td>\n",
+       "      <td>3329.772890</td>\n",
+       "      <td>614.877667</td>\n",
+       "      <td>7000.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2026-01-01 12:04:39.743</td>\n",
+       "      <td>-6206.113475</td>\n",
+       "      <td>-491.581464</td>\n",
+       "      <td>3185.746222</td>\n",
+       "      <td>615.179509</td>\n",
+       "      <td>7000.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2026-01-01 12:08:32.899</td>\n",
+       "      <td>-6001.419050</td>\n",
+       "      <td>-2201.001458</td>\n",
+       "      <td>2838.173086</td>\n",
+       "      <td>615.907931</td>\n",
+       "      <td>7000.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2026-01-01 12:12:26.328</td>\n",
+       "      <td>-5417.739050</td>\n",
+       "      <td>-3773.474882</td>\n",
+       "      <td>2311.083824</td>\n",
+       "      <td>617.012573</td>\n",
+       "      <td>7000.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         Sat.UTCGregorian        Sat.X        Sat.Y        Sat.Z  Altitude_km  \\\n",
+       "0 2026-01-01 12:00:00.000 -5936.162915  1590.590059  3336.771210   614.863000   \n",
+       "1 2026-01-01 12:01:00.000 -6040.931768  1149.786937  3329.772890   614.877667   \n",
+       "2 2026-01-01 12:04:39.743 -6206.113475  -491.581464  3185.746222   615.179509   \n",
+       "3 2026-01-01 12:08:32.899 -6001.419050 -2201.001458  2838.173086   615.907931   \n",
+       "4 2026-01-01 12:12:26.328 -5417.739050 -3773.474882  2311.083824   617.012573   \n",
+       "\n",
+       "   SMA_km  \n",
+       "0  7000.0  \n",
+       "1  7000.0  \n",
+       "2  7000.0  \n",
+       "3  7000.0  \n",
+       "4  7000.0  "
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "combined.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e315c3c4",
+   "metadata": {},
+   "source": [
+    "## Plot the trend\n",
+    "\n",
+    "Two views of the same sweep:\n",
+    "\n",
+    "- **Left:** terminal altitude vs commanded SMA — the headline scalar.\n",
+    "- **Right:** altitude trace per run, overlaid — context for the   variation along each orbit. The wave shape is the eccentricity   showing through (`Sat.ECC = 0.001` in the script); the vertical   separation is the SMA sweep."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "0bf085ba",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-26T17:20:57.252277Z",
+     "iopub.status.busy": "2026-04-26T17:20:57.252115Z",
+     "iopub.status.idle": "2026-04-26T17:20:57.781044Z",
+     "shell.execute_reply": "2026-04-26T17:20:57.780082Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABEIAAAGGCAYAAAB/gyR8AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAA2iFJREFUeJzs3XlcFPX/B/DX7HIKcsohKoKaB96pqWneivetaZp4VqaZWV5lXqXkkWb1NTtQyzSvtJ9pkeZdmqJ5ayUK4gGCct+wM78/lh122QXX5VhgX8/v18fufD6fmf28F2Lm857PzAiSJEkgIiIiIiIiIrIACnN3gIiIiIiIiIiorDARQkREREREREQWg4kQIiIiIiIiIrIYTIQQERERERERkcVgIoSIiIiIiIiILAYTIURERERERERkMZgIISIiIiIiIiKLwUQIEREREREREVkMJkKIiIiIiIiIyGIwEUJERERElZIgCFi8eLFRbf38/DB+/PhS7Y/G5s2bIQgCIiMjy+TziIhIFxMhRKXgypUrGD58OGrXrg07OzvUqFEDPXv2xGeffWburhEREVUK69evhyAIaNu2rdHrnDp1CosXL0ZiYuIT216/fh2LFy+uEMmKitRXIqLygIkQohJ26tQptG7dGpcuXcKUKVPw+eefY/LkyVAoFFi3bp25u0dERFQpbN26FX5+fjh79izCw8ONWufUqVNYsmSJwUTIv//+i6+//lpevn79OpYsWVIhkgsVqa9EROWBlbk7QFTZLFu2DM7OzggLC4OLi4tOXWxsrHk6RWUiMzMTNjY2UCiYYyYiKk0RERE4deoU9uzZg1dffRVbt27FokWLirVNW1vbEupd+SZJEjIzM2Fvb2/urpS5tLQ0ODg4lFp7Iqo4eLROVMJu3bqFxo0b6yVBAMDT01N+P3ToUDz77LM69QMGDIAgCNi3b59cdubMGQiCgF9//VUuS0xMxMyZM1GrVi3Y2tqiXr16WLFiBURR1NmeKIr45JNP0LhxY9jZ2cHLywuvvvoqEhISdNr5+fmhf//+OHjwIFq0aAE7OzsEBARgz549RsW8fft2tGrVClWrVoWTkxOaNm2qM/tl8eLFEARBbz1D10hr+nLs2DG0bt0a9vb2aNq0KY4dOwYA2LNnD5o2bQo7Ozu0atUKFy5c0Nnm+PHj4ejoiKioKPTv3x+Ojo6oUaMG/ve//wFQX7bUrVs3ODg4oHbt2ti2bZvO+vHx8XjnnXfQtGlTODo6wsnJCX369MGlS5d02h07dgyCIGD79u1YsGABatSogSpVquDixYsQBAFr167Vi/fUqVMQBAE//PCDUd8rEREZtnXrVri6uqJfv34YPnw4tm7d+sR1Fi9ejNmzZwMA/P39IQiCzj5I+x4hmzdvxogRIwAAXbt2ldtq9kWF3XvE0H1Grl27hm7dusHe3h41a9bEhx9+qLe/1vj111/xwgsvwMHBAVWrVkW/fv1w7dq1IuN6Ul81+9XffvtN3q9++eWXAIBNmzahW7du8PT0hK2tLQICAvDFF18U2rfOnTvL+/o2bdro7UPPnDmD3r17w9nZGVWqVEHnzp3x559/Ftl/IH+fumPHDrz77rvw9vaGg4MDBg4ciLt37+q1N+ZzNMce169fx0svvQRXV1d07NixyO9REAQcP34cr7/+Ojw9PVGzZk0A6mMLPz8/vXUMHd8IgoDp06fjp59+QpMmTWBra4vGjRsjNDT0id8DEZUdJkKISljt2rVx/vx5XL16tch2L7zwAi5duoTk5GQA6jM0f/75JxQKBU6ePCm3O3nyJBQKBTp06AAASE9PR+fOnfH9999j3Lhx+PTTT9GhQwfMnz8fs2bN0vmMV199FbNnz0aHDh2wbt06TJgwAVu3bkVgYCBycnJ02t68eRMvvvgi+vTpg+DgYFhZWWHEiBE4dOhQkXEcOnQIo0ePhqurK1asWIGPPvoIXbp0MerApzDh4eF46aWXMGDAAAQHByMhIQEDBgzA1q1b8dZbb2Hs2LFYsmQJbt26hZEjR+odUKpUKvTp0we1atXCypUr4efnh+nTp2Pz5s3o3bs3WrdujRUrVqBq1aoYN24cIiIi5HVv376Nn376Cf3798eaNWswe/ZsXLlyBZ07d8aDBw/0+vrBBx/gwIEDeOedd7B8+XI0bNgQHTp0MHhQvnXrVlStWhWDBg0y+bshIiL139OhQ4fCxsYGo0ePxs2bNxEWFlbkOkOHDsXo0aMBAGvXrsWWLVuwZcsWeHh46LXt1KkTZsyYAQB499135baNGjV6qn7GxMSga9euuHjxIubNm4eZM2fiu+++M3ip7JYtW9CvXz84OjpixYoVeP/993H9+nV07NixyEtejOnrv//+i9GjR6Nnz55Yt24dWrRoAQD44osvULt2bbz77rv4+OOPUatWLbz++uvyyQONzZs3o1+/foiPj8f8+fPx0UcfoUWLFjqD+yNHjqBTp05ITk7GokWLsHz5ciQmJqJbt244e/asUd/XsmXLcODAAcydOxczZszAoUOH0KNHD2RkZJj8OSNGjEB6ejqWL1+OKVOmPLEPr7/+Oq5fv46FCxdi3rx5RvW7oD/++AOvv/46Ro0ahZUrVyIzMxPDhg3D48ePTdoeEZUCiYhK1MGDByWlUikplUqpffv20pw5c6TffvtNys7O1mkXFhYmAZB++eUXSZIk6fLlyxIAacSIEVLbtm3ldgMHDpRatmwpL3/wwQeSg4OD9N9//+lsb968eZJSqZSioqIkSZKkkydPSgCkrVu36rQLDQ3VK69du7YEQPrxxx/lsqSkJKl69eo6n23Im2++KTk5OUm5ubmFtlm0aJFk6M/Npk2bJABSRESEXl9OnToll/32228SAMne3l66c+eOXP7ll19KAKSjR4/KZUFBQRIAafny5XJZQkKCZG9vLwmCIG3fvl0u/+effyQA0qJFi+SyzMxMSaVS6fQzIiJCsrW1lZYuXSqXHT16VAIg1alTR0pPT9dpr+nXjRs35LLs7GypWrVqUlBQUKHfExERPdm5c+ckANKhQ4ckSZIkURSlmjVrSm+++aZe24J/41etWqW339GoXbu2zt/oXbt26e1jCttuYduYOXOmBEA6c+aMXBYbGys5Ozvr9CMlJUVycXGRpkyZorO9mJgYydnZWa+8oKL6qtmvhoaG6tUV3H9JkiQFBgZKderUkZcTExOlqlWrSm3btpUyMjJ02oqiKL8+88wzUmBgoFym2b6/v7/Us2fPIvuv2afWqFFDSk5Olst37twpAZDWrVv31J+jOfYYPXp0kZ+toTkm6dixo94xTVBQkFS7dm29dQwd3wCQbGxspPDwcLns0qVLEgDps88+M6ovRFT6OCOEqIT17NkTp0+fxsCBA3Hp0iWsXLkSgYGBqFGjhs4lLy1btoSjoyNOnDgBQD3zo2bNmhg3bhz+/vtvpKenQ5Ik/PHHH3jhhRfk9Xbt2oUXXngBrq6uePTokfyvR48eUKlU8vZ27doFZ2dn9OzZU6ddq1at4OjoiKNHj+r028fHB0OGDJGXnZycMG7cOFy4cAExMTGFxuvi4oK0tLQnzhx5GgEBAWjfvr28rHkiQLdu3eDr66tXfvv2bb1tTJ48WaePDRo0gIODA0aOHCmXN2jQAC4uLjrr29rayvf4UKlUePz4MRwdHdGgQQP8/fffep8TFBSkd531yJEjYWdnpzMr5LfffsOjR48wduxY474EIiIyaOvWrfDy8kLXrl0BqC9FePHFF7F9+3aoVCoz907XL7/8gnbt2uG5556Tyzw8PDBmzBiddocOHUJiYiJGjx6ts89WKpVo27at3j77afn7+yMwMFCvXHv/lZSUhEePHqFz5864ffs2kpKS5L6lpKRg3rx5sLOz01lfc1nIxYsXcfPmTbz00kt4/Pix3P+0tDR0794dJ06cKPRyIG3jxo1D1apV5eXhw4ejevXq+OWXX0z+nNdee83Ib0ltypQpUCqVT7VOQT169EDdunXl5WbNmsHJycng8QoRmQdvlkpUCtq0aYM9e/YgOzsbly5dwt69e7F27VoMHz4cFy9eREBAAJRKJdq3by9fBnPy5Em88MIL6NixI1QqFf766y94eXkhPj5eJxFy8+ZNXL582eBUXiD/hqw3b95EUlKSzn1JDLXTqFevnt51rvXr1wcAREZGwtvb2+B2Xn/9dezcuRN9+vRBjRo10KtXL4wcORK9e/c24psyTDvZAQDOzs4AgFq1ahksL3jPEzs7O73vx9nZGTVr1tSL0dnZWWd9URSxbt06rF+/HhEREToH1e7u7np99ff31ytzcXHBgAEDsG3bNnzwwQcA1AfuNWrUQLdu3QwHTURET6RSqbB9+3Z07dpV57LGtm3b4uOPP8bhw4fRq1cvM/ZQ1507dww+3rdBgwY6yzdv3gSAQvcRTk5OxeqHoX0VAPz5559YtGgRTp8+jfT0dJ26pKQkODs749atWwCAJk2aFLp9Tf+DgoIKbZOUlARXV9ci+/nMM8/oLAuCgHr16smXBpnyOYXFXpinbW9IweMYAHB1ddU7XiEi82EihKgU2djYoE2bNmjTpg3q16+PCRMmYNeuXfKd7Tt27Ihly5YhMzMTJ0+exHvvvQcXFxc0adIEJ0+ehJeXFwDoJEJEUUTPnj0xZ84cg5+pSV6IoghPT89CbyBXWCLlaXl6euLixYv47bff8Ouvv+LXX3/Fpk2bMG7cOHz77bcAYPBGqQAKPXNX2JmYwsolSSqx9ZcvX473338fEydOxAcffAA3NzcoFArMnDnT4Nmswu66P27cOOzatQunTp1C06ZNsW/fPrz++ut8ogwRUTEcOXIE0dHR2L59O7Zv365Xv3XrVrMmQkydkaLZv2zZssXgiQcrq+IdshvaV926dQvdu3dHw4YNsWbNGtSqVQs2Njb45ZdfsHbtWqNmcGho2q5atUq+/0hBjo6OJvW9uJ/ztE/HMdS+pI5jCh6vEJH5MBFCVEZat24NAIiOjpbLXnjhBWRnZ+OHH37A/fv35YRHp06d5ERI/fr15YQIANStWxepqano0aNHkZ9Xt25d/P777+jQoYNRBwHh4eGQJElnZ//ff/8BgME7pWuzsbHBgAEDMGDAAIiiiNdffx1ffvkl3n//fdSrV08+M5OYmKjzNJ07d+48sV9lbffu3ejatStCQkJ0yhMTE1GtWjWjt9O7d294eHhg69ataNu2LdLT0/Hyyy+XdHeJiCzK1q1b4enpqXczT0D9VLG9e/diw4YNhe73ChvQPm1bV1dXJCYm6pRlZ2fr7OMB9Q3UNbMYtP377786y5rLKDw9PZ+4f3/avhbm559/RlZWFvbt26czg6HgZTiavl29ehX16tUzuC1NGycnJ5P6r1Hwu5IkCeHh4WjWrFmJfs7TMvTzBsrncQwRGYenJolK2NGjRw1m/DXXt2pPh23bti2sra2xYsUKuLm5oXHjxgDUCZK//voLx48f15kNAqjvP3H69Gn89ttvep+RmJiI3NxcuZ1KpZIvzdCWm5urt0N/8OAB9u7dKy8nJyfju+++Q4sWLQq9LAaA3h3QFQqFfMCSlZUFIP/ARXP/EgBIS0uTZ4yUJ0qlUu/nt2vXLty/f/+ptmNlZYXRo0dj586d2Lx5M5o2bSp/L0RE9PQyMjKwZ88e9O/fH8OHD9f7N336dKSkpOjcj6sgBwcHADA4qH2atnXr1tXZpwHAV199pTdDoG/fvvjrr790nmYSFxenN1szMDAQTk5OWL58ud5T3TTrmNrXwmhmLWjv85KSkrBp0yaddr169ULVqlURHByMzMxMnTrNuq1atULdunWxevVqpKamPnX/Nb777jukpKTIy7t370Z0dDT69OlTop/ztOrWrYukpCRcvnxZLouOjtY5biKiioUzQohK2BtvvIH09HQMGTIEDRs2RHZ2Nk6dOoUdO3bAz88PEyZMkNtWqVIFrVq1wl9//YUBAwbIZ3Q6deqEtLQ0pKWl6SVCZs+ejX379qF///4YP348WrVqhbS0NFy5cgW7d+9GZGQkqlWrhs6dO+PVV19FcHAwLl68iF69esHa2ho3b97Erl27sG7dOgwfPlzebv369TFp0iSEhYXBy8sLGzduxMOHD/UOiAqaPHky4uPj0a1bN9SsWRN37tzBZ599hhYtWsiP7uvVqxd8fX0xadIkzJ49G0qlEhs3boSHhweioqJK6qsvEf3798fSpUsxYcIEPP/887hy5Qq2bt2KOnXqPPW2NI83Pnr0KFasWFEKvSUishz79u1DSkoKBg4caLC+Xbt28ky8F1980WCbVq1aAQDee+89jBo1CtbW1hgwYICcSNDWokULKJVKrFixAklJSbC1tUW3bt3g6emJyZMn47XXXsOwYcPQs2dPXLp0Cb/99pvezME5c+Zgy5Yt6N27N9588004ODjgq6++Qu3atXUG1U5OTvjiiy/w8ssv49lnn8WoUaPkfeSBAwfQoUMHfP7554V+N0X1tTC9evWSZ3S++uqrSE1Nxddffw1PT0+dmS1OTk5Yu3YtJk+ejDZt2uCll16Cq6srLl26hPT0dHz77bdQKBT45ptv0KdPHzRu3BgTJkxAjRo1cP/+fRw9ehROTk74+eefC+2LhpubGzp27IgJEybg4cOH+OSTT1CvXj35sbcl9TlPa9SoUZg7dy6GDBmCGTNmID09HV988QXq169v8EbqRFQBmOtxNUSV1a+//ipNnDhRatiwoeTo6CjZ2NhI9erVk9544w3p4cOHeu1nz54tAZBWrFihU16vXj0JgHTr1i29dVJSUqT58+dL9erVk2xsbKRq1apJzz//vLR69Wq9x/R+9dVXUqtWrSR7e3upatWqUtOmTaU5c+ZIDx48kNvUrl1b6tevn/Tbb79JzZo1k2xtbaWGDRtKu3btemK8u3fvlnr16iV5enpKNjY2kq+vr/Tqq69K0dHROu3Onz8vtW3bVm6zZs2aQh+f269fP73PASBNmzZNpywiIkICIK1atUouCwoKkhwcHPTW79y5s9S4cWO98oKfl5mZKb399ttS9erVJXt7e6lDhw7S6dOnpc6dO0udO3eW22ke9fek76hx48aSQqGQ7t27V2Q7IiIq2oABAyQ7OzspLS2t0Dbjx4+XrK2tpUePHkmSZPgxtx988IFUo0YNSaFQ6OyDCj76VpIk6euvv5bq1KkjKZVKncfTqlQqae7cuVK1atWkKlWqSIGBgVJ4eLjBbVy+fFnq3LmzZGdnJ9WoUUP64IMPpJCQEIOP8T169KgUGBgoOTs7S3Z2dlLdunWl8ePHS+fOnXvi91NYXwvbr0qSJO3bt09q1qyZZGdnJ/n5+UkrVqyQNm7caLBv+/btk55//nnJ3t5ecnJykp577jnphx9+0Glz4cIFaejQoZK7u7tka2sr1a5dWxo5cqR0+PDhIvuu2af+8MMP0vz58yVPT0/J3t5e6tevn3Tnzh299sZ8jubRtnFxcU/87iQp//G5YWFhBusPHjwoNWnSRLKxsZEaNGggff/994U+Prfg8YokGf79IiLzESSJd+0hsnR+fn5o0qQJ9u/fb+6uVDotW7aEm5sbDh8+bO6uEBERlUvHjh1D165dsWvXLp3ZqkREpYX3CCEiKiXnzp3DxYsXMW7cOHN3hYiIiIiI8vAeIUREJezq1as4f/48Pv74Y1SvXr3Qa9WJiIiIiKjscUYIEVEJ2717NyZMmICcnBz88MMPsLOzM3eXiIiIiIgoD+8RQkREREREREQWgzNCiIiIiIiIiMhiMBFCRERERERERBaDN0s1kiiKePDgAapWrQpBEMzdHSIiqsQkSUJKSgp8fHygUPCcxdPiPpuIiMoK99kVExMhRnrw4AFq1apl7m4QEZEFuXv3LmrWrGnublQ43GcTEVFZ4z67YmEixEhVq1YFoP4Fd3JyMnk7oigiLi4OHh4elSpjyLgqlsoYV2WMCWBcFUlJxpScnIxatWrJ+x56OiW1zwYq5++qMSw1boCxW2Lslho3wNhLInbusysmJkKMpJla6+TkVOxESGZmJpycnCrVHxvGVbFUxrgqY0wA46pISiMmXtZhmpLaZwOV83fVGJYaN8DYLTF2S40bYOwlGTv32RWLZf22ExEREREREZFFYyKEiIiIiIiIiCwGEyFEREREREREZDGYCCEiIiIiIiIii8FECBERERERERFZDCZCiIiIikklSvjr9mMc/Ccef91+DJUombtLRERERFQIPj6XiIioGEKvRmPJz9cRnZSZVxKB6s52WDQgAL2bVDdr34iIiIhIH2eEEBERmSj0ajSmfv+3VhJELSYpE1O//xuhV6PN1DMiIiIiKgwTIURERCZQiRKW/Hwdhi6C0ZQt+fk6L5MhIiIiKmd4aQwREZEJzkbE680E0SYBiE7KxNmIeLSv6152HSMiomKRJAmSJEEUxSe+L6zMlDbGrFPS/0RRRFpaGuzt7XViL+yfdpvC3hvbztRtaZa1X59UVlh927Zt4enpadLvCVVsTIQQERGZIDal8CSIKe2IiIxVcJBsaJBu7Kv2e5VKhfj4eKSkpADAU2+rpF6L27a4ZdoD5fJMEIQS+adSqWBtbf3Edtqfacp7hUJRItvRvGq/f9oyQRAgSRKqVKlSrJ8BVVxmTYQEBwdjz549+Oeff2Bvb4/nn38eK1asQIMGDeQ2mZmZePvtt7F9+3ZkZWUhMDAQ69evh5eXl9wmKioKU6dOxdGjR+Ho6IigoCAEBwfDyio/vGPHjmHWrFm4du0aatWqhQULFmD8+PFlGS4REVUi2bmiUe08q9qVck/KBvfZFYehM6kFX59UJooiMjIykJqaKg8YCm67sDJjziSXRLunOXtubFtNWVpaGuzs7HS+D0PrPc37kl6vvNAeKGsGuiX9+rR1T1sGAGlpaXBycoJCoTB63YJ1xi6b2qZgWUkQRRGxsbHw9PSUvwtLoYmdLJNZEyHHjx/HtGnT0KZNG+Tm5uLdd99Fr169cP36dTg4OAAA3nrrLRw4cAC7du2Cs7Mzpk+fjqFDh+LPP/8EAKhUKvTr1w/e3t44deoUoqOjMW7cOFhbW2P58uUAgIiICPTr1w+vvfYatm7disOHD2Py5MmoXr06AgMDzRY/ERFVPLkqEV+euI1PDv1XZDsBgLezHZ7zdyubjpUyS9xnJyQkICQkBKIo6g0QCg5EDQ1Mn9TG1OWiEhqW7EkDyKcp15whf9JAVPu9lZVVkfVPem9K25JIJGi/AkB8fDw8PDygVCqN3nZFZ8nJACJLJUjlaM8ZFxcHT09PHD9+HJ06dUJSUhI8PDywbds2DB8+HADwzz//oFGjRjh9+jTatWuHX3/9Ff3798eDBw/kM04bNmzA3LlzERcXBxsbG8ydOxcHDhzA1atX5c8aNWoUEhMTERoaalTfkpOT4ezsjKSkJDg5OZkcY2X9Q8u4KpbKGFdljAlgXOXNPzHJmL3rMq7cTwIANKnhhKv3kyEAOjdN1QwLvhj7rEmP0C2pfU5psoR9dnp6Os6ePYu0tDQ4ODjoDfietGxMG1OXtQeghl6ftq5gGQAkJSXB2dkZSqVSp13B9k/6Z2y7J7UFoDP4Lq3BeEX9+1QSLDV2S40bYOwlEXtF2GeTvnJ1j5CkJPWBpZub+uzZ+fPnkZOTgx49eshtGjZsCF9fX/mg6vTp02jatKnOtNvAwEBMnToV165dQ8uWLXH69GmdbWjazJw5s9C+ZGVlISsrS15OTk4GoP4PRhSNmw5tiPY0x8qEcVUslTGuyhgTwLjKixyViC+P38ZnR8ORo5LgZGeFRQMCMLiFD3679hBL999ATHL+vUC8ne3wfr9G6BXgZVKMFeF7sYR9tp2dHTp27Ii4uDh4eHhY1CBBFMUKE3dJXypS0f4+lSRLjd1S4wYYe0nEbonfXWVQbhIhoihi5syZ6NChA5o0aQIAiImJgY2NDVxcXHTaenl5ISYmRm6jfUClqdfUFdUmOTkZGRkZ8l2StQUHB2PJkiV65XFxccjMNP3Gd6IoIikpCZIklfsDi6fBuCqWyhhXZYwJYFzlwc24dHx46A7+jU0HAHSs44y53Xzh4WiNuLg4POupwI/jA3DhXjLuxiWjlocTWtZ0glIhmHztseZGheWVpeyzgYr1u1qSLDVugLFbYuyWGjfA2Esi9vK+zybDyk0iZNq0abh69Sr++OMPc3cFADB//nzMmjVLXk5OTkatWrXg4eFR7EtjBEGoEGdYngbjqlgqY1yVMSaAcZlTjkrEhuO38XneLBBne2ssGtAIg5r7GJyG7+XpUWJn0DU3aSyvLGWfDVSM39XSYKlxA4zdEmO31LgBxl4SsZf3fTYZVi4SIdOnT8f+/ftx4sQJ1KxZUy739vZGdnY2EhMTdc4wPXz4EN7e3nKbs2fP6mzv4cOHcp3mVVOm3cbJycngmSUAsLW1ha2trV655k7SxaG5prWy/bFhXBVLZYyrMsYEMC5zuP4gGe/suoTr0epLLHo08sLyIU3g6VT0wU5JxVQevxMNS9tnA+X7d7U0WWrcAGO3xNgtNW6AsRc3dkv83ioDs/7UJEnC9OnTsXfvXhw5cgT+/v469a1atYK1tTUOHz4sl/3777+IiopC+/btAQDt27fHlStXdKYfHzp0CE5OTggICJDbaG9D00azDSIiIkD9SNxPfv8PAz//A9ejk+FSxRrrRrXA1+NaPTEJUtlxn01ERESVhVlnhEybNg3btm3D//3f/6Fq1ary9cHOzs6wt7eHs7MzJk2ahFmzZsHNzQ1OTk5444030L59e7Rr1w4A0KtXLwQEBODll1/GypUrERMTgwULFmDatGny2aHXXnsNn3/+OebMmYOJEyfiyJEj2LlzJw4cOGC22ImIqHy59iAJ7+y6jBt5s0B6BXjhwyFN4FnVshMgGtxnExERUWVh1kTIF198AQDo0qWLTvmmTZswfvx4AMDatWuhUCgwbNgwZGVlITAwEOvXr5fbKpVK7N+/H1OnTkX79u3h4OCAoKAgLF26VG7j7++PAwcO4K233sK6detQs2ZNfPPNNwgMDCz1GImIqHzLzhXx+dFwrD8ajlxRgmsVaywZ1AQDmlUv0UdyVnTcZxMREVFlYdZEiDGPOrOzs8P//vc//O9//yu0Te3atfHLL78UuZ0uXbrgwoULT91HIiKqvK7eT8I7uy7hnxj1Hd97N/bGB4ObwKOq/v0mLB332URERFRZlIubpRIREZWlrFwVPj8SjvXHbkElSnBzsMHSQY3RrylngRARERFVdkyEEBGRRblyTz0L5N+H6lkg/ZpWx5JBjVHNkbNAiIiIiCwBEyFERGQRsnJV+PTwTWw4fhsqUYK7gw2WDmqCfs2qm7trRERERFSGmAghIqJK7/K9RLyz6xL+e5gKAOjXrDqWDmwMd84CISIiIrI4TIQQEVGllZWrwrrfb+LLE+pZINUcbfDBoCbo05SzQIiIiIgsFRMhRERUKV28m4jZuy7hZqx6FsiA5j5YMrAx3BxszNwzIiIiIjInJkKIiKhSycxR4ZPfb+KrE7cgSkA1R1t8OLgJejfxNnfXiIiIiKgcYCKEiIgqjQtRCXhn1yXciksDAAxq4YPFAxrDlbNAiIiIiCgPEyFERFThZeaosPbQf/j65G15FsiyIU0Q2JizQIiIiIhIFxMhRERUoZ2/k4DZuy/hdt4skCEta2DRgAC4VOEsECIiIiLSx0QIERFVSJk5Knx88F9880cEJAnwqGqL5UOaomeAl7m7RkRERETlGBMhRERU4ZyLjMec3Zdx+5F6FsjQZ2tgYX/OAiEiIiKiJ2MihIiIKoyMbBVWH/wXG/9UzwLxclLPAuneiLNAiIiIiMg4TIQQEVGFEJY3CyQibxbI8FY18X6/ADhXsTZzz4iIiIioImEihIiIyrWMbBVW/vYPNp+KhCQB3k52CB7aFF0bepq7a0RERERUATERQkRE5dbZiHjM3n0Jdx6nAwBGtq6J9/oFwNmes0CIiIiIyDRMhBARUbmTnp2LlaH/4tvT6lkg1Z3Vs0C6NOAsECIiIiIqHiZCiIioXPnr9mPM2X0ZUfHqWSCj2tTCu/0awcmOs0CIiIiIqPiYCCEionIhLSsXK0P/wben7wAAfJztEDysGTrX9zBzz4iIiIioMmEihIiIypRKlHDm9mOE34tHvVQl2taphjMRjzH3x8u4G58BABj9XC3M78tZIERERERU8pgIISKiMhN6NRpLfr6O6KTMvJIIVLFRIj1bBQCo4WKP4KFN0YmzQIiIiIiolDARQkREZSL0ajSmfv83pALlmiTIC89Uw/oxz6IqZ4EQERERUSliIoSIiEqdSpSw5OfrekkQbeGxqahiw90SERFZLkmSAAmA/GqoTIJU2LKYX15wvYLrQAJElQgpPgNZGclQCIJ6fWi2h7wOaN5rfRYAiHlvNNuD1mcUKNftj9Z2Ne3UnwqdAwVJ642hcs1n6rQ1Yr28N6IkQfIEwAfSWSQecRIRUak7GxGvdTmMYdFJmTgbEY/2dd3LqFdERFQYedAqqkfQkmaALUqQxPw6STP4lt/nDbrFAu/ldbW2o9m+9nYkA+U6y1p9MliO/H4UXC7YL614VBmZiLd5bCCxoB3Dk+t049W01/6+8vsp12klL8zlMe6Z78O1CYbeC7rlcp26UDBhHfmlOy/FtVRmTYScOHECq1atwvnz5xEdHY29e/di8ODBcn1qairmzZuHn376CY8fP4a/vz9mzJiB1157TW6TmZmJt99+G9u3b0dWVhYCAwOxfv16eHl5yW2ioqIwdepUHD16FI6OjggKCkJwcDCsrJgHIiIqC1HxaUa1i00pOllC5sN9NpmT7kCzwKBXM+jUHqRqDzQNDlIN1InqgbEkihDj05CZmAABgoFtaQ+ooTeY1U4S6CUQnmawrpNoMC25UOjnayUepIJtRREPpJtmHZTrEQAo1ANbQRDy3gsQFMh/r2mj0Hov5K2jEPLXL6QcKvV3IggCoFRAIRTYdt466u0LgCK/LL9PyP98ocDn5bUXtLaTX1+gTiiwbe3PN9Af3XYG2hSyLUEhQBRFxCfEw83dHQqlIu/7FvKTC9rbhWa7yM8+aL3X+UzovhcKK1cUzFaUHVEUERsba7bPJ/My61FFWloamjdvjokTJ2Lo0KF69bNmzcKRI0fw/fffw8/PDwcPHsTrr78OHx8fDBw4EADw1ltv4cCBA9i1axecnZ0xffp0DB06FH/++ScAQKVSoV+/fvD29sapU6cQHR2NcePGwdraGsuXLy/TeImILNHJm3FYFfqvUW09q9qVcm/IVJa4z1alZiP5cBRUGRlIsk9VH8gXIEkFRosFB49F1UsmbEN7HalAvfZgX3tZe5va09oNrCcXSxJys7PxyDoGgJC/Xe3PFQuUGZoCr51EgNbnyMkEzQrQ/4wC/Spr8XjwdCvIA+O8AbqgPygvrNzYwXr+oFqAQikYHPir2yP/vU6CoECdTjsBkiAhNS0VVatWhaBU6Azi8/tRIA6dBEDeNuX3Rcdg8PvQTiRoD/JLkWZA7O7pCYVCUaqfVd6IoghBkQZrzyoWFztZNrMmQvr06YM+ffoUWn/q1CkEBQWhS5cuAIBXXnkFX375Jc6ePYuBAwciKSkJISEh2LZtG7p16wYA2LRpExo1aoS//voL7dq1w8GDB3H9+nX8/vvv8PLyQosWLfDBBx9g7ty5WLx4MWxsbMoiVCIii5OSmYPlv9zAD2fvAgCUAqAqZEAjAPB2tsNz/m5l10F6Kpa4z5ZyRWRFJEHKzUWWVbbeLOuCU6wLFsPQ4E2vraBbXEi9zvraZ2blMkHvc+XBpPZ2FYr8poWsJ4eVJUFpZ5d3JldrEFtg3SeesTZYplnXUJnueoCBxIA8UIZO/3QH0Vqfq72+zpl07Xp1nQgJjx8/RjWPauoz5HoDeOgmGTTvKwFRFJEeGwsHC0wIEJFlKdfzTJ9//nns27cPEydOhI+PD44dO4b//vsPa9euBQCcP38eOTk56NGjh7xOw4YN4evri9OnT6Ndu3Y4ffo0mjZtqjPtNjAwEFOnTsW1a9fQsmXLMo+LiKiyO/FfHOb9eBkP8u4LEtS+Nlr6uuKtHRcB6J7g1QwfFg0IgLKSDCYsUWXcZ1u52MFzRkvExsbC08IGhpoz5K4WFjeQd4Y81xpKF1uLi52IyFKU60TIZ599hldeeQU1a9aElZUVFAoFvv76a3Tq1AkAEBMTAxsbG7i4uOis5+XlhZiYGLmN9gGVpl5TV5isrCxkZWXJy8nJyQDUO0dRFE2OSRRFSJJUrG2UR4yrYqmMcVXGmICKF1dyZg6W//IPdp5T33TN180eK4Y2Rds66hug2igFLN1/AzHJ+fcC8Xa2w/v9GqFXgFeFidOQkvxZVcTvoTLuszXbqEj/DZYUS40bYOyWGLulxg0w9pKI3RK/u8qg3CdC/vrrL+zbtw+1a9fGiRMnMG3aNPj4+OicUSoNwcHBWLJkiV55XFwcMjNNv5mfKIpISkqCJEmV6iwD46pYKmNclTEmoGLFdToyCcG/30Fsag4AYGQLT0zt4AN7a5V8M7JnPRX4cXwALtxLxt24ZNTycELLmk5QKoQKf8OykvxZpaSklFCvyk5l3GcDFeu/wZJkqXEDjN0SY7fUuAHGXhKxV8R9NpXjREhGRgbeffdd7N27F/369QMANGvWDBcvXsTq1avRo0cPeHt7Izs7G4mJiTpnmB4+fAhvb28AgLe3N86ePauz7YcPH8p1hZk/fz5mzZolLycnJ6NWrVrw8PCAk5OTyXGJoghBEODh4VGp/tgwroqlMsZVGWMCKkZcyRk5WPbLP9h1Xj0LpLZbFawY1rTI+314eXogLi6uXMf1tEryZ2VnV7FuGltZ99lAxfhvsDRYatwAY7fE2C01boCxl0TsFW2fTWrlNhGSk5ODnJwcvV9KpVIpTz9q1aoVrK2tcfjwYQwbNgwA8O+//yIqKgrt27cHALRv3x7Lli2Tr+8FgEOHDsHJyQkBAQGFfr6trS1sbW31yhUKRbH/SAiCUCLbKW8YV8VSGeOqjDEB5Tuuo//GYv6PVxCTnAlBAMY/74fZgQ1QxebJu5fyHJepSiqmivadVOZ9NlA5f1eNYalxA4zdEmO31LgBxl7c2C3xe6sMzJoISU1NRXh4uLwcERGBixcvws3NDb6+vujcuTNmz54Ne3t71K5dG8ePH8d3332HNWvWAACcnZ0xadIkzJo1C25ubnBycsIbb7yB9u3bo127dgCAXr16ISAgAC+//DJWrlyJmJgYLFiwANOmTTN40ERERE+WlJGDD/dfl2eB+LlXwcrhzfnUl0qM+2wiIiKqLMyaCDl37hy6du0qL2umtQYFBWHz5s3Yvn075s+fjzFjxiA+Ph61a9fGsmXL8Nprr8nrrF27FgqFAsOGDUNWVhYCAwOxfv16uV6pVGL//v2YOnUq2rdvDwcHBwQFBWHp0qVlFygRUSVy5J+HmL/nCh4mZ0EQgIkd/PFOrwawt1Gau2tUirjPJiIiospCkCRJenIzSk5OhrOzM5KSkop9j5DK+Bg+xlWxVMa4KmNMQPmKKyk9B0v3X8ePf6tngfhXc8Cq4c3Q2u/pZ4GUp7hKSknGVFL7HEtVkt9fZfxdNYalxg0wdkuM3VLjBhh7ScTOfXbFVG7vEUJEROXH4RvqWSCxKepZIJM6+ONtzgIhIiIiogqIiRAiIipUUnoOlvx8DXsu3AcA1KnmgFUjmqFVbd4LhIiIiIgqJiZCiIjIoN+vP8S7e/NngUx5oQ5m9awPO2vOAiEiIiKiisvkREhUVBTu3LmD9PR0eHh4oHHjxryjOxFRJZCYno0lP1/HXs0sEA8HrBreHK1qu5q5Z0REREQVmyiKyM7ONnc3KiUbGxuj7/fyVImQyMhIfPHFF9i+fTvu3bsH7fus2tjY4IUXXsArr7yCYcOGWdzNdoiIKoNDebNA4lKyoMibBfIWZ4EQERERFVt2djYiIiIgiqK5u1IpKRQK+Pv7w8bG5oltjU6EzJgxA99++y0CAwPx4Ycf4rnnnoOPjw/s7e0RHx+Pq1ev4uTJk1i4cCGWLFmCTZs2oU2bNsUKhIiIykZCWjaW/HwNP118AACo6+GAVSOa41lfzgIhIiIiKi5JkhAdHQ2lUolatWpx4kAJE0URDx48QHR0NHx9fSEIQpHtjU6EODg44Pbt23B3d9er8/T0RLdu3dCtWzcsWrQIoaGhuHv3LhMhREQVwG/XYvDe3qt4lKqeBfJKp7qY2eMZzgIhIiIiKiG5ublIT0+Hj48PqlSpYu7uVEoeHh548OABcnNzYW1tXWRboxMhwcHBRnegd+/eRrclIiLziE/LxuJ917DvknoWSD1PR6we0RwtarmYt2NERERElYxKpQIAoy7bINNovluVSlVyiRAiIqo8Qq9GY8FPV/EoNRsKAXi1c1282Z2zQIiIiIhK05Mu2SDTPc13a1Ii5PHjx1i4cCGOHj2K2NhYvZu9xMfHm7JZIiIqZfFp2Vj4f1ex/3I0AOCZvFkgzTkLhIiIiIgshEl3aHn55Zdx6NAhBAUFYfXq1Vi7dq3OPyIiKn9+vRKNnmuOY//laCgVAqZ1rYv9MzoyCUJERERUycXFxWHq1Knw9fWFra0tvL29ERgYiD///BMA4OfnB0EQsH37dr11GzduDEEQsHnzZr264OBgKJVKrFq1qrRDKFEmzQg5efIk/vjjDzRv3ryk+0NERCXscWoWFu67hgN5s0Dqe6lngTSr6WLejhERERFRmRg2bBiys7Px7bffok6dOnj48CEOHz6Mx48fy21q1aqFTZs2YdSoUXLZX3/9hZiYGDg4OBjc7saNGzFnzhxs3LgRs2fPLvU4SopJiZCGDRsiIyOjpPtCREQl7MDlaCz8v6t4nJYNpULA1M518Ub3erC14r1AiIiIiCxBYmIiTp48iWPHjqFz584AgNq1a+O5557TaTdmzBisXbsWd+/eRa1atQCoEx1jxozBd999p7fd48ePIyMjA0uXLsV3332HU6dO4fnnny/9gEqASZfGrF+/Hu+99x6OHz+Ox48fIzk5WecfERGZ16PULLy+9Tymbfsbj9Oy0dC7Kn56vQPeCWzAJAgRERGRBXF0dISjoyN++uknZGVlFdrOy8sLgYGB+PbbbwEA6enp2LFjByZOnGiwfUhICEaPHg1ra2uMHj0aISEhpdL/0mBSIsTFxQXJycno1q0bPD094erqCldXV7i4uMDV1bWk+0hEREaSJAn7Lz9Ar7Un8MuVGCgVAmZ0q4d90zuiaU1nc3ePiIiIiMqYlZUVNm/ejG+//RYuLi7o0KED3n33XVy+fFmv7cSJE7F582ZIkoTdu3ejbt26aNGihV675ORk7N69G2PHjgUAjB07Fjt37kRqampph1MiTLo0ZsyYMbC2tsa2bdvg5eXFRwAREZUDcSlZWPh/V/Hr1RgAQEPvqlg9ojma1GAChIiIiMiSDRs2DP369cPJkyfx119/4ddff8XKlSvxzTffYPz48XK7fv364dVXX8WJEyewcePGQmeD/PDDD6hbt65839AWLVqgdu3a2LFjByZNmlQWIRWLSYmQq1ev4sKFC2jQoEFJ94eIiJ6SJEn4+XI0Fv3fVSSk58BKIeD1rvUwvWs92FiZNPGPiIiIiCoZOzs79OzZEz179sT777+PyZMnY9GiRTqJECsrK7z88stYtGgRzpw5g7179xrcVkhICK5duwYrq/yUgiiK2LhxY+VNhLRu3Rp3795lIoSIyMziUrLw/k9XEXpNPQukUXUnrBrejLNAiIiIiKhIAQEB+Omnn/TKJ06ciNWrV+PFF180eOuLK1eu4Ny5czh27Bjc3Nzk8vj4eHTp0gX//PMPGjZsWJpdLzaTEiFvvPEG3nzzTcyePRtNmzaFtbW1Tn2zZs1KpHNERGSYJEnYd+kBFu27hsS8WSDTu9XD6104C4SIiIiI8j1+/BgjRozAxIkT0axZM1StWhXnzp3DypUrMWjQIL32jRo1wqNHj1ClShWD2wsJCcFzzz2HTp066dW1adMGISEhWLVqVYnHUZJMSoS8+OKLAKBzvZAgCJAkCYIgQKVSlUzviIgsmEqUcOb2Y4Tfi0e9VCXa1qkGpUJAbEomFuy9ioPXHwIAAqo7YdWIZmjsw1kgRERERKTL0dERbdu2xdq1a3Hr1i3k5OSgVq1amDJlCt59912D67i7uxssz87Oxvfff4+5c+carB82bBg+/vhjLF++XG/CRHliUiIkIiKipPtBRERaQq9GY8nP1xGdlJlXEgFvZzv0aeKNPX/fR1JGDqyVAt7o9gymdqkLayVngRARERGRPltbWwQHByM4OLjQNpGRkUVuIzExUX7/6NGjQtvNmTMHc+bMedouljmTEiGurq5wcnIyWBceHl6sDhERWbrQq9GY+v3fkAqUxyRlYtOfkQCAxj5OWD2iORpVN/y3mIiIiIiIDDMpEdKvXz8cOnQIdnZ2OuX//vsvunfvjnv37pVI54iILI1KlLDk5+t6SRBtVW2t8OPU52FnrSyzfhEREREVhyRJmjeQNEc6klY5JOS/1W4jIb+5BE0j9UtRR0xFE0URqtxck9enis2kRIijoyOGDh2Kffv2yY/LuXHjBrp164aRI0eWaAeJiCzJ2Yh4rcthDEvJysWFqES0r2v42k0iIqKKQJIkSJIISRQhiurXgu8Lr1Op30tSgTqVbru8enVbzbqSul1enUqlQnJSEh46OqoH4JJuff76ecuS7rYLrRfz4pMk+T3kNpJWe833IMnvjW5n4DM07fO/YykvLlGdeIC6rTrxIEGVmwuFQqHVTmsdABDFAutA3pZmu5qkhFRI0qK86jj+VVT38TF3N8gMTEqE7NmzBz169MCYMWOwfft2XLt2Dd27d8eYMWOwZs2aku4jEZHFiE0pOgnytO2ISsqJEyewatUqnD9/HtHR0di7dy8GDx6s0+bGjRuYO3cujh8/jtzcXAQEBODHH3+Er68vACAzMxNvv/02tm/fjqysLAQGBmL9+vXw8vKStxEVFYWpU6fi6NGjcHR0RFBQEIKDg+UTL0TmoDuwLmRwLhVY1hpw67eV9AfsBt/rtikyIWCgL0W2KfBeFEWIKhUyMzJgY21dRIKisH6riuin4XXK5SBZEKBQKCAIAgSFMu9VAUGRv6xTr8irF/TroVDktxUUgEL9qm6r/d7Aq0IBwcpa3o56G1pthLw+ab2HoNVOEIACr3rvIQACkJ6WDgdHRygUCnVR3nYAQFAo5Fch7/tR10N3+1DHlPcl5n2VguYtAEHeJuQX9bpyW/lHoFWu9XPRKdNZL3/dpyFJIqxdq5m0LlV8Jh1V2Nvb48CBA+jSpQtGjhyJEydOYNy4cU/9iBweVBER6TL2pqeeVe2e3IioBKWlpaF58+aYOHEihg4dqld/69YtdOzYEZMmTcKSJUvg5OSEa9eu6VxG+9Zbb+HAgQPYtWsXnJ2dMX36dAwdOhR//vknAEClUqFfv37w9vbGqVOnEB0djXHjxsHa2hrLly8vs1g1crKzEHPrJhISEpCT8AgKIf+/T50p2+oCg+X54zzNchHtNevIq0j5beTp43lnfTVnWg2c3dU9iwv5DC+gHtDrbE+uy5uSnnd2VxQlpKQk456Dg/rJgAbOTOefOdY/G40CbTVnseX+GzpLrr1OwbPrRZ55N3SWPv+Mvk7iQa4r4qy+KEIUVfn9zDuzXm5oBtp5//LfKw2Wqwfi2mVK9Xul/jqCIEBU5QLW1lBaWelt1/Dn5m9XZ/uF9UWrrXYs2nWa5IJcJ+RvV69OLs9PIuj2p0ByQTs5kffdSADiHj2Cl5cXlErLuuxUFEXExsbC09NT/TOxIJrYyTIZnQlITk7WWVYoFNixYwd69uyJYcOG4f3335fbFHYj1YIs8aCKiMgQSZLw49/3sWTf1SLbCQC8ne3wnL9b2XSMKE+fPn3Qp0+fQuvfe+899O3bFytXrpTL6tatK79PSkpCSEgItm3bhm7dugEANm3ahEaNGuGvv/5Cu3btcPDgQVy/fh2///47vLy80KJFC3zwwQeYO3cuFi9eDBsbm9IL0IDU+MfYuXhemX6mWeSdzc0/E4z8s62aQXQhZ7Dzzy4/+ey07pnt/Pb5Z5jzPgP6g1bknW1X5p0h167P3556m+r2ivwz81pn8uV4FPl9UCiUchyaz0pLT4eTk3NeskBrwK312fmDbP3EgCAUWM77nIIx6Q3YC0026A7qS4ulDopFUcyfxUFEFsHoRIiLi4vBPw6SJGHDhg348ssvIUkSBEGASqUyapuWeFBFRFRQTFIm5u+5jKP/xgEAartXwZ3H6RCgewswzV/gRQMCoFTwYI3KD1EUceDAAcyZMweBgYG4cOEC/P39MX/+fHmm5/nz55GTk4MePXrI6zVs2BC+vr44ffo02rVrh9OnT6Np06Y6szoDAwMxdepUXLt2DS1btizTuJyqeSBo9Xo8jn8Mdzd3rWnfavnHRZop2jqVeTWC7rLWNHGdbTyhXDOFXHt6u6adIGims6uniAt5CQ1opq7rrau7PUMsdUAMWHbsRESWwuhEyNGjR0uzH3oq60EVEZGGJEnYff4elu6/jpTMXNgoFZjZ8xm88kId/H7jIZb8fF3nxqneznZYNCAAvZtUN2OvifTFxsYiNTUVH330ET788EOsWLECoaGhGDp0KI4ePYrOnTsjJiYGNjY2cHFx0VnXy8sLMTExAICYmBid/bWmXlNXmKysLGRlZcnLmhmqouY+BCYSFEq4VPdBjpU1XDw8KtWguOAlMwVpLicpzvdXUTF2y4vdUuMGGHtJxF6Rv7vHjx+je/fu8nJ6ejpu376N2NhYuLm5ITY2FuPGjcOtW7dga2uL9evXo1OnTgBgcp22zZs346effsJPP/1UJvFqMzoR0rlz59Lsh57KelBVWf/YMK6KpTLGVdFiik7KwLt7r+H4f+pZIM1qOmPVsKZ4xqsqAKBXgBe6N/TEmduPcetBHOr6eKBtHXcoFUKFibEoFe3nZYySjKmifS+a/g4aNAhvvfUWAKBFixY4deoUNmzYUOrHEMHBwViyZIleeVxcHDIzi3djYVEUkZSUBEmSKlUi5EksNW6AsVti7JYaN8DYSyL2lJSUEuxV2XJ3d8fFixfl5dWrV+P48eNwc1Nfgj1v3jy0a9cOoaGhCAsLw5AhQxAREQFra2uT68oLoxMhUVFR8g1KjXH//n3UqFHDpE4BlfegqrL+sWFcFUtljKuixCRJEvZff4xPjt9FWrYIa6WAKe188FIrL1gJGYiNzdBpX8dRhLuXAs6OuXj8KM5MvS55FeXn9TRKMqaKdlBVrVo1WFlZISAgQKe8UaNG+OOPPwAA3t7eyM7ORmJios4JjIcPH8Lb21tuc/bsWZ1tPHz4UK4rzPz58zFr1ix5OTk5GbVq1YKHh4fR9y0rjCiKEAQBHpVsRsiTWGrcAGO3xNgtNW6AsZdE7Nr3r6zoQkJCEBwcLC/v3LkT4eHhAIA2bdrAx8cHx48fR48ePUyuK8yDBw8waNAgTJ06FRMnToSfnx/Gjh2LI0eO4O7du3jvvfdga2uLr776CtHR0fjoo48watQok2M1OhHSpk0bDB48GJMnT0abNm0MtklKSsLOnTuxbt06vPLKK5gxY4bJHausB1WV9Y8N46pYKmNcFSGmB4kZeO+nqzj+3yMAQPOazlipNQvEkIoQlykqY1wlGVNFO6iysbFBmzZt8O+//+qU//fff6hduzYAoFWrVrC2tsbhw4cxbNgwAMC///6LqKgotG/fHgDQvn17LFu2TL4/AwAcOnQITk5OescD2mxtbWFra6tXrtDclLKYNDfRrCy/q8ay1LgBxm6JsVtq3ABjL27sxVk3I1uFW3GpJq//JHU9HGFvY9yTkE6dOoWEhAT0798fgPqymZycHJ0xs5+fH6KiokyuK8yVK1cwatQorF27Fr169ZLL09LScOrUKYSHh6Np06Z47733cPr0aYSFhaFv375lkwi5fv06li1bhp49e8LOzg6tWrWCj48P7OzskJCQgOvXr+PatWt49tlnsXLlSvTt29fkTgGV+6Cqsv6xYVwVS2WMq7zGJEkSdp67iw/330BKVi5srBR4u2d9TOroDysjHpdbXuMqrsoYV0nFVB6/k9TUVPnsDgBERETg4sWLcHNzg6+vL2bPno0XX3wRnTp1QteuXREaGoqff/4Zx44dAwA4Oztj0qRJmDVrFtzc3ODk5IQ33ngD7du3R7t27QAAvXr1QkBAAF5++WWsXLkSMTExWLBgAaZNm2Zwn0xERFSR3YpLRf/P/ii17e9/oyOa1HA2qm1ISAjGjRsHKyujUwQl4tq1axg4cCB++uknNG/eXKfuxRdfBADUq1cPdnZ2GD58OACgdevWiI+P15sQ8TSMjtLd3R1r1qzBsmXLcODAAfzxxx+4c+cOMjIyUK1aNYwZMwaBgYFo0qSJ0R/OgyoiquweJGZg3p4rOJF3L5AWtVywekQz1PMsfBYIUXl07tw5dO3aVV7WzJoMCgrC5s2bMWTIEGzYsAHBwcGYMWMGGjRogB9//BEdO3aU11m7di0UCgWGDRuGrKwsBAYGYv369XK9UqnE/v37MXXqVLRv3x4ODg4ICgrC0qVLyy5QIiKiMlLXwxH73+j45IbF2L4xUlNTsXPnToSFhcll7u7usLKyQkxMjDy7IzIyEr6+vibXGeLj44OsrCwcOXJELxGiPUNWqVTKy5qnoOXm5hr5Teh76nSPvb09hg8fLmdjioMHVURUWUmShB1hd/HhgRtIzZsF8k6v+pjUsQ4ffUtmk5WVZfJJgC5duhT6hBGNiRMnYuLEiYXW29nZ4X//+x/+97//Fdqmdu3a+OWXX0zqIxERUUVib6M0esZGadqxYweaN2+Ohg0b6pSPGDECGzZswOLFixEWFob79+/L9+o0ta4gV1dXbNmyBf3790dKSgoWLlxYusHmKdt5LwXwoIqIKqP7iRmY9+NlnLypvhfIs74uWDm8Oep5GpeVJyopv/76K7Zv346TJ0/i7t27EEURDg4OaNmyJXr16oUJEybAx8fH3N0kIiIiMwoJCcGUKVP0ylesWIGXX34ZzzzzDGxsbPD999/LT34xtc6QqlWrIjQ0FEOGDMHs2bOxatWq0glUi1kTIURElYkkSdgedhfL8maB2Fop8E6vBpjY0Z+zQKhM7d27F3PnzkVKSgr69u2LuXPnwsfHB/b29oiPj8fVq1fx+++/44MPPsD48ePxwQcfwMPDw9zdJiIiIjM4deqUwXIvLy8cPHiwROu0jR8/HuPHjwegvvIkNDRUrouMjNRp++jRI53l4lwWAzARQkRUIu4lpGP+nivyLJBWtV2xcngzo6/NJCpJK1euxNq1a9GnTx+DN14dOXIkAPWj7j/77DN8//338qPqiYiIiCo7JkKIiIpBkiT8cPYulv+SPwtkdmADTOjAWSBkPqdPnzaqXY0aNfDRRx+Vcm+IiIiIyhcmQoiITHQvIR3zfryCP8LzZ4GsGt4MdTgLhIiIiIio3DI5EbJlyxZs2LABEREROH36NGrXro1PPvkE/v7+GDRoUEn2kYioXJEkCVvPRCH4lxtIy1ZxFgiVa5IkYffu3Th69ChiY2MhiqJO/Z49e8zUMyIiIiLz0L9w2AhffPEFZs2ahb59+yIxMREqlQoA4OLigk8++aQk+0dEVK7cjU/HmG/OYMFPV5GWrULr2q4IndkJk1/gY3GpfJo5cyZefvllREREwNHREc7Ozjr/iIiIiCyNSTNCPvvsM3z99dcYPHiwzrXFrVu3xjvvvFNinSMiKi9EUcLWs+pZIOnZKthZKzAnsCGCnvdjAoTKtS1btmDPnj3o27evubtCREREVC6YlAiJiIhAy5Yt9cptbW2RlpZW7E4REZUnd+PTMWf3ZZy+/RgA0MbPFSuHN4d/NQcz94zoyZydnVGnTh1zd4OIiIio3DDp0hh/f39cvHhRrzw0NBSNGjUqbp+IiMoFUZSw5XQkAj85gdO3H8POWoFFAwKw45X2TIJQhbF48WIsWbIEGRkZ5u4KERERlSOPHz9GixYt5H/169eHlZUV4uPjAQATJkxA/fr10bx5c3To0AFhYWHyuunp6Rg9ejTq1auH+vXrY/fu3UbVaTt27BhatGhRqjEWxqQZIbNmzcK0adOQmZkJSZJw9uxZ/PDDDwgODsY333xT0n0kIipzUY/TMefHS/jrtnpH8Jy/G1YOawY/JkCoghk5ciR++OEHeHp6ws/PD9bW1jr1f//9t5l6RkRERObk7u6uM8Fh9erVOH78ONzc3AAAQ4YMwddffw0rKyvs378fI0aMQGRkpNzW1tYW4eHhiIiIQNu2bdG1a1e4u7sXWVdemJQImTx5Muzt7bFgwQKkp6fjpZdego+PD9atW4dRo0aVdB+JiMqMKErY8tcdfPTrP8jIUcHeWom5vRtgXHs/KHgvEKqAgoKCcP78eYwdOxZeXl4QBP4eExERkb6QkBAEBwfLywMHDpTft2vXDvfv30dubi6srKywY8cOhISEAFBfMdKlSxfs3bsXkydPLrKuMMnJyRg+fDg6duyIhQsXokuXLmjVqhXCwsIQGRmJoKAgtG/fHsuXL8e9e/cwY8YMzJo1y+RYTX587pgxYzBmzBikp6cjNTUVnp6eJneCiKg8uPM4DXN2X8aZCPUskLb+blg5vBlqu3MWCFVcBw4cwG+//YaOHTuauytERESkLTsdePRf6W2/Wn3ApopRTU+dOoWEhAT079/fYP26devQt29fWFmpUwhRUVGoXbu2XO/n54eoqKgn1hly9+5dDB48GG+++SbGjRsnl9+5cwdHjx5FcnIy/Pz8kJCQgJMnT+LBgwdo0KABJk6cCBcXF6PiK8jkRIhGlSpVUKWKcV8uEVF5JIoSvjsdiRWh/8qzQOb3bYixbWtzFghVeLVq1YKTk5O5u0FEREQFPfoP+Kpz6W3/leOATwujmoaEhGDcuHFyokPb999/j507d+LEiRMl3EHg4cOH6NSpE7755ht0795dp2748OFQKpVwdXVFnTp10L9/fwiCgBo1asDDwwORkZEm32PE6ERIy5YtjZ5Oy+uNiaiiuPM4DbN3X8bZvFkg7eq4YeWw5vB1Z4KXKoePP/4Yc+bMwYYNG+Dn52fu7hAREZFGtfrqZEVpbt8Iqamp2Llzp87NUDV27NiBJUuW4PDhw/Dy8pLLfX19cefOHVSvXh0AEBkZiV69ej2xriAXFxfUq1cP+/fvR7du3XRyDnZ2dvJ7pVKpt5ybm2tUfIYYnQgZPHiw/D4zMxPr169HQEAA2rdvDwD466+/cO3aNbz++usmd4aIqKyIooRvT0diZd4skCo2Sszv0xBjOAuEKpmxY8ciPT0ddevWRZUqVfRulqq5MzwRERGVMZsqRs/YKE07duxA8+bN0bBhQ53ynTt3YsGCBfj999/h6+urUzdixAhs2LAB7dq1Q0REBI4dO4b169c/sa4gW1tb7NmzB2PHjsWUKVPw1VdfQaEw6eG2T8XoRMiiRYvk95MnT8aMGTPwwQcf6LW5e/duyfWOiKgURD5S3wvkbKR6ANi+jjtWDm+GWm6cBUKVz9q1a3mDVCIiIipUSEgIpkyZolc+ZswYeHt7Y9CgQXLZ4cOH4e7ujtmzZ2PixImoW7culEolPv/8c1SrVg0AiqwzxNraGtu2bcPkyZMxZswYbNmypeSDLMCke4Ts2rUL586d0ysfO3YsWrdujY0bNxa7Y0REJU0UJWw+FYmVv/2DzBxRPQukbyOMec6Xs0Co0ho/fnyhdRkZGWXXESIiIiqXTp06ZbA8Jyen0HUcHBywY8eOp67T1qVLF/nxvUqlEps2bZLrjh07ptO2YP4hPDz8idsviklzTuzt7fHnn3/qlf/555861+0QEZUXEY/S8OJXp7F0/3Vk5oh4vq47fpvZCS+346UwVLnNmDHDYHlaWhr69u1bxr0hIiIiMj+TZoTMnDkTU6dOxd9//43nnnsOAHDmzBls3LgR77//fol2kIioOFR5s0BW5c0CcbBR4t1+jfDSc768XIAswoEDB+Dq6oolS5bIZWlpaejdu7cZe0VERERkPiYlQubNm4c6depg3bp1+P777wEAjRo1wqZNmzBy5MgS7SAR0ZOoRAlnbj9G+L141EtVom2dalAqBNyOS8Wc3Zdx7k4CAKBDPXd8NJT3AiHLcvDgQbzwwgtwdXXFzJkzkZKSgsDAQFhZWeHXX381d/eIiIiIypxJiRAAGDlyJJMeRGR2oVejseTn64hOyswriYC3kx061nPHz5ejkZXLWSBk2erWrYvQ0FB07doVCoUCP/zwA2xtbXHgwAE4ODiYu3tEREREZc7kRAgRkbmFXo3G1O//hlSgPCY5E7v/vg8A6FivGj4a1hQ1XTkLhCxXs2bNsH//fvTs2RNt27bF/v37YW9vb+5uEREREZmFSYkQhUJR5FlVlUplcoeIiIyhEiUs+fm6XhJEm7O9NTZPaAMrZek/i5yoPGnZsqXB/bStrS0ePHiADh06yGV///13WXaNiMgsJFGCJEmQRECSJIiiBEjqJ8qJKhGZqblIt80CoMhrp9tefjVYpn6FgTJJUn82pALlomYdI8pF7c/IewV0ytTL6nbQvGriBvLX0zTX2nZaWhqqVEkGIGh9Rl4b+QuE1ntJU5RfWFRbCXrtJWj3u5g/3EI8aRKwJEmo2bwKPD1L5/OpfDMpEbJ3716d5ZycHFy4cAHffvutzs3YiIhKy9mIeK3LYQxLyshBWGQC2td1L6NeEZUPgwcPNncXiMgEOgNfUT1YV79XD9g1A3Qxr0wzWC9qOX8bee8Lbl/Kb6tSiUhOSkacQw4AQV5Xux/529f6DKmwZf2+a5YhSRDlhEKBuArGKScmoBOP+rP0kxySdpyaRERFJACCIKgH9Drv1a8C8t9DAAQIEPLO/Qh5DQQAQt7T8eQyzTbyPkOlUsHKKhOCIm+7mgpBN5mgnWDXSzJo+qFXL+QvF7ItQ/VFMuLHaVxyRUJujmXPjnz8+DG6d+8uL6enp+P27duIjY2Fm5ubXH7kyBH07NkTH3/8MWbOnCm3nTRpEsLCwqBQKLB8+XIMHz78iXXajh07hpkzZ8qP0C1LJiVCBg0apFc2fPhwNG7cGDt27MCkSZOK3TEioqLEphSdBHnadkSVyaJFi0p8mydOnMCqVatw/vx5REdHY+/evYUmXF577TV8+eWXWLt2rXzABADx8fF444038PPPP0OhUGDYsGFYt24dHB0d5TaXL1/GtGnTEBYWBg8PD7zxxhuYM2dOicdTGWmf7ZXPEkvqM6+S5r3WmWSds8baZ4GhHhhlJOcg1SoTgkJh8Iy0fOYahZ0dzx+IAkaeKdcZwBZ4b2BArDmjX9jgV69fBQb+8oC7QHIgMyMTNjaxeevm10mawbuBz3yqQXshy6V1ZvxpCQr14FkhCBCUAhQKQT0I15QbWtYqK3RZM9DOq7Oyzt+GIGi2kzfgz2uv0LTXLGvXa9UpFOqBu07fCrbTKdckFgRAkJCcnAwXV2coFAq9+PS3o1Uu6G5PO2GRn1jQKldAZz0UaFewfWkTRRGxsbHw9PSEQmFZM2g1sVsyd3d3nSTE6tWrcfz4cZ0kSFJSEubNm4e+ffvqrLt69WrY2toiPDwcERERaNu2Lbp27Qp3d/ci68qLEr1HSLt27fDKK68Y3Z4HVURkqhyVcUeLnlXtSrknROWPJEklfgCdlpaG5s2bY+LEiRg6dGih7fbu3Yu//voLPj4+enVjxoxBdHQ0Dh06hJycHEyYMAGvvPIKtm3bBgBITk5Gr1690KNHD2zYsAFXrlzBxIkT4eLi8lTHFyUl+VEG9qw6D5UoQqkI16mTCrwpOGVcb9HAdHD9NpJ20wLTybWSGTAwdb3UBtA3S2vDJpEHiQpAIQiA9kA5b5AJQb/siQNZrcE8BCA3VwVBUkEQFFAoAIVSgGCtyBusF9i2PGDXDNbzP09RcFBfYGBdcOAvL+skBgqUy5+lmwQoLFGhUBb8vPzP1FlWCIAkIe5RnMUNitUDYgmentUsKm6igkJCQhAcHKxTNn36dCxYsAB79uzRKd+xYwdCQkIAAP7+/ujSpQv27t2LyZMnF1lXmOTkZAwfPhwdO3bEwoUL0aVLF7Rq1QphYWGIjIxEUFAQ2rdvj+XLl+PevXuYMWMGZs2aZXKsJZYIycjIwKeffooaNWoYvY4lHlQRUfGoRAnfnLyN1Qf/LbKdAMDb2Q7P+bsV2Y6oMmrcuDEWLlyIoUOHwsbGptB2N2/exJo1a1C7dm3MmzevyG326dMHffr0KbLN/fv38cYbb+C3335Dv379dOpu3LiB0NBQhIWFoXXr1gCAzz77DH379sXq1avh4+ODrVu3Ijs7Gxs3boSNjQ0aN26MixcvYs2aNWbZZ9vYWyHgBR+kpabBwdGh0ORSwSng8otQsJ32vHDNi5HraE1Xl6euC4LOOvnT3/PaKfKnzmteNGeaNdvWnlJfsA9JyYlwcXGBQqnQO/MNoZCz4YDhM+MGz5jrTuPXnNHXTlQotJMePENe6kRRNHcXiMhMTp06hYSEBPTv318u2717NxQKBQYOHKiXCImKikLt2rXlZT8/P0RFRT2xzpC7d+9i8ODBePPNNzFu3Di5/M6dOzh69CiSk5Ph5+eHhIQEnDx5Eg8ePECDBg3kcb0pTEqEuLq66uyIJElCSkoKqlSpgu+//97o7VjiQRURmS48NhXv7LqEi3cTAQAB1Z1wPToZAnRPhmr+Oi0aEAClgo/LJcvz2WefYe7cuXj99dfRs2dPtG7dGj4+PrCzs0NCQgKuX7+OP/74A9euXcP06dMxderUYn+mKIp4+eWXMXv2bDRu3Fiv/vTp03BxcZH31wDQo0cPKBQKnDlzBkOGDMHp06fRqVMnneRNYGAgVqxYgYSEBLi6uhr87KysLGRlZcnLycnJcp+KM7CzsVfi2d6+iIuLg4eHh0UNikVRhF1cLjw8XMtF3PmzYEr/2hFRFPMugbG8pIClxm6pcQOMvSRiL876GbkZiEiKKNbnF8Xf2R/2VsbdByUkJATjxo2DlZU6RRATE4MPP/wQx44dK7X+AcDDhw/RqVMnfPPNNzr3KwHUt99QKpVwdXVFnTp10L9/fwiCgBo1asDDwwORkZFo0aKFSZ9rUiJk7dq1OokQhUIBDw8PtG3bttCDFFNUxoOqyvrHhnFVLBUtLpUo4Zs/IrD295vIzhXhaGuFBf0aYkSrmvjt2kMs3X8DMcn59wLxdrbD+/0aoVeAV4WJsTAV7WdlrMoYV0nGVNxtdO/eHefOncMff/yBHTt2YOvWrbhz5w4yMjJQrVo1tGzZEuPGjcOYMWNKbL+9YsUKWFlZYcaMGQbrY2Ji4Fng1vxWVlZwc3NDTEyM3Mbf31+njZeXl1xXWF+Dg4MN3qw9Li4OmZnFu0+QKIpISkqCJEnlIiFQViw1boCxW2Lslho3wNhLIvaUlBST141IisCL+180ef0n2dF/BwLcA57YLjU1FTt37kRYWJhcprl9hSbR8OjRI+zbtw9xcXFYtmwZfH19cefOHVSvXh0AEBkZiV69egFAkXUFubi4oF69eti/fz+6deumk2ews8u/xF2pVOot5+bmGvlN6DMpEdKtWzfUqlXL4PTEqKgo+Pr6mtwhbZXxoKqy/rFhXBVLRYorIj4DHx68g2sxaQCAdrWd8G6P2vCsaoO4uDg866nAj+MDcOFeMu7GJaOWhxNa1nSCUiFUihtgVaSf1dOojHGVZEzFOajS1rFjR3Ts2LFEtlWU8+fPY926dfj777/L5NKFgubPn69znXBycjJq1aoFDw8PODk5FWvboihCEASLnBFiiXEDjN0SY7fUuAHGXhKxaw/On5a/sz929N9h8vrGbN8YO3bsQPPmzdGwYUO5rF+/fnj48KG8PH78eLRo0UK+X+eIESOwYcMGtGvXDhERETh27BjWr1//xLqCbG1tsWfPHowdOxZTpkzBV199VSa/iyYlQvz9/REdHa2XhHj8+DH8/f2hUqmK3bHKelBVWf/YMK6KpSLElasS8c0fEfjkcLg8C+T9/o0w/NkaBv8meHl6VMrp6xXhZ2WKyhhXScZUnIMqczh58iRiY2N1ToSoVCq8/fbb+OSTTxAZGQlvb2+95GRubi7i4+Ph7e0NAPD29tY56AIgL2vaGGJrawtbW1u9cvXTH4r/+6W+f0XJbKsisdS4AcZuibFbatwAYy9u7MVZ197K3qgZG6UtJCQEU6ZMeap1Zs+ejYkTJ6Ju3bpQKpX4/PPPUa1atSfWGWJtbY1t27Zh8uTJGDNmDLZs2VKseIxhUiKksOszU1NTS+zgrTIfVFXWPzaMq2Ipz3HdfJiCd3ZfxqW8e4F0aeCB4KFNUd256Gscy3NMxcG4Ko6SiqmifScvv/wyevTooVMWGBiIl19+GRMmTAAAtG/fHomJiTh//jxatWoFADhy5AhEUUTbtm3lNu+99x5ycnJgbW0NADh06BAaNGhQopfeEhERUb5Tp049sc3mzZt1lh0cHLBjh+HZLEXVaevSpYv8+F6lUolNmzbJdQXvTXLu3Dmd5fBw3ae5Pa2nSoRoZkgIgoCFCxeiSpUqcp1KpcKZM2dMvllJQTyoIrI8uSoRX528jU8O3US2SkRVOyss7B+A4a1qmmVmGBHlS01N1TnoiIiIwMWLF+Hm5gZfX1+4u7vrtLe2toa3tzcaNGgAAGjUqBF69+6NKVOmYMOGDcjJycH06dMxatQo+alwL730EpYsWYJJkyZh7ty5uHr1KtatW4e1a9eWXaBERERU6T1VIuTChQsA1DNCrly5onMDUhsbGzRv3hzvvPOO0dvjQRURadx8mIJ3dl3CpXtJAICuDTwQPLQZvJ0r1iUCRJXVuXPn0LVrV3lZc3IkKChI7yxRYbZu3Yrp06eje/fuUCgUGDZsGD799FO53tnZGQcPHsS0adPQqlUrVKtWDQsXLuRT3oiIiKhEPVUi5OjRowCACRMmYN26dcW+ARkPqojI0CyQRQMaY1gh9wIhIvPo0qXLUz26NDIyUq/Mzc0N27ZtK3K9Zs2a4eTJk0/bPSIiIiKjmXSPEO1rd4qDB1VElu2/vFkgl/NmgXRr6InlQ5pyFghRCbt16xY2bdqEW7duYd26dfD09MSvv/4KX19fg4+nJyIiIqrMjE6EDB06FJs3b4aTkxOGDh1aZNs9e/YUu2NEVHnlqkR8eeI21v3OWSBEpe348ePo06cPOnTogBMnTmDZsmXw9PTEpUuXEBISgt27d5u7i0RERERlyuhEiLOzszxAcXJy4mCFiEzyb4x6FsiV+5wFQlQW5s2bhw8//BCzZs1C1apV5fJu3brh888/N2PPiIiIiMzD6ESI9uUwxt6/g4hIo+AsECc7Kywe2BhDWnIWCFFpunLlisFLSD09PfHo0SMz9IiIiIjIvBSmrNStWzckJibqlScnJ6Nbt27F7RMRVTL/xCRjyPpTWPXbv8hWieje0BOHZnXG0Gf5WFyi0ubi4oLo6Gi98gsXLqBGjRpm6BERERGVB48fP0aLFi3kf/Xr14eVlRXi4+MBqJ8Wu3jxYtSvXx9NmzbVedBJbGwsevfujWeeeQZNmjTBiRMnjKrTtnnzZgwePLhUYyyMSTdLPXbsGLKzs/XKMzMzeVNSIpLlqER8efwW1h2+iRyVxFkgRGYwatQozJ07F7t27YIgCBBFEX/++SfeeecdjBs3ztzdIyIiIjNxd3fHxYsX5eXVq1fj+PHjcHNzAwB8+umnuHz5Mq5evQobGxvExMTIbefNm4d27dohNDQUYWFhGDJkCCIiImBtbV1kXXnxVImQy5cvy++vX7+u80WoVCqEhoby7BIRAVDPAnln1yVcvZ8MAOjRSH0vEE8n3guEqCwtX74c06ZNQ61ataBSqRAQEACVSoWXXnoJCxYsMHf3iIiIqJwICQlBcHCwvLxq1SocOXIENjY2AABvb2+5bufOnQgPDwcAtGnTBj4+Pjh+/Dh69OhRZF1hHjx4gEGDBmHq1KmYOHEi/Pz8MHbsWBw5cgR3797Fe++9B1tbW3z11VeIjo7GRx99hFGjRpkc61MlQlq0aAFBECAIgsFLYOzt7fHZZ5+Z3BkiqvhyVCI2HLuFT4+oZ4E421tj8cAADG7BWSBE5mBjY4Ovv/4a77//Pq5evYrU1FS0bNkSzzzzjLm7RkREZNHEjAxk3b5datu3rVMHCnt7o9qeOnUKCQkJ6N+/PwD1bS8ePnyI//u//5OfMDdr1iy8+OKLePz4MXJycnQSI35+foiKiiqyrjBXrlzBqFGjsHbtWvTq1UsuT0tLw6lTpxAeHo6mTZvivffew+nTpxEWFoa+ffuWXSIkIiICkiShTp06OHv2LDw8POQ6GxsbeHp6QqlUmtwZIqrYbkQnY/Zu7VkgXlg+pAlngRCVA76+vvD19TV3N4iIiChP1u3biBw2vNS27/fjbtg3bmxU25CQEIwbNw5WVuoUQW5uLnJzc5GRkYEzZ84gMjISzz//PBo2bIiaNWuWWB+vXbuGgQMH4qeffkLz5s116l588UUAQL169WBnZ4fhw9XfVevWrREfH4/ExES4uLiY9LlPlQipXbs2AEAURZM+jIgqpxyViC+O3cJnWrNAlgxsjEEtfDgLhMgMZs2aZXTbNWvWlGJPiIiIqDC2derA78fdpbp9Y6SmpmLnzp0ICwuTy9zc3ODo6IixY8cCUM/q6NChA8LCwtC8eXNYWVkhJiZGnvkRGRkJX19fuLu7F1pniI+PD7KysnDkyBG9RIidXf7JVKVSKS9rrlLJzc018pvQZ3QiZN++fUZvdODAgSZ1hogqnusP1LNArj1QzwLpGeCFZUOawLMqZ4EQmcuFCxd0lv/++2/k5uaiQYMGAID//vsPSqUSrVq1Mkf3iIiICIDC3t7oGRulaceOHWjevDkaNmyoUz569GiEhobi9ddfR3x8PM6ePYvZs2cDAEaMGIENGzZg8eLFCAsLw/3799G5c+cn1hXk6uqKLVu2oH///khJScHChQtLN9g8RidCjH2sjSAIUKlUpvaHiCqIHJWI9UfVs0ByRQkuVdSzQAY25ywQInM7evSo/H7NmjWoWrUqvv32W7i6ugIAEhISMGHCBLzwwgvm6iIRERGVEyEhIZgyZYpeeXBwMCZMmID169cDAObOnYvnnnsOALBixQq8/PLLeOaZZ2BjY4Pvv/9efipMUXWGVK1aFaGhoRgyZAhmz56NVatWlUKUuoxOhPByGCLSuP5A/USY69HqWSC9ArzwIWeBEJVLH3/8MQ4ePCgnQQD12ZcPP/wQvXr1wttvv23G3hEREZG5nTp1ymC5u7t7oVeGeHl54eDBg09dp238+PEYP348APWDV0JDQ+W6yMhInbaPHj3SWS7OZTHAU94jhIgsW3auiPXHwvH5kXDOAiGqIJKTkxEXF6dXHhcXh5SUFDP0iIiIiMi8TE6EpKWl4fjx44iKikJ2drZO3YwZM4rdMSIqX649SMI7uy7jRt4skMDGXvhwcFN4VLU1c8+IqChDhgzBhAkT8PHHH8vTWc+cOYPZs2dj6NChZu4dERERUdkzKRFy4cIF9O3bF+np6UhLS4ObmxsePXqEKlWqwNPTk4kQokokO1fE/46G439H1bNAXKtYY8mgJhjQrDpngRBVABs2bMA777yDl156CTk5OQAAKysrTJo0qUyuwSUiIiIqb0xKhLz11lsYMGAANmzYAGdnZ/z111+wtrbG2LFj8eabb5Z0H4nITArOAund2BsfDG7CWSBEFUiVKlWwfv16rFq1Crdu3QIA1K1bFw4ODmbuGREREZF5mJQIuXjxIr788ksoFAoolUpkZWWhTp06WLlyJYKCgjjVlqiCy84V8fnRcKzXmgWydFAT9OcsEKIKy8HBAc2aNTN3N4iIiIjMzqREiLW1NRQKBQDA09MTUVFRaNSoEZydnXH37t0S7SARla2r95Pwzq5L+CdGfRNFzgIhqti6du1aZALzyJEjZdgbIiIiIvMzKRHSsmVLhIWF4ZlnnkHnzp2xcOFCPHr0CFu2bEGTJk1Kuo9EVAayc0V8fuQm1h+7hVxRgpuDDZYOaox+TTkLhKgia9Gihc5yTk4OLl68iKtXryIoKMg8nSIiIiIyI5MSIcuXL5cfubds2TKMGzcOU6dOxTPPPIONGzeWaAeJqGSpRAlnbj9G+L141EtVom2dargRnawzC6RPE/UskGqOnAVCVNGtXbvWYPnixYuRmppaxr0hIiKi8uLx48fo3r27vJyeno7bt28jNjYWbm5uOHv2LGbMmIGsrCxkZmZiwoQJmDNnjtx20qRJCAsLg0KhwPLlyzF8+PAn1mk7duwYZs6ciYsXL5ZJvNpMSoS0bt1afu/p6YnQ0NAS6xARlZ7Qq9FY8vN1RCdl5pVEwNFWifRsFUQJcHOwwQeDmqBfs+pm7ScRlb6xY8fiueeew+rVq83dFSIiIjIDd3d3nSTE6tWrcfz4cbi5uQEAXnnlFSxduhQDBw5EfHw8GjZsiP79+yMgIACrV6+Gra0twsPDERERgbZt26Jr165wd3cvsq68MCkRQkQVT+jVaEz9/m9IBcpTs1QAgGd9XfDVuNacBUJkIU6fPg07Oztzd4OIyOJIkgSIIiCK+e8lCZAkSKIEoEBZ3ivy2uosy2XQWU8SRaBgmSTll6lXgKhSITc+HpmPHkO+ElqCXK/dVv48TQzyQaXhNk9U1KXXptZBUP9f00YQ8v/J9eo2kiRBtLUFPD2N668FCAkJQXBwsLwsCAISExMBAGlpabCxsZGTJDt27EBISAgAwN/fH126dMHevXsxefLkIusKk5ycjOHDh6Njx45YuHAhunTpglatWiEsLAyRkZEICgpC+/btsXz5cty7dw8zZszArFmzTI6ViRAiC6ASJSz5+bpeEkRbdFImXKvYlFmfiKhsFHySmyRJiI6Oxrlz5/D++++bqVdEZA7yoFulgiSKkHJVgKiCpFIBoggxNxdibBxycnIhQFK3U+XXa14166vrxbxtaL1Kot46kkoFqERIou5roesWbCtK6jZiXr8kUbdOq0y9DdFge4hift/lbYjIycpCulIpJyjUyQUx73ONe6+T2CjifXmUYu4OmInD4kVA3bpm+/ycbBUSY9JLbfsu3lVgbaM0qu2pU6eQkJCA/v37y2WbNm3CoEGDsGDBAsTFxeHLL7+Et7c3ACAqKgq1a9eW2/r5+SEqKuqJdYbcvXsXgwcPxptvvolx48bJ5Xfu3MHRo0eRnJwMPz8/JCQk4OTJk3jw4AEaNGiAiRMnwsXFxaj4CmIihMgCnI2I17ocxrDopEycjYhH+7rlZ8oaERWfk5OTzg2PFQoFGjRogKVLl6JXr15Gb+fEiRNYtWoVzp8/j+joaOzduxeDBw8GoL4B64IFC/DLL7/g9u3bcHZ2Ro8ePfDRRx/Bx8dH3kZ8fDzeeOMN/Pzzz1AoFBg2bBjWrVsHR0dHuc3ly5cxbdo0hIWFwcPDA2+88YZ8PTJVbjqDRs1r3qBWPWiV8gfgeu1U6rPQqryBr1ignTwo1mqv96peT8zNRVZCIpIcHSBIklxX6MBds10Dg3yDr7mqJ7dT5RZZD1EFqYjtyAmMAkkLYwfhSaX8s4YgAEolBIVC/1WhAJQKCAql/qtCodtG0F2vyDorawg2mjIBUCghKBWAoK4Xs7Jg5+AAQeezBLle+z0Ugnr7mvcKzXYEg+vqt9F6LwjqNhD0lwWtMiFvewLy1i9QZmg7OtvSbgN5hoQkSYhPSICbmxsEhUJ3JoXmVXs2BQCDMy6018n7vCIVOWmkiMqiZpsYnLFiYKZK3uwYSZKQaGvemdCJMenYuTys1LY/8t028PCtalTbkJAQjBs3DlZW+SmCjz76CMHBwXjppZdw+/ZtdO7cGa1bt0ZAQECJ9fHhw4fo1KkTvvnmG537lQDA8OHDoVQq4erqijp16qB///4QBAE1atSAh4cHIiMj9W4KbyyzJkJ4UEVUNh4kGpdpjk0pOllCRBXP5s2bS2Q7aWlpaN68OSZOnKg3yyQ9PR1///033n//fTRv3hwJCQl48803MXDgQJw7d05uN2bMGERHR+PQoUPIycnBhAkT8Morr2Dbtm0A1NNie/XqhR49emDDhg24cuWKfLbnlVdeKZE4nkZufDwebdiA9PQMxFax10koSfIBtVxg+BWSVtsnrFNYW3kKvJh/cK9JGmjWEbWmySNver3W1HlJ0kyzf8K6mgGCqEJOVjYylErd6fhPe6ZcQtFnx7USHEZPpy8jOntOQwP2ggNwQ/VKBWBoQK9UQFBa6dUL1tYQbAtpr1ACVkrD5TrbVeYN8g2Va9dr+phfLgkCklJS4OLmBoWVlbqdlYH1Cr4aiB2CoP9Zmjbl7Gl0oigiNjYWnp6eUGgSBRZCFEVYxcbCzkJjV8TGmrUPLt5VMPLdNqW6fWOkpqZi586dCAvLT8o8evQIe/fuxfbt2wEAderUQbt27fDnn38iICAAvr6+uHPnDqpXV99bMDIyUj7BUlSdXh9dXFCvXj3s378f3bp10/n7oH0Jr1Kp1FvOzc01Kj5DzJoIscSDKqKydvleIj75/aZRbT2r8n4BRJVNnTp1EBYWpneDssTERDz77LO4ffu2Udvp06cP+vTpY7DO2dkZhw4d0in7/PPP8dxzzyEqKgq+vr64ceMGQkNDERYWJt90/bPPPkPfvn2xevVq+Pj4YOvWrcjOzsbGjRthY2ODxo0b4+LFi1izZo1Z9tlSZibSTp1Gbm4u0qysDFyWbuDMqcFXQChuW4Uiv05e1pzl1T47nHc2GFrLSiUEQTP4fMK6AiAo1ANiMSsLtg5V8s5wFzgDrjkTbeyZckEwcHa9wFl5peaMfv4ZeyjyBtOCIm/grX3m/ynbac84KGIgLwGIexwPTy9PKKyt1dspZwP30iKKItJjY+FggYNiInOwtlEaPWOjNO3YsQPNmzdHw4YN5TJXV1c4ODjgyJEj6NatGx49eoQzZ87I9+UYMWIENmzYgHbt2iEiIgLHjh3D+vXrn1hXkK2tLfbs2YOxY8diypQp+Oqrr8rk74/RiZBPP/3U6I3OmDHDqHaWeFBFVFayclX49PBNbDh+GypRgkJQn6QzRADg7WyH5/zdyrSPRFT6IiMjoVKp9MqzsrJw//79UvvcpKQkCIIgX7t7+vRpuLi46Dx5rkePHlAoFDhz5gyGDBmC06dPo1OnTrCxyb9fUWBgIFasWIGEhAS4urqWWn8Nsfbxgf++/7PIM8WWfoZcSE2FYGOjTo4QEVVyISEhmDJlik6ZUqnEzp07MXv2bOTm5iInJwczZ85E+/btAQCzZ8/GxIkTUbduXSiVSnz++eeoVq3aE+sMsba2xrZt2zB58mSMGTMGW7ZsKb1g8xidCFm7dq1R7QRBMDoR8rQqw0EVUVm4fC8R7+y6hP8epgIA+jerjs71PTBn92UAuldeas5xLRoQAKXCMs54EVmCffv2ye9/++03ODs7y8sqlQqHDx+Gn59fqXx2ZmYm5s6di9GjR8PJyQkAEBMTA88Cd+a3srKCm5sbYmJi5Db+/v46bby8vOS6wvbZWVlZyMrKkpeTk5MBqAe0YjFvTCjmXcZR3O1UNJYaN8DYLTF2S40bYOwlEXtl+O5OnTplsLxHjx44f/68wToHBwfs2LHjqeu0denSRX58r1KpxKZNm+S6Y8eO6bTVvioEAMLDw5+4/aIYnQiJiIgo1gcVV2U5qKqsf2wYV/mQlavCZ0du4csT6lkg7g42WDqoMfo0Ud/d2cFGiaX7byAmOf9eIN7Odni/XyP0CvCqMHEaUtF+VsZiXBVHScZUEtvQ3HNLEAQEBQXp1FlbW8PPzw8ff/xxsT+noJycHIwcORKSJOGLL74o8e0bEhwcjCVLluiVx8XFITOzePc+EkURSUlJkCTJomZGWGrcAGO3xNgtNW6AsZdE7CkplvrMnYqtQjw1pjIdVFXWPzaMy/xuPEzDBwcjcfux+vezZ31XvN3VFy72CsTm3QjqWU8FfhwfgAv3knE3Lhm1PJzQsqYTlApBblNRVaSf1dNgXBVHScZUEgdVmmSKv78/wsLCipySWlI0++s7d+7gyJEj8okLAPD29tb7O5Obm4v4+Hj5UXze3t54+PChThvNsqaNIfPnz5evWQbUJy9q1aoFDw8PnT6YQhRFCIIADw+PSvO7agxLjRtg7JYYu6XGDTD2kohd+waeVHGYnAi5d+8e9u3bh6ioKGRnZ+vUrVmzptgd06hsB1WV9Y8N4zIf9b1AwvHVyQh5FsgHgxqjd5PCf7+9PD0QFxdXruN6WhXhZ2UKxlVxlGRMJXlQVVYzOjX765s3b+Lo0aN6N2dt3749EhMTcf78ebRq1QoAcOTIEYiiiLZt28pt3nvvPeTk5MDa2hoAcOjQITRo0KDIS1ltbW1ha+ARiAqFokR+vwRBKLFtVSSWGjfA2C0xdkuNG2DsxY3dEr+3ysCkRMjhw4cxcOBA1KlTB//88w+aNGmCyMhISJKEZ599tsQ6V1kPqirrHxvGVfYu3VXfC+RmrPpeIAOa+2DJwMZwc7B5wprlOy5TVcaYAMZVkZRUTMVd/9NPP8Urr7wCOzu7J97s3Nj7eqWmpupcjxsREYGLFy/Czc0N1atXx/Dhw/H3339j//79UKlU8iWqbm5usLGxQaNGjdC7d29MmTIFGzZsQE5ODqZPn45Ro0bBx8cHAPDSSy9hyZIlmDRpEubOnYurV69i3bp1Rt+njIiIiMgYJiVC5s+fj3feeQdLlixB1apV8eOPP8LT0xNjxoxB7969jd4OD6qITJOVq8K632/K9wKp5miDDwc3Qe8m1c3dNSIqB9auXYsxY8bAzs6uyP3d09zg/Ny5c+jatau8rJk1GRQUhMWLF8s3Z23RooXOekePHkWXLl0AAFu3bsX06dPRvXt3KBQKDBs2TCdR4+zsjIMHD2LatGlo1aoVqlWrhoULF/Ipb0RERFSiTEqE3LhxAz/88IN6A1ZWyMjIgKOjI5YuXYpBgwZh6tSpRm2HB1VET6/gLJCBzX2w2MhZIERkGbQvhympS2O6dOkCSSrkGdxAkXUabm5u2LZtW5FtmjVrhpMnTz51/4iIiIiMZdLcWwcHB/m+INWrV8etW7fkukePHhm9Hc1BVcF/mzdvhp+fn8E6SZLkJAiQf1CVkpKCpKQkbNy4EY6OjjqfozmoyszMxL179zB37lxTwiYyq8wcFVaE/oMh6//EzdhUVHO0wYaxrfDp6JZMghBRoZYuXYr09HS98oyMDCxdutQMPSIiIqLy4pdffsGzzz6LFi1aoEmTJvj222/lutjYWPTu3RvPPPMMmjRpghMnThS7TtvmzZvlp9yVNZMSIe3atcMff/wBAOjbty/efvttLFu2DBMnTkS7du1KtINEBFy8m4gBn/2BL47dgiipZ4EceqtzkTdEJSICgCVLliA1NVWvPD093eDT0YiIiMgySJKEsWPHYvPmzbh48SL279+PV199VX563bx589CuXTvcvHkTmzZtwksvvYScnJxi1ZUXJiVC1qxZI9+MdMmSJejevTt27NgBPz8/hISElGgHiSxZZo4KH/36D4bKs0Bs5VkgrpwFQkRGkCQJgiDolV+6dAlubm5m6BERERGVF4IgIDExEYD6Sanu7u7yQ0N27tyJ1157DQDQpk0b+Pj44Pjx48WqK8yDBw/Qpk0bbNy4EQDg5+eHBQsW4Pnnn0etWrWwYcMGbNq0Ce3bt4efnx+2b99erLhNukdInTp15PcODg7YsGFDsTpBRPou5t0LJDzvXiCDWvhg8YDGTIAQkVFcXV0hCAIEQUD9+vV1kiEqlQqpqanyQQoRERGVvZysTMTfv1dq23erURPWtnaF1guCgB07dmDo0KFwcHBAQkIC9uzZAxsbGzx+/Bg5OTnw9s6fge7n54eoqCiT6wpz5coVjBo1CmvXrkWvXr3k8rS0NJw6dQrh4eFo2rQp3nvvPZw+fRphYWHo27cvRo0aZepXY1oiRCM7OxuxsbEQRVGn3NfXtzibJbJomTkqfPL7TXx1Qn0ZTDVHWywb0gSBjXkZDBEZ75NPPoEkSZg4cSKWLFkCZ2dnuc7GxgZ+fn5o3769GXtIRERk2eLv38P382eW2vbHBn8Crzr1Cq3Pzc3Fhx9+iD179qBTp04ICwvDwIEDceXKFYOzSUvDtWvXMHDgQPz0009o3ry5Tt2LL74IAKhXrx7s7OwwfPhwAEDr1q0RHx+PxMREuLi4mPS5JiVC/vvvP0yaNAmnTp3SKddMv1WpVCZ1hsjSXYhKwOzdlzkLhIiKLSgoCADg7++P559/HtbW1mbuEREREWlzq1ETY4M/KdXtF+XixYt48OABOnXqBEB9GUvNmjVx4cIF9OzZE1ZWVoiJiZFnd0RGRsLX1xfu7u4m1Rni4+ODrKwsHDlyRC8RYmeXP5tFqVTKy5oZr7m5uSZ8K2omJUImTJgAKysr7N+/H9WrVy+zbBFRZZWZo8La3//D1yducxYIERVbcnKy/L5ly5bIyMhARkaGwbZOTk5l1S0iIiLSYm1rV+SMjdJWq1YtREdH48aNG2jUqBHCw8Nx69YtNGjQAAAwYsQIbNiwAYsXL0ZYWBju37+Pzp07F6uuIFdXV2zZsgX9+/dHSkoKFi5cWCaxm5QIuXjxIs6fP4+GDRuWdH+ILM6FqAS8s+sSbsWlAQAGt/DB4oGN4VKFs0CIyDQuLi5PPEnBWZxERESWzcvLC1999RVGjhwJhUIBURTx+eefy7M3VqxYgZdffhnPPPMMbGxs8P3338szTE2tM6Rq1aoIDQ3FkCFDMHv2bKxatarUYzcpERIQEIBHjx6VdF+ILIqhWSDLhzRBL84CIaJiOnr0qLm7QERERBXA6NGjMXr0aIN1Xl5eOHjwYInWaRs/fjzGjx8PALC3t0doaKhcFxkZqdO2YP6hOJfFACYmQlasWIE5c+Zg+fLlaNq0qV52h9NsiYr2d1QCZmvNAhnSsgYWDQjgLBAiKhGFTT8t6OrVq6XcEyIiIqLyx6RESI8ePQAA3bt31ynnNFuiomXmqLD20H/4+qR6FohHVVssH9IUPQO8zN01IrIQKSkp+OGHH/DNN9/g/Pnz3GcTERGRxTEpEcIpt0RPj7NAiMicTpw4gZCQEPz444/w8fHB0KFD8b///c/c3SIiIiIqcyYlQoydcktE6lkgaw79h284C4SIylhMTAw2b96MkJAQJCcnY+TIkcjKysJPP/2EgIAAc3ePiIiIyCyMToRcvnwZTZo0gUKhwOXLl4ts26xZs2J3jKgy+DvviTC382aBDG1ZAws5C4SIysCAAQNw4sQJ9OvXD5988gl69+4NpVKJDRs2mLtrRERERGZldCKkRYsWiImJgaenJ1q0aAFBECBJkl473iOEyPAskOAhTdGDs0CIqIz8+uuvmDFjBqZOnYpnnnnG3N0hIiIiKjeMToRERETAw8NDfk9Ehp2/k4DZu7VmgTxbAwv7cxYIEZWtP/74AyEhIWjVqhUaNWqEl19+GaNGjTJ3t4iIiIjMTmFsw9q1a0MQBPl9Uf+ILFFmjgrLDlzH8A2ncDsuDZ5VbfHNuNZYM7IFkyBEVObatWuHr7/+GtHR0Xj11Vexfft2+Pj4QBRFHDp0CCkpKebuIhEREZnZL7/8gmeffRYtWrRAkyZN8O2338p1EyZMQP369dG8eXN06NABYWFhcl16ejpGjx6NevXqoX79+ti9e7dRddqOHTuGFi1alFpsRTHpZqkA8ODBA/zxxx+IjY2FKIo6dTNmzCh2x4gqkvN34jF712XcfpQ/C2RR/8ZwrmJt5p4RkaVzcHDAxIkTMXHiRPz7778ICQnBRx99hHnz5qFnz57Yt2+fubtIREREZiBJEsaOHYtjx46hWbNmiIyMRMOGDTF06FBUrVoVQ4YMwddffw0rKyvs378fI0aMQGRkJABg9erVsLW1RXh4OCIiItC2bVt07doV7u7uRdaVFyYlQjZv3oxXX30VNjY2cHd3l2eKAOp7hDARQpYiM0eFjw/+i2/+iIAkAZ5VbRE8tCm6N+K9QIio/GnQoAFWrlyJ4OBg/Pzzz9i4caO5u0RERERmJAgCEhMTAQDJyclwd3eHra0tAGDgwIFyu3bt2uH+/fvIzc2FlZUVduzYgZCQEACAv78/unTpgr1792Ly5MlF1hUmOTkZw4cPR8eOHbFw4UJ06dIFrVq1QlhYGCIjIxEUFIT27dtj+fLluHfvHmbMmIFZs2aZHLdJiZD3338fCxcuxPz586FQGH11DVGlwlkgRFRRKZVKDB48GIMHDzZ3V4iIiCyWmK1CblxGqW3fysMeChtlofWCIGDHjh0YOnQoHBwckJCQgD179sDGRv+y/nXr1qFv376wslKnEKKionRui+Hn54eoqKgn1hly9+5dDB48GG+++SbGjRsnl9+5cwdHjx5FcnIy/Pz8kJCQgJMnT+LBgwdo0KABJk6cCBcXF6O/D20mJULS09MxatQoJkHIImXmqLD6t38R8qd6FoiXky2WD+EsECIiIiIiMl5uXAZiP7tQatv3fKMlbGo4Fv75ubn48MMPsWfPHnTq1AlhYWEYOHAgrly5gmrVqsntvv/+e+zcuRMnTpwo8T4+fPgQnTp1wjfffIPu3bvr1A0fPhxKpRKurq6oU6cO+vfvD0EQUKNGDXh4eCAyMtLke4yYlAiZNGkSdu3ahXnz5pn0oUQVgUqUcOb2Y4Tfi0e9VCXa1qmGC1EJmLM7fxbIsGdrYmH/AM4CISIiIiKip2LlYQ/PN1qW6vaLcvHiRTx48ACdOnUCALRp0wY1a9bEhQsX0LNnTwDAjh07sGTJEhw+fBheXvknfn19fXHnzh1Ur14dABAZGYlevXo9sa4gFxcX1KtXD/v370e3bt10brthZ2cnv1cqlXrLubm5Rn8XBZmUCAkODkb//v0RGhqKpk2bwtpadxC4Zs0akztEVB6EXo3Gkp+vIzopM68kAg42SqRlqwCoZ4EED22Kbg05C4SIiIiIiJ6ewkZZ5IyN0larVi1ER0fjxo0baNSoEcLDw3Hr1i00aNAAALBz504sWLAAv//+O3x9fXXWHTFiBDZs2IB27dohIiICx44dw/r1659YV5CtrS327NmDsWPHYsqUKfjqq6/K5MoTkxMhv/32m/wFFbxZKlFFFno1GlO//xtSgXJNEqR9HXdsGNuKs0CIiIiItEiSBFESIUoiVJLK8Kuou1ywvSiJECFCFPNeC2sj6ddJkmS4TYHtafopQZL7lJKaAvsYe0iCpBOHpo1cBtFgvfY/CXnbyGsrSRI0/xMlUee70rTVrpfLNOWSgboC66k3Cvm9pk5drG6r87PSKsvJyYHSSgkI0GmneS9v3wABhsd+xo4JC2snaP4nCPJnaN4XLIfwhPZa6+Wvon4zouYI9PDsYVRfKyMvLy989dVXGDlyJBQKBURRxOeffy4nPcaMGQNvb28MGjRIXufw4cNwd3fH7NmzMXHiRNStWxdKpRKff/65fDlNUXWGWFtbY9u2bZg8eTLGjBmDLVu2lG7gMDER8vHHH2Pjxo0YP358CXeHyLxUooQlP18v4s89EPk4DY52Jj95moiIiMqRgoPnXFUu0nLSkJSVBEnIHygXObiXVBBFw4P+otYpdLt55blSrsFynToD2zDUH+1y7fa5Uq5O26ycLCiUCuPiK/CqGeSXNwpBAQUU6ldBAUEQ5DLNe0iAUqEstF4hKCBA0N2G1ja1y7QH4Jr1dAbkQv577XqFoICVYCVvS9P3gutqPkNTD0Bv8K+haScnAqCffMhIz0CVKlXyt1VgG4bW0VYwyWKMopIrBRM9OmVaCRxDSaGCbbWXNYki7USTlYLH9KNHj8bo0aMN1uXk5BS6noODA3bs2PHUddq6dOmCixcvAlBf6rJp0ya57tixYzptz507p7McHh7+xO0XxaSfvK2tLTp06FCsDyYqj85GxGtdDmNYdFImzkbEo33d8vMcbCKi0nbixAmsWrUK58+fR3R0NPbu3avz1BlJkrBo0SJ8/fXXSExMRIcOHfDFF1/gmWeekdvEx8fjjTfewM8//wyFQoFhw4Zh3bp1cHTMnxZ8+fJlTJs2DWFhYfDw8MAbb7yBOXPmlGWosszcTNx4fAMJiQmIFqINDgS0D7Q1y4WdRS14hrbgenlv9M7iFvmqdZZYs26hZ40NnF3W7pfeGfKUFFSJq5J/druIs+HGnC2XIEElqtSvRZzZN3Q2X04AFDJToKiZAYYG69rJg6IGZGVJM5hWCsr8AbEif1mnTmGlsyy/KpT6ZVp11gprKKx067TXUUCBrMwsOFZxVCcFFAa2Y2C7hsrl90/YhiAIBtfV3oamjXbbgm0Klsnr5iUPiiKKImJjY+Hp6WlxD4Ng7LHm7gaZiUmJkDfffBOfffYZPv3002J9uCUeVFH5dj8h3ah2sSlFJ0uIiCqbtLQ0NG/eHBMnTsTQoUP16leuXIlPP/0U3377Lfz9/fH+++8jMDAQ169fl29uNmbMGERHR+PQoUPIycnBhAkT8Morr2Dbtm0AgOTkZPTq1Qs9evTAhg0bcOXKFfnReK+88kqZxgsAsemxGBc67skNKyBD08U1g0nNmWlTz5AXrNc+c15wQKs3wIVCPVg3MKh90qBXAQUUCt0z/4UN1gsb0AtQ9zU1JRWuzq5QKotOLBSZIMhLMujV5SUGNP+0vz9zs+RBMRFZFpMSIWfPnsWRI0ewf/9+NG7cWO9mqXv27DFqO5Z4UEXl17nIeKw++J9RbT2r2j25ERFRJdKnTx/06dPHYJ0kSfjkk0+wYMEC+Tri7777Dl5eXvjpp58watQo3LhxA6GhoQgLC0Pr1q0BAJ999hn69u2L1atXw8fHB1u3bkV2djY2btwIGxsbNG7cGBcvXsSaNWvMss+u7lAdewbsQXx8PNzc3PQGhtrXp2sva5+B1i7TtC04Pb1gG517r2mmzmu11Zkqb+Ca+YJT7jWfqb3ek1jygNiSYycishQmJUJcXFwMJi6eliUeVFH5k5GtwuqD/2LjnxGQJEAhAGIhs2QFAN7OdnjO361M+0hEVJ5FREQgJiYGPXrk33DO2dkZbdu2xenTpzFq1CicPn0aLi4u8v4aAHr06AGFQoEzZ85gyJAhOH36NDp16gQbGxu5TWBgIFasWIGEhAS4uroa/PysrCxkZWXJy8nJyQDUA1pRNP2eBUpBCX8nfzhmOcLDyaPiD4ol3Ut3iiKKeZe4FOP7q6gYu+XFbqlxA4y9JGK3xO+uMnjqREhubi66du2KXr16wdvbuzT6BMD8B1VkGcIi4zFn92VEPEoDAIxoVRPt6rrjnZ2XAEDnqmHN+bNFAwKgVJh/+ioRUXkRExMDQH33eW1eXl5yXUxMDDw9PXXqrays4ObmptPG399fbxuausL22cHBwViyZIleeVxcHDIzi3cpoyiKSEpKgiRJFT8R8hQsNW6AsVti7JYaN8DYSyL2lJSUEuwVlZWnToRYWVnhtddew40bN0qjPzJzH1SV1tmlypp1rWhxZWSrsPrQf9h8KhKSBHg72WLZkCbo2kD9+2RvpcDS/TcQk5x/AO3tbIf3+zVCrwCvChNnYSraz8sYlTEmgHFVJCUZU2X6XsrC/PnzMWvWLHk5OTkZtWrVgoeHB5ycnIq1bVEUIQgCPDwqwYyQp2CpcQOM3RJjt9S4AcZeErFrbtlAFYtJl8Y899xzuHDhAmrXrl3S/Sk3SuvsUmXNulakuC7eT8WyQ5G4m6hOdPUPcMebnWqiqh3kO0c/66nAj+MDcOFeMu7GJaOWhxNa1nSCUiFUirtLV6Sfl7EqY0wA46pISjKminZ2STND9OHDh6hevbpc/vDhQ7Ro0UJuU/DvZ25uLuLj4+X1vb298fDhQ502muWiZqHa2trC1tZWr1yhUJTI75cgCCW2rYrEUuMGGLslxm6pcQOMvbixV/Tv7ZdffsGCBQsgiiJyc3Mxe/ZsBAUF6bQ5cuQIevbsiY8//hgzZ84EAKSnp2PSpEkICwuDQqHA8uXLMXz48CfWaTt27BhmzpwpP0K3LJmUCHn99dfx9ttv4969e2jVqhUcHBx06ps1a1bsjpn7oKq0zi5V1qxrRYjrSbNADPHy9EBcXFy5jssUFeHn9bQqY0wA46pISjKminZ2yd/fH97e3jh8+LC8j05OTsaZM2cwdepUAED79u2RmJiI8+fPo1WrVgDUB1aiKKJt27Zym/feew85OTnyjdgPHTqEBg0a8FJWIiKiEiZJEsaOHYtjx46hWbNmiIyMRMOGDTF06FBUrVoVAJCUlIR58+ahb9++OuuuXr0atra2CA8PR0REBNq2bYuuXbvC3d29yLrywqREyKhRowAAM2bMkMsEQYAkSRAEASqVqtgdM/dBVWmeXaqsWdfyHJehe4Es6B8AZ3vrJ6xZvuMqjsoYV2WMCWBcFUlJxVQev5PU1FSEh4fLyxEREbh48SLc3Nzg6+uLmTNn4sMPP8QzzzwjP+nNx8cHgwcPBgA0atQIvXv3xpQpU7Bhwwbk5ORg+vTpGDVqFHx8fAAAL730EpYsWYJJkyZh7ty5uHr1KtatW4e1a9eaI2QiIqJKTxAEJCYmAlCPt93d3XXGwdOnT8eCBQv0ngy7Y8cOhISEAFCP3bt06YK9e/di8uTJRdYVJjk5GcOHD0fHjh2xcOFCdOnSBa1atUJYWBgiIyMRFBSE9u3bY/ny5bh37x5mzJihM3HhaZmUCImIiDD5A7XxoIpKW0a2Cqt++xebTkXkzQKxQ/CwpkXOAiEiIn3nzp1D165d5WXNwUdQUBA2b96MOXPmIC0tDa+88goSExPRsWNHhIaG6sxu2bp1K6ZPn47u3btDoVBg2LBh+PTTT+V6Z2dnHDx4ENOmTUOrVq1QrVo1LFy4kE95IyKiSik7OxuPHj0qte1Xq1ZN56EhBQmCgB07dmDo0KFwcHBAQkIC9uzZI6+ze/duKBQKDBw4UC8REhUVpXOrDD8/P0RFRT2xzpC7d+9i8ODBePPNNzFu3Di5/M6dOzh69CiSk5Ph5+eHhIQEnDx5Eg8ePECDBg0wceJEuLi4PNV3omFSIqSk7g3CgyoqTWGR8Zi96xIiH6cDAEa2ron3+hk3C4SIiHR16dKlyMeuCoKApUuXYunSpYW2cXNzw7Zt24r8nGbNmuHkyZMm95OIiKiiePToEb766qtS2/4rr7wiTxAwJDc3Fx9++CH27NmDTp06ISwsDAMHDsSVK1fkumPHjpVa/wD1bSs6deqEb775Bt27d9epGz58OJRKJVxdXVGnTh30798fgiCgRo0a8PDwQGRkpHz1yNMyKRECAFu2bMGGDRsQERGB06dPo3bt2vjkk0/g7++PQYMGGbUNHlRRaeAsECIiIiIiKu+qVatWqifoq1WrVmT9xYsX8eDBA3Tq1AkA0KZNG9SsWRMXLlxAdnY2oqOj5UTDo0ePsG/fPsTFxWHZsmXw9fXFnTt35Pt5RkZGolevXgBQZF1BLi4uqFevHvbv349u3bpBEAS5TnsChFKp1FvOzc19ym8kn0mJkC+++AILFy7EzJkzsWzZMvmeIC4uLvjkk0+MToQQlTTOAiEiIiIioorAxsamyBkbpa1WrVqIjo7GjRs30KhRI4SHh+PWrVto0KABfH19dR46Mn78eLRo0UJ+asyIESOwYcMGtGvXDhERETh27BjWr1//xLqCbG1tsWfPHowdOxZTpkzBV199VSb3SjPpEz777DN8/fXXeO+996BUKuXy1q1b48qVKyXWOSJjZWSrsPTn6xj55WlEPk6Ht5MdNk1og5XDmzMJQkRERET0/+3dd3gU5doG8Hs3gTRSCCQkgZAQSEgCIQlFehOQXj1HqrQjcjgUEctBpUuxIFL0owjSwXIQFEUIgiIK0ov0XpQWSEJ6232+P8IOu2mUlC1z/66Li913yr737mZ355l3ZohyqVSpEpYsWYIXXngBkZGR6NmzJz755BNUrVr1kcu+8cYbSEtLQ/Xq1dG+fXt88sknygiUwqblp0yZMli3bh10Oh369+9fpJEej+upT5YaHR2dp93BwQEpKSlF7hTRk+AoECIiIiIioifXt29f9O3b95HzrVixwuS+i4sLvvzyy3znLWyasVatWuHo0aMAcg51Wb58uTIt97lJDh48aHLf+KIrT+OpCiHVqlXD0aNH85w0devWrQgLCytSh4geV+5zgfi6O2JWrwi04rlAiIiIiIiIqABPVAiZNm0aXn/9dYwbNw4jR45Eeno6RAT79+/H+vXrMWvWLCxdurSk+kqkyG8UyIQu4XBz5CgQIiIiIiIiKtgTFUKmTp2Kf//733jppZfg5OSECRMmIDU1Ff369YOfnx/mzZuHPn36lFRfiZCWqcMH285gxZ4rHAVCRERERERET+yJCiHGl7rt378/+vfvj9TUVCQnJ8PbmxuiVLL2X47DG/87hqscBUJERERERFbIeJuaiteTPLdPfI4Q4+v6AoCzszOcnZ2fdDVEj42jQIiIiIiIyJoZrraamZkJJycnM/fGNmVmZgKAyZVtC/LEhZCQkJA8xZDc4uLinnS1RPnKPQqkd31/vNMljKNAiIiIiIjIatjb28PZ2RmxsbEoU6YMtFqtubtkU/R6PWJjY+Hs7Ax7+0eXOZ64EDJ16lS4u7s/VeeIHhdHgRARERERka3QaDTw9fXF5cuXcfXqVXN3xyZptVpUrVr1kQM3gKcohPTp04fnA6ESxVEgRERERERka8qWLYvg4GDlEA4qXmXLln3skTZPVAh5nMoK0dPiKBAiIiIiIrJlWq0Wjo6O5u6G6j31VWOIihNHgRAREREREVFpeKJCiF6vL6l+kEqlZmbjg61nsXIvR4EQERERERFRyXvic4QQFZfco0D6NPDH2505CoSIiIiIiIhKDgshVOryGwXy3vN10DLEy9xdIyIiIiIiIhvHQgiVKo4CISIiIiIiInNiIYRKBUeBEBERERERkSVgIYRKHEeBEBERERERkaVgIYSKTKcX7Lt0Dxf+ikONZDs0DKoIO60mzygQP3dHzOIoECIiIiIiIjIjFkKoSLaeuImpm0/h5v30By2X4evuiL7PVMWGw39xFAgRERERERFZFBZC6KltPXETI9YchuRqv3k/HXO2nwOQMwrkvefroAVHgRARERFRcRIB9DpA9Ln+Gdokn2m5/wmgy4ZdXCyAuw/Wm2u68X3Iw3bj28o0GN2WwpdR5hHTZQy/rot8G4W3P7jvnJwElHMFtNp8nmRN/s+9poD2fOfTPOH/yL+twGW0Obc1WqP72pyu52kzmg+ARu8OwPvxspBNYSGEnopOL5i6+VSeIogx57J2+OGV5ijvXLbU+kVERERkcZQNdh2gzza6rc+nTWd6W/lfn3c+wzr02Y/RVtA69Mp9jS4b5VKSoHF0BKDP/7HyrLOAdqVAkft2rmKFYRnRP1yP0p7PMsbtxUQLwHp32eUqHgAPCwT53jaa78EtV4hRWwG/7nMXUB5OKLhrxsWe3EUeC6AF4ND2YyAg1NxdITNgIYSeyv7LcUaHw+QvNVOHMzeT0Lh6hVLqFRERmZNOp8OUKVOwZs0a3Lp1C35+fhg8eDAmTJgAzYMf4CKCyZMn47PPPkNCQgKaNm2KhQsXIjg4WFlPXFwcRo8ejc2bN0Or1eL555/HvHnzUK5cOXNFs3zKXuv89jjn3vtsvLe6gD3meh3sEmMB++QH63/EHvVH7nV/uN68G7q5NnoLm5Z7739+6yuwiJBfu+Rp0+h18MxMh8ZOm/dx81uHye3svPPps2H+jT8NoLUDtPaAxi7ntkb74H87o/+1cNQDKFM2T7vp/QKWt3cocL3Q5FpGua0xXadyW1PIMtq8tw3TDXv8TaYZ/9PkadMLEJ9wH+UrVIRWa5/vPCZthuJDgSMSco9OMNxH/tPy3H5EIeNxR2M8BtHrcefOHXh7e0OT74iQEiL5FEie6n/k+qzLPUIn9/2Hn3t6vQ4Z6dwcViu+8vRU7iQVXgR50vmIiMj6vf/++1i4cCFWrlyJWrVq4eDBgxgyZAjc3d0xZswYAMAHH3yA+fPnY+XKlahWrRomTpyI9u3b49SpU3B0dAQA9O/fHzdv3sT27duRlZWFIUOG4OWXX8a6detKN1D8VWiWd4CXTp+zUWw8RFzZO1rYkHQpYL6CpuWzvjw/4PO5XQLMvoc83w3gXBu8xhvOGk3BG9+P025vb/JYuswslHFyeVA8yL280ePnV1gosNhgn08f8msr7vXaPfaGs+j1uGuOjWJz0+uR5XQH8PYu4PAQKnZKIcmM9HrInTvm7QOZjUUXQrhnyXK5Oz3eSU+9XR1LuCdERGQp9uzZg+7du6Nz584AgMDAQKxfvx779+8HkPOdPXfuXEyYMAHdu3cHAKxatQqVKlXCpk2b0KdPH5w+fRpbt27FgQMHUL9+fQDAggUL0KlTJ8yePRt+fn6lF8jBFYh6EWkpKXBxccn7oz3f4ejG9wub9qih7Chg73Ku4+MLnCf3beRtN4wSyGevt140SLh/Hx7lK0Brl/88hf/Ltff8cUYBGE8zI9Hrcf/OHTiorRhARKQiFl0Isbk9SzZi36V7mPTtiULn0QDwcXfEM9U8S6dTRERkdk2aNMGSJUtw7tw5hISE4NixY/jtt98wZ84cAMDly5dx69YttG3bVlnG3d0dDRs2xN69e9GnTx/s3bsXHh4eShEEANq2bQutVot9+/ahZ8+eeR43IyMDGRkZyv3ExEQAgF6vh16vf/pAjh7Qt3gTSbGxcPTyglZFG8V6vR4ZsbHQe3mV7h5yMR4pYx56vR4iUrT3jpVSa3a15gaYvTiyq/G5swUWXQixuT1LVi41MxsfbD2LFXuuAADKO5dBfGoWNDAdmGvYjzO5azjstGYe8kZERKVm/PjxSExMRGhoKOzs7KDT6TBjxgz0798fAHDr1i0AQKVKlUyWq1SpkjLt1q1b8PY2PYO/vb09PD09lXlymzVrFqZOnZqnPTY2FunpRTtEU6/X4/79+xAR1RVC1JgbYHY1ZldrboDZiyN7UlJSMfaKSotFF0LMtWcJKLm9S9Zadd1/OQ7/3fAnrsalAgB616+CtzqFYs+Fe5j2/WncSnz4Q9PH3RETO4fhufBKVpczN2t9vR7FFnPZYiaAuaxJcWay1uflq6++wtq1a7Fu3TrUqlULR48exdixY+Hn54dBgwaV2OO+9dZbGDdunHI/MTER/v7+8PLygpubW5HWrdfrodFo4KXCESFqzA0wuxqzqzU3wOzFkd1wFAJZF4suhJhrzxJQcnuXrK3qmpalw8Lfb+Dro3cgACq5lsHbbQPRMMAN6YnxqOutxYbB4TjyVyKuxybC38sN0VXcYKfV4I4NnHzI2l6vx2WLuWwxE8Bc1qQ4M1nr3qU33ngD48ePR58+fQAAERERuHr1KmbNmoVBgwbBx8cHAHD79m34+voqy92+fRtRUVEAAB8fnzzfH9nZ2YiLi1OWz83BwQEODg552rVabbG8vzQaTbGty5qoNTfA7GrMrtbcALMXNbsanzdbYNGFEHPtWQJKbu+SNVVdc0aBnM4zCsTNMe+JUit5eyE2NtYqcj0Ja3q9noQt5rLFTABzWZPizGSte5dSU1PzZLezs1NGuFSrVg0+Pj7YsWOHUvhITEzEvn37MGLECABA48aNkZCQgEOHDqFevXoAgJ07d0Kv16Nhw4alF4aIiIhslkUXQsy1Zwko2b1Lll51NZwLZOXeKxABfN0d8d7zddAypPAL6Vl6rqfFXNbDFjMBzGVNiiuTtT4nXbt2xYwZM1C1alXUqlULR44cwZw5czB06FAAOc/P2LFjMX36dAQHBysnOffz80OPHj0AAGFhYejQoQOGDRuGRYsWISsrC6NGjUKfPn14Xi8iIiIqFhZdCOGepdK3/3Ic3vjfMVy9lzMKpE8Df7zdOSzfUSBERETGFixYgIkTJ+I///kP7ty5Az8/PwwfPhyTJk1S5nnzzTeRkpKCl19+GQkJCWjWrBm2bt1qMgpm7dq1GDVqFNq0aaNc9n7+/PnmiEREREQ2yKILIdyzVHqedhQIERGRgaurK+bOnYu5c+cWOI9Go8G0adMwbdq0Aufx9PTkJe6JiIioxFh0IYR7lkoHR4EQERERERGRWlh0IYR7lkoWR4EQERERERGR2lh0IYRKDkeBEBERERERkRqxEKIyHAVCREREREREasZCiIrkHgXSu74/3unCUSBERERERESkHiyEqEBapg4fbDuDFXsejgKZ1SsCrWp6m7trRERERERERKWKhRAbx1EgRERERERERA+xEGKjOAqEiIiIiIiIKC8WQmwQR4EQERERERER5Y+FEBvCUSBEREREREREhWMhxEZwFAgRERERERHRo7EQYuU4CoSIiIiIiIjo8bEQYsVyjwJ5oX4VTOgSzlEgRERERERERAVgIcQKpWXq8OG2s1i+5zJHgRARERERERE9ARZCrMyBK3F44+tjuMJRIERERERERERPjIUQK8FRIERERERERERFx0KIFeAoECIiIiIiIqLiwUKIBcs9CsTHzRGzno9Aa44CISIiIiIiInoqLIRYqPxGgbzTORzuThwFQkRERERERPS0WAixMBwFQkRERERERFRyWAixIBwFQkRERERERFSyWAgpRTq9YN+le7jwVxxqJNuhYVBF2Gk1HAVCREREREREVEpYCCklW0/cxNTNp3DzfvqDlsvwdXdE/4ZVseHw37h8NwUAR4EQEREREVEOEYHIg9sP7j+8XfiyGk0+bbnu6/V66PQCnV4gkHznMaxLk98KiawUCyGlYOuJmxix5jByf1bdvJ+O2THnAHAUCBERERE9OZGcjVidCPR6QCcCnS7nvk4v0BumG93WiyDb0GZYRi/I1ulwLy4Jbkl2EMBoGeRZl+ExxTBduf1go1oertcwj16M+wCT/ugNGQQ5t43m0cvD2/Igp6FNck3XG02XXMuLyXwPnzsRQVZ2NrR2OZtGxssaig2G2wLDsg+KFHi4XlHmMWrDw7acFwxKwcG43bAuQ7sl02hyiiUajUYpmuS05UzQGN3PM6/xfaPb2gcTtRpA++C+YZ4C78Povjbnf+P1aQ2PoTFer+k6etfxxHPe3P5SIxZCSphOL5i6+VSeIogxpzJ22PJKc3i6lC21fhEREZWEv//+G//973/x448/IjU1FTVq1MDy5ctRv359ADk/9idPnozPPvsMCQkJaNq0KRYuXIjg4GBlHXFxcRg9ejQ2b94MrVaL559/HvPmzUO5cuXMFYuKkWHjM++GMB5sCOdsFOsfbEjr9flvPOfesM+zsW7YuDaebtSm3DZpA3Q6Pe4nJcHJOUnZmDfMl603zIsHxQR9zm39w8JD7sfWGU3TiyBbZ9xHQFfQOnIXHgzr0D/oh9FzYgnstBrYPdjIzH07Z0M1p02rQc5tQ7vxPBpDO5T5DRuthnmMN2Jz7mtQRnmMnI1eu1zTtUYby/ltFGsApKWlopyLC7QPGgwb1cYb04YNfGVazta7yXoKmh94OEJDY3QnTyEh13wPb2uUmR8u87AQkVt+bwvJp8KiF0FSYiJc3dxyRnzks6BxMUfyLe7Iw2nGt40eM/dyxveBnPe/od1Q8BI8LFrpHyxoWhQzLTgpxS79w/uG5XS5iluGvy8OclEvFkJK2P7LcUaHw+QvLUuHs7eS0Lh6hVLqFRERUfGLj49H06ZN0bp1a/z444/w8vLC+fPnUb58eWWeDz74APPnz8fKlStRrVo1TJw4Ee3bt8epU6fg6OgIAOjfvz9u3ryJ7du3IysrC0OGDMHLL7+MdevWlWqeuJRMfPrzeaSmpsLZ+R6MNzly77k1/kGvzJNrD6/xXmDDOh4uY7SxYLSBYPiBb9gAMNlQeLBYfnuqYbxRYLRBYrpu03kMe8YNGw+ZmVnQ2p8zaTPZw67Pfw+7YQPdUETIfdvSaDTI2XB+sOFtpwW0AOzttNBqtbDT5ky3s9Pkmu/hP61GA3ut6TSt9kGbRgMHO8O8WtgZbeTb22lMNvLttQ+XNTyWvdFj2GmhrCP3YzyqL3YPCgG52+yMltdAkBAfB6+KFWBvZ2eSUcmez7qs/ZAJvV6PO3fuwNvbG1qt1tzdKVXMfsfc3SAzsfhCiLXvWbqTVHgR5EnnIyIislTvv/8+/P39sXz5cqWtWrVqym0Rwdy5czFhwgR0794dALBq1SpUqlQJmzZtQp8+fXD69Gls3boVBw4cUL7rFyxYgE6dOmH27Nnw8/MrtTypmdnYdTYW2Tod7O1S8hxwb7wnN+e+6d7cnNv57PUtYH7Nw4Ue7Fl+uMfXsJfadI+z8Z5mw1DxXHu8tRplT7NWazp0Pb897IaNWg2AjPQ0uDg7Q2u05z7PHnZl2PnDvfjKHnzj0QEP1msyIsBoOLvxiABlhIBhAz3PfKbLGBcATDbSjTfen2AjXvUbhkiFdwUX1WUnInWx6EKILexZ8nZ1LNb5iIiILNV3332H9u3b45///Cd27dqFypUr4z//+Q+GDRsGALh8+TJu3bqFtm3bKsu4u7ujYcOG2Lt3L/r06YO9e/fCw8NDKYIAQNu2baHVarFv3z707Nmz1PJUKe+MmFdbqHKjWM3FACIisn0WXQixhT1Lz1TzhK+7I27dT8/3WD0NAB93RzxTzbNE+0FERFTSLl26hIULF2LcuHF4++23ceDAAYwZMwZly5bFoEGDcOvWLQBApUqVTJarVKmSMu3WrVvwznXiOnt7e3h6eirz5JaRkYGMjAzlfmJiIoCcjXm9Xl+kTHq9/sEx50Vbj7VRa26A2dWYXa25AWYvjuxqfO5sgUUXQmxhz5KdVoPJXcMxYs1haGB6/iHDQMzJXcNhp7XuYyuJiIj0ej3q16+PmTNnAgCio6Nx4sQJLFq0CIMGDSqxx501axamTp2apz02Nhbp6UU79FSv1+P+/fsQEVWNjFBrboDZ1ZhdrbkBZi+O7ElJScXYKyotFl0IMdeeJaB49y49F14Jn/aLxrTvT+NW4sMfZD7ujpjYOQzPhVey+kqirVaTmct62GImgLmsSXFmstbnxdfXF+Hh4SZtYWFh2LBhAwDAx8cHAHD79m34+voq89y+fRtRUVHKPLlPXpednY24uDhl+dzeeustjBs3TrmfmJgIf39/eHl5wc3NrUiZ9Ho9NBoNvLy8VLWRoNbcALOrMbtacwPMXhzZDadjIOti0YUQc+1ZAop/71Jdby02DA7Hkb8ScT02Ef5eboiu4gY7rcYmzlZsq9Vk5rIetpgJYC5rUpyZrHXvUtOmTXH27FmTtnPnziEgIABAzuGtPj4+2LFjh1L4SExMxL59+zBixAgAQOPGjZGQkIBDhw6hXr16AICdO3dCr9ejYcOG+T6ug4MDHBwc8rRrtdpieX9pNJpiW5c1UWtugNnVmF2tuQFmL2p2NT5vtsCiCyHm2rMElNzepUreXoiNjbW5qqutVpOZy3rYYiaAuaxJcWay1r1Lr776Kpo0aYKZM2fihRdewP79+7FkyRIsWbIEQM4PzrFjx2L69OkIDg5WTnLu5+eHHj16AMj5nu/QoQOGDRuGRYsWISsrC6NGjUKfPn1K9YoxREREZLssuhBirj1LQMnuXbLVqitzWRdbzGWLmQDmsibFlclan5MGDRpg48aNeOuttzBt2jRUq1YNc+fORf/+/ZV53nzzTaSkpODll19GQkICmjVrhq1bt5oUf9auXYtRo0ahTZs2ymXv58+fb45IREREZIMsuhDCPUtERETWpUuXLujSpUuB0zUaDaZNm4Zp06YVOI+np2epXOKeiIiI1MmiCyHcs0RERERERERExcmiCyEA9ywRERERERERUfGxzoOQiYiIiIiIiIiegsWPCLEUIgIg52SsRaHX65GUlARHR0erPRlefpjLuthiLlvMBDCXNSnOTIbvGsN3Dz2Z4vrOBmzzvfo41JobYHY1ZldrboDZiyM7v7OtEwshjykpKQkA4O/vb+aeEBGRWiQlJcHd3d3c3bA6/M4mIqLSxu9s66IRlq4ei16vx40bN+Dq6gqNRvPU60lMTIS/vz+uX78ONze3YuyheTGXdbHFXLaYCWAua1KcmUQESUlJ8PPzU90euuJQXN/ZgG2+Vx+HWnMDzK7G7GrNDTB7cWTnd7Z14oiQx6TValGlSpViW5+bm5tNftgwl3WxxVy2mAlgLmtSXJm4V+npFfd3NmCb79XHodbcALOrMbtacwPMXtTs/M62PixZEREREREREZFqsBBCRERERERERKrBQkgpc3BwwOTJk+Hg4GDurhQr5rIutpjLFjMBzGVNbDETqfd1VWtugNnVmF2tuQFmV2t24slSiYiIiIiIiEhFOCKEiIiIiIiIiFSDhRAiIiIiIiIiUg0WQoiIiIiIiIhINVgIISIiIiIiIiLVYCGEiMhMkpKSYHy+als5d7Ut5rLFTGRKTa+pmrIWRs3Pg1qzqzU3wOxEufGqMcUkKysLP/zwAypXroyoqCiUKVPG3F0qMlvMBNh2ri+++AI+Pj6oV68ePD09zd2lIrPFTEBOrlGjRuHEiROoUKEC+vfvj969e5u7W0Vmi7lsMRPlWLBgAfbu3YuQkBAMHDgQQUFB5u5SqZg7dy527NgBf39/DBo0CNHR0Shbtqy5u1Uq1PqaA+rNrtbcALOrNTs9AaEiW758ubi5uUlkZKQ4OTlJv3795NdffxURkezsbDP37unYYiYR2821du1acXNzk3r16omHh4e0bNlSNm3aJCIiOp3OzL17OraYSUQkPj5emjVrJk2aNJH169dLhw4dJDg4WF599VVzd61IbDGXLWYikXv37kmHDh0kMDBQRo4cKSEhIVKjRg1ZtmyZubtWopKTk6VXr14SGBgoEydOlAYNGkhwcLBMmDDB3F0rcWp9zUXUm12tuUWYXa3Z6cmxEFJEN27ckAYNGsicOXMkNTVVNm3aJN26dZMaNWpIRkaGubv3VGwxk4jt5kpOTpZmzZrJtGnTRERk9+7d8tJLL4mbm5tcv37dzL17OraYyeCXX36R4OBg+fPPP0VEJD09XZYvXy4ajUZ+/PFHM/fu6dliLlvMRCIxMTESEhIily5dUtr69+8vDRs2lK1bt5qxZyVr//79EhwcLIcPH1baJk2aJNWrV5f169ebsWclT62vuYh6s6s1twizqzU7PTkWQp6SXq8XEZGNGzeKo6Oj3Lt3T5l26NAhCQ4OlqFDh4qI9ey9tsVMIrafa9euXVK2bFm5fPmyMu3OnTvSoEED6dKli1WNdLHFTLlt2LBBnJycTNr0er0MGDBAateuLWlpaWbqWdHYYi5bzKRmhs/3ZcuWSY0aNeTu3bvKtGPHjkmPHj2kXbt25upeiYuJiRFPT0+TYvK1a9fkX//6l9SoUcOMPSs5hu8UNb7man2/Z2VliYj6couo9zUXUXd2eno8WeoTunfvHgBAo9EAAFxdXeHr64sbN24o80RFRWHChAlYvnw5zp49C61Wa9En6bHFTIDt5vr7778BPMzl7e2NcuXK4a+//gIA6PV6eHl54cMPP8SWLVuwa9cupd1S2WImIOdY/E8//RR//PGH0ubq6gp/f39s2LABQM4JvDQaDSZPnowLFy4o7ZaczRZz2WImAmJiYrBr1y7cu3cPWm3OT56UlBSUKVMGd+/eVearU6cOunXrhrt372Lt2rXm6m6xuXjxYp625ORkVK5cGadPn1ba/P390b9/f2i1Wnz00Uel2cUSs2fPHpw+fRrJycnKd0pqaqrNv+YAsHXrVnz77be4fPkysrOzAajj/b506VL07t0b2dnZsLe3BwCkp6fbfG4AmDdvHqpUqYI7d+4on3Fqya7Wz3cqPiyEPKbPPvsMtWrVQpcuXTBmzBgcOXIEAFCmTBm4u7vj119/VebVarVo164dmjVrhnfffRfAww08S2KLmQDbzbV06VJUr14dnTt3xvPPP4+dO3cCyOlvZGQkvv32WwBQvgyaN2+Ozp07Y+bMmSbtlsQWMwHArl274Ovri9WrV+Ozzz5D9+7d8d///hcAEBoaiipVquCnn35CSkoKNBoN9Ho9AgMD0bdvXyxZsgSAZWazxVy2mImAkydPok6dOhg6dCgGDx6Mdu3aYfHixQCAQYMG4dKlS/jpp59MlmnTpg08PT1x+PBhZSPS2hw5cgQNGjRA//79le8+nU4HAOjYsSPu37+PnTt3IjU1VVmmTp06aNKkCfbs2YO0tDSz9Ls4/PHHH4iOjsbAgQPRsWNHdOnSRfm+HzhwoM2+5gCwd+9eREREYNSoUXj77bfRuXNnLFu2DIBtv9+BnALfpEmTsG3bNsybN09pf/HFF20696+//oqQkBB88MEHmDx5Mry9vZWivK1nV+vnOxU//np7DB9//DEmTZqEcePGoUuXLjh69Cg6d+6MGzduoEWLFqhatSq+//57nDx5UlnG19cXzZo1Q3x8PBITE83Y+/zZYibAdnMtX74cU6dOxeTJkzF69GjodDp07doVe/fuRc2aNREVFYV9+/YphQS9Xg+tVotu3bohNjbWZBSMpbDFTAarVq3Cs88+i0OHDiEmJgaffvopPvzwQyxYsAD+/v5o3749Dh48iI0bNwLI2ZC2t7dH+fLl4eDggOTkZDMnyJ8t5rLFTJRzxYCQkBAcO3YM33//PRo3bozJkyfj22+/hZubG0aMGIH3338fV65cUZapWrUqvLy8cPbsWdjb21v86MDcfvrpJ/zrX/+Cs7MzMjIysHnzZuj1etjZ2SErKwuOjo4YM2YMFi1ahIMHDyrLVahQAZ6enrhz5w6cnJzMmODpiAjWrFmDAQMGoGPHjvj555+xevVqpKSkYOXKlbh37x7c3NwwevRom3vNRQSff/45/vnPf6JHjx44ePAgvv/+e0RERGD37t1ISEiw2ewGFy5cgJ2dHYYMGYJVq1bh2rVrAHJG9NlibhHBBx98gFatWmHgwIG4fv06hg0bBhFRivKurq4YNWqUzWU3UOPnO5WQ0j8ax3ro9XrJzMyUjh07ymuvvaa0x8bGSmRkpHTo0EFEck5AFhAQIFOnTjU5Znz48OHSoEED5RhVS6DT6Wwuk4jt5jKcC6N///7Sp08fk2mtW7eWJk2ayPXr1+X8+fPSuHFjGTJkiNy/f1+ZZ8qUKRIWFibJycml2u/C2GImYzdv3pQaNWrIwoULReThMeqvvvqqBAcHy4EDByQxMVF69OghLVq0kDNnzijLDhgwQAYNGmSObj/SrVu3bCqXXq+32ddK7e7evSvu7u6yevVqpe3GjRvyr3/9S/z8/EREJDU1VSpVqiSDBw+WmzdvKvP17t1bhgwZYnHfBY/j0KFDMmrUKPn7779l1KhR0qJFC9m+fbuImF4VLSIiQnr27CnHjh1T2saMGSNdu3ZVzq9gTZKTk2X06NEyc+ZMSU1NVc4VMH/+fAkODlbmS0xMFF9fX5t6zTMzM2Xjxo2yevVqyczMVLKPHTtW3njjDWW+pKQk8fHxsansBrt27ZLhw4fL9u3bpVGjRjJ8+HBlWmJiovj5+cmgQYNsJnd2drZ8/vnnotFoJCUlRUREPv74Y3n33Xdl3rx5cufOHRHJ+buwxddcrZ/vVDJYCHkM3t7esnz5chF5eBKmgwcPikajkZUrV4qIyMSJEyUqKkr++9//yr179+TatWvSpk0bmTFjhrm6XShbyZSYmGhy31Zy/fbbbyb3a9euLe+++66I5Fy5QkTk/PnzUqlSJZk+fbqI5JwgKjIyUgYMGCCXLl2Sa9euSZcuXWTMmDGl2/kC5D7BqS1kEhE5evRonqJMUFCQcsUbQ8EtLS1NqlWrJqNGjRKRnNe4Y8eO4uHhIa+//rr0799fPD095fvvvxcRMfsX9YULF/JsFFWvXt2qcy1evFhiYmJM2qw9E+UVFxcndevWlY8++sik/cSJE+Ll5SWTJ08WEZHNmzdLtWrV5Nlnn5W1a9fKjBkzpGLFisrram2ysrKUovGFCxekYcOGMnLkSElISBARUa6O9vvvv0vjxo0lNDRU5s2bJ1OmTBFPT09Zu3at2fpeVDExMRIXFyciD/8ev/76a4mMjJTExESlQPDjjz/a1GsuknOZb+Mr361evVo8PDykW7duMnPmTDl06JCIiHz33Xc2ld3wOq9atUo6deokIiLTp0+X8PBwOXnypBw/flxEct4bgYGBNpNbROT+/fvStm1bqVq1qjRo0ECio6OlZ8+e4uDgIK1atZJNmzaJiO19xomo9/OdSgYLIUY2bNgg48aNk3Xr1ilnVc/KypJ//OMfyoesiOke7ejoaBERSUhIkMWLF0u5cuWkbt264uHhIa1bt5Zbt26VfhAjW7ZskdmzZ8uPP/6oVEXT0tLkhRdesNpMIiK//vqrBAcHy7x585QfABkZGVafa/369RIYGCiNGjUyuWLK6NGjpXbt2sp9wwbquHHjpHr16pKQkCBpaWmyZcsW8fHxkVq1akn58uWlRYsW8vfff5d2DBNffvmldOnSRYYOHSpffvmlUjQYOXKk1WYSEfnf//4nVapUkerVq0uNGjVk5syZEh8fLyIib775ptSoUUMp8Bjeo/Pnzxd3d3dJTU0VkZy/xQkTJsjAgQOlV69eJiMOzGX9+vVSp04diY6OlqioKKWwqNPpZPz48Vaba+rUqaLRaGT48OFy7do1Ecn5fLDmTPSQcaE1KSlJOnXqJMOGDZPbt28r7RkZGTJ58mSpUqWK8jm0fft26d27tzRt2lRq1apldT+S87uClqHtvffekwYNGuRb4Dhz5oyMGDFCOnbsKNHR0bJ58+YS72txyy+7Xq9X2kePHm3ye8Bgx44dVv2ai+SfXSTn+9PV1VUmTZokU6dOlXbt2klgYKBSIIuJibHq7Pnlnj17trz66qsiIvL3339LixYtxNnZWXx8fOTChQsiIvLTTz9ZdW6RvNl//vlnCQkJkcmTJys7Bc+cOSP/+Mc/pFWrVspoEWv/jBNR7+c7lTwWQiSnmt6rVy+pWLGidOvWTQICAiQoKEgZNjp//nyJioqSLVu2iEjOUESRnD3BdnZ2cvjwYWVd58+flx07dsgvv/xS+kGMnDt3Tpo2bSpVqlSRtm3biq+vrzRv3lyZPmfOHKlbt65VZTI2YcIE0Wg0Ur9+fTl16pTS/vHHH1ttrtmzZ4uvr6/MnTtXrl+/LklJScq0jRs3SkBAgKxatUpEHo6giI+PF41Gowx/Fsk5NOPQoUOyZ8+e0g2QS2xsrPTs2VP8/Pxk/Pjx0r17d/Hw8FBem40bN0pgYKBVZTLYt2+fsjf1wIEDMnv2bHF1dZW33npLUlNTZdeuXVKrVi2ZMmWKiDx8H969e1dcXV1l27ZtJuuzhMsBJyQkyIgRI6RKlSryySefyHfffScjR46UMmXKKEXUH374QerUqWNVuQx7DSdNmiR16tSR0NBQkyG1W7ZssbpM9JDxaJz09HTl8uhz5syRmjVryjfffGMy/w8//CCRkZHyxx9/mLQb/6C2BrlzG0Z96HQ6ZVpiYqK0bdtW+vTpoxTWc4/yMv6esRYFZTf+28zMzJSGDRvK559/XuB6rO01Fyk4u+Fz68aNGya5jh07JiEhIbJkyRKT9Vhb9oJyi+QcLjtnzhxJS0uTfv36iZ2dnVSoUCHPiAER68stkje7YYdLfHy87Nq1y+TQDxGRzz//XMLDw+XgwYMm7daS3TivWj/fqfSouhBi+AOLiYmRGjVqKJXjxMREadCggbRr105OnTolV69elfbt20vPnj2VjTWRnGFYAQEBsnHjRnN0v0CXLl2S5s2by7BhwyQ2NlZSUlJkz5494uHhoWx0Hjt2TDp27Gg1mQwyMzNFr9fL22+/LWvXrpUKFSrI66+/rlTDjx8/Lp06dbK6XLGxsdKsWTP58ssvRSTn+Mbr168rQ32vX78uAwcOlKioKGWPtV6vlzt37khwcLAsWLDAbH3PzfB3tX79eomOjlZGV4mI+Pv7y3vvvSciIteuXZNBgwZZRSYDww/thQsXSkBAgMlGxMyZM6V+/fqyePFiEREZP368+Pr6mhTqfv75Z6lcubIcOHCgdDv+GPbs2SORkZGye/duk/aQkBCZOXOmiOT88HrrrbfEz8/P4nMZ/4DKyMiQjh07ysmTJ6VXr17SoUMHOXLkiIjk/O299dZbVvVaqdnSpUtl+vTpsm7dOpPDAU6cOCH169eXiRMnKm2NGjWSF154weRcGDt27BB7e3tlRI+1HNb0qNyG4eAGhs+qL774QqKjo2X+/Ply+fJl+c9//iPnz58vza4X2ZNmF8kpngcHB8uJEydEJKfgs2zZMqvbIHrS7Ib3s+H137t3r7i6uiojfgyHCFm6J8ndvXt3iYqKEldXV+WwkJdeekkaN26sjAywltwiT/d+F3lY5Fy3bp3Y2dkp2zTW8hknIjJv3jx5+eWXZcqUKSa/HW39853MR7VXjVmxYgU+/vhjADmXXHNzc0OFChUA5JxteenSpbh58yaWLl0Kf39/9O/fHxcvXsSUKVOUdRiu2R0dHW2OCHksX74c8+bNQ3Z2NipUqIAxY8agYsWKcHZ2RlhYGKKionD9+nUAOZfL69WrFy5fvmzRmQDT16pMmTLQaDTYvXs3AgICMHv2bPzf//0fjh07BgCIiIjAP//5T1y4cMGqct2/fx+3b99G3bp1sXz5coSHh6NXr16oU6cONm7cCF9fXwwbNgypqakYNmwYdDodNBoNrl27Bp1Oh1atWpk3zAMrVqzA3LlzAQBbt26Fl5cXXF1dAQDZ2dmIjIxEq1atkJGRAX9/fwwcOBBpaWkWnQkA4uLiAAB2dnYAgEuXLiEkJES5DwCjRo1CzZo18fXXX+Pvv//GqFGjEBkZie7du2Pt2rW4cOEC1q5di6CgIAQHB5slR26GXADwzDPPYNSoUWjUqJHSlpaWBkdHR/j6+gIAPDw8MGjQIERFRVlsLkMmw2Wws7KyULZsWej1emRlZWH8+PE4fvy4ctUMBwcHjBs3DnXq1LHYTATs3LkTNWrUwIIFC/Dbb7/hP//5D/r27atMr1mzJgICAuDt7a1cAnbq1Km4cuUK3n77bVy4cAH379/H9u3b0a5dO/j4+ACw3MulGzxu7ooVKyIrK0tpN3w29e7dG8HBwZg1axZq1qyJ3bt3o2zZsqWe42k8bXYAOHDgABwcHBAYGIjFixfD29sbX3zxhdVc6vppsxvez4YrBf34449o2bIlGjduDMDyL/X9JLnT09MBAB06dEBSUhI+++wzxMTEoHv37ujQoQNu3rxpcrUvS1eU9zsA2NvbIz09Hdu3b8fQoUMRFBQEwPI/4wBg+/btqF69OpYuXQp7e3t8/vnn6NmzJ+Lj4wHY7uc7WQBzV2JK26ZNm6RKlSqi0Whk4MCBIiLy0UcfiY+PjzKPoZI+ceJEiY6Olr1790pGRoYsWrRINBqNtGvXTkaNGiVeXl7y0ksvSWpqqlmrjsaZhg4dKiL5DwOrWbOmMiJEJGfky+LFiy0yk4hprsGDB4tIzoiQlJQUadSokZw9e1ZERGrVqiUDBgyQtWvXymeffSYiYrGvlUj+ubZt2ybVq1eXr776Sho2bChr1qyRPXv2yIABAyQyMlLJtW3bNnF1dZXo6GgZOnSoeHl5SZ8+fSQxMdFi3oMvvviiiOQcplS+fHl55513ZM2aNRIYGCju7u4SFhYmrVu3lh9//NGiM4nknGyrWbNm8uyzz8qrr76qDDXduHGjODo6yqVLl0Tk4WfGpk2bpF69esqJeRMSEqRbt24SHh4u/v7+EhUVJSdPnjRPGCO5cxkfMmaQlZUlCQkJUqVKlTwnGLXEXLkzHT16VJmWnJwsISEhyl4iw1VhPDw8ZMiQISJimZkox+7du6VBgwYydepUyczMlNTUVDlw4IBoNBrZt2+fMp/xcHmD77//XurXry9Vq1aVoKAg8fX1zfN+tlRFyS2SMxLq66+/Fl9fXwkKCpINGzaUVteLrKjZR4wYIUFBQRIRESEVKlSQNWvWlFbXi6wo2VNSUuT333+XNWvWSGRkpAQHB8vPP/9cir1/ekXJbWgzPizs9OnTpdPxYlDU13z37t2yevVqiYqKklq1apksY+l++eUXadmypUybNk35LfXXX3+JRqMxGe1ha5/vZBlUUwg5c+aMNGnSRFxcXGTevHkyYcIEqVWrloiIXL16VVxcXJTjxg2HVNy7d08qV64sc+fOVdbzww8/yIQJE6R79+5mP8N6fpkiIiKU6cZDAS9duiSVK1dWhn4bb2B+//33FpNJ5NG59Hq9NGrUSNnQWbNmjWg0GnF0dJSPP/5Ymc+SXiuRwt+DIiJ+fn7i5uYm//73v5W29PR06devn/Ts2VO5JNrvv/8uc+fOlYEDB8q6detKPYexR2WaMWOGvPLKK1K+fHmZNGmSXLt2TQ4ePCg9e/aU5557Tq5cuSIiOVflsJRMer1e0tLSZPTo0VKxYkWZPn26zJgxQ6KiomT48OGSmZkpGRkZEhoaqlymz/jY9MjISHn99deV+xkZGRIbG6scimEuheX697//rQyrNf5s+OWXXyQwMNDkvAKGz5X09HSz53rcTH/99Zd069ZNRHI+75s0aSJarVaaNGlicpiApbxWZOrgwYPSoUMH5Vh4vV4v8fHxEhERIf/3f/+X7zLG338JCQmyf/9++d///lcq/S0uT5PbWFJSkjg5OZlcUt5aFCV7cnKytGrVShwdHWXSpEml0d1iVZTsN2/elDfeeEPq1q1b4CEUlqoouc2906SoipL9xo0bMmrUKAkLCzM5dMTSGV6zW7duybp165QT+ork/Cbs2bOn3L17N99lbeHznSyDKgohly9fVkZLGM65MHv2bKlVq5ZcunRJkpOTZdiwYVKlShVlGcMP6H79+kmHDh3M0u/CFJYpv+N/161bJ+Hh4ZKcnKx8+FjiF8fj5Dp79qy0adNGkpKSZPjw4WJvby9VqlSR2rVry40bN8zZ/QIVlsswsmXu3Lmi0WiUkzYaLFy40OSqFpaisEzGV9T45ptvpGnTphIfH698ea1bt04CAgJMzslgSU6dOiVhYWEmJ2cdNmyY9OjRQ0Ry/nZWrlwpWq1Wfv/9d5Nle/XqZXKlAkv6OysoV8+ePUWv1+fp6/jx46Vr167K/Rs3bijHHVuKwjIZ3m+nTp0Sb29v6d+/v5QpU0YGDx4s48ePl/DwcPnuu++U5SzptVKz/Pb8Ga7eY5Ceni4+Pj75nkD5t99+k5kzZxY4WsBSlURuwyWhLV1xZTd8F33//ffKSSUtXXFlN+S9fPlynku6W6Lifr9b0+d3cb/m58+ft5oTH+eX3biwMXv2bHF2dhZ/f3+pXr26TJgwwWS7xlo/38kyWf5Bc8UgMDAQly5dwrJly1C+fHkAQK1atXDhwgW4uLjAxcUFQ4cOBQCMHTsWQM6xdjqdDvHx8cpxdiJilv7np6BMFy9ehJubmzKfTqcDAPzyyy+IjIyEi4sLsrKy8Nprr+GLL74wS98LU1guw7kmRAR//vkn3NzcsH//fvz22284cOAAzp07h+XLl+d77KS5FZbLw8MDANCzZ09ER0dj27ZtuHjxorJsZmYmvLy8LC5XYZkM94Gc9563tzc8PDxMztvg4OBgMp8luXTpEjIyMqDX65U2nU6H5s2b4+bNm9Dr9Rg4cCA6d+6MYcOGYffu3QCAmzdv4sqVKybH9VrSMaoF5WrWrBlu376N7OxsAEBGRgYA4Ndff8Vzzz0HnU6Hd955B5UrV0ZMTIxZ+l6Qx8nk4eEBX19fXL16FVu2bMHy5csxa9YsZGZmYsWKFbh37x4Ay3qt1Gj37t2oU6cOPvjgA6SkpJhMc3JyMnmNDxw4ABcXF4SEhCjvW4OffvoJ8+fPx549e0ql30VVkrkdHR1LtvNFVFLZO3furHy3WqqSyh4YGAgXF5eSD/CUSiq3NXx+l1T2GjVqoFy5ciUfoAgKy244h8uxY8ewY8cOzJ8/H1u2bMHkyZOxZs0arFy5UnkOrO3znSycuSsxpcm4Wnzp0iXx9vZWDpnIyMiQL774QjQajbzyyiuybds2Wb16tVSuXFk2bdpkri4/Un6Z1q9fn2e+Bg0ayIYNG+S7774TPz8/qVSpkuzfv780u/pE8stlOGTi2rVr8tprr8nq1atN9naNHDlSunbtatF7wArLJZJzhvdy5cpJp06dZMWKFbJixQoJCAiQefPmmaO7j+VR78Fvv/1WNBqNLFmyRI4cOSLr16+XgIAAmTBhgsVeivTevXvSqFEjadCggSxatEhCQkKkXLlyUq9ePQkJCZExY8aISM4enJYtW0qlSpWkQ4cO4ufnJ02aNJG//vrLzAnyV1iumjVrKrlEcoarBgcHy+jRoyUgIEBCQ0Nl586dZux9/h71WhkOCzh58qSyx8zwvtu9e7fJMchkHjqdTlavXi3h4eESFhYm3t7eBR7jbnjtZs6cKY0bN85zdSARkbi4OKs4L4Jac4swuxqzqzW3CLM/bnbDocfGevXqJV26dFHux8fHW012snyqKoQYu3jxooSHhyvH3hk+aBYtWiStW7eW0NBQ8fX1VU5SaQ1yZzLYv3+/aDQacXNzE2dnZ/nkk0/M1MOnk18u4w9KaxoOaSx3LsOX3w8//CD9+vWTBg0aSPXq1WXJkiXm7OYTKeg9OHLkSKlUqZKEhoZKQECAVWQ6cuSILFiwQOrWrSvDhg2TW7duyc2bN+Xzzz8XHx8f+f7770Uk53CRmJgYeffdd63ihHyPyrV161YRyRlartFoxM/Pz+I/MwrLVKlSJdm2bZuIWO9nha1LTU2VxYsXy+TJkyUlJUWqV68u/fr1y/fQBsNhq23btpUJEyaISE7RbsCAAbJp0yarukymWnOLMLsas6s1twizP2524+/o7OxsSU5Olg4dOijnYyMqbqothIiIREVFyciRI0UkpwppzFLPXfAoxpkMH6ZHjx4VDw8PGT9+vDm7ViTGuQoaRWCNGzmFvQct9Xwnj5Lfe1BE5O+//5bffvvNXN16KteuXZOqVauaXFXFUOwxPjGvtXmcXAkJCTJ//nwz9fDJ2eprpRbXr19XjvmOiYkRjUYj3333Xb6f6wkJCRIVFSV79+6V9957T1xcXKR+/fr5Xi3N0qk1twizqzG7WnOLMPvjZjdITU2VyZMnS0REhOzdu7e0ukoqo8pCiOEPb+TIkdK8eXOTDVBr3JgWKTxTcnKy1Zw0LLfCclkzNb0HrTWPiMixY8ekbt26cvXqVaXt6NGjEhQUZHVFHWOF5dq9e7cZe/b0bPW1UhtDofu5554r8DAzw+F2zs7OUqVKFWXEjzVTa24RZhdRX3a15hZhdpHCs2/atEleeeUVCQkJkdDQUH5/U4lSxclSczOcUMnZ2RlpaWkmJyeyhpMt5Se/TPLg5K4uLi4Wf9KwghT2WlkztbwHjdutUUREBG7fvo133nkHX375Jb766iu88MILaNCgAcLDw83dvadWWK5atWqZu3tPxVZfK7VasmQJ9u7di02bNiknyTOc/NvZ2RlOTk6YP38+rl+/jueee86cXS1Was0NMLsas6s1N8DsubMbtlmCg4Nx8+ZNvPnmmzh9+jSaNm1qzq6SrTN3JcYcDHuoV6xYIRUrVjS5drW1ssVMIsxlTWwxk4jImTNnpHnz5lK7dm0JDg6Wjz76yNxdKha2mMsWM9kCw/l0Hnd0mOGQuldeeUWqVq0qZ8+elXPnzsn8+fOVy6Na6omWjak1twizi6gvu1pzizC7SPFkv3fv3hOti6ioVFkIMbh7967NHGphYIuZRJjLmthipuzsbDlz5gxzWQFbzGStfv75ZwkODhaNRiObN28WEXmsE/0Z/wiuUKGC1KlTRzQajfTo0UM5ztySqTW3CLOrMbtac4swe3Fm79mzpyQkJLAIQqVKI/JgLBIRERFRMTh06BCmTZsGb29v3L9/H8eOHcPZs2cfe/nU1FRs27YNL774IgIDAzFjxgx07969BHtcPNSaG2B2NWZXa26A2dWanWyMuSsxREREZFuuX78uH330kZw5c0ZOnTol5cuXlw8++EBEHm+v4fbt26VMmTIyadKkku5qsVJrbhFmV2N2teYWYXa1ZifbwhEhREREVCR79+5FYGAgfH19lbasrCyUKVMGIoKZM2fivffew9WrV+Hp6QkRKfREyklJSbC3t4eTk1NpdP+pqTU3wOxqzK7W3ACzqzU72TYWQoiIiOip7NixA8OGDYNer4dOp0PHjh3x+uuvIyQkRLkKgEajwY0bN9C2bVs0bNgQy5cvf+QPZUun1twAs6sxu1pzA8yu1uykEiU/6ISIiIhszbVr16RRo0YyceJEuXDhgnz99dcSFBQkvXr1kitXrojIwysEiIisW7dONBqNHD58WEREMjMzJTk52Sx9Lwq15hZhdjVmV2tuEWZXa3ZSDxZCiIiI6InFxMSIk5OTXLhwQWnbsGGDtGjRQoYPH660Ga4CkJiYKB07dpSWLVvK8ePHpWPHjrJo0SKruUykgVpzizC7GrOrNbcIs6s1O6mH1twjUoiIiMj6xMXFISwsDDqdTmnr3r072rdvj927d2PXrl0AAL1eDwBwdXXFsGHD8OuvvyIyMhLp6el44YUXYGdnZ5b+Py215gaYXY3Z1ZobYHa1Zif1YCGEiIiInlitWrVw6tQpnDlzRmmzs7NDp06d4O/vj2+//VZpy8rKwqpVq9C3b1/Ur18f+/fvx86dO1G+fHlzdf+pqTU3wOxqzK7W3ACzqzU7qQcLIURERPTEateujdatW2POnDlITk5W2qOiouDt7Y1Lly4pewtTUlJw4sQJzJ07F/v370f9+vXN1e0iU2tugNnVmF2tuQFmV2t2UhFzH5tDROZz+fJlASBHjhwp0npatmwpr7zySrH0ydZkZGRI9erV5ffffxeR4nvOc1u4cKF06dKlWNdJ9ChHjx4Ve3t7WbhwoWRkZCjt77zzjtSoUcOMPStZas0twuxqzK7W3CLMrtbspA4cEUKqdOvWLYwePRpBQUFwcHCAv78/unbtih07dpi7azZJp9PhvffeQ2hoKJycnODp6YmGDRti6dKlj72OK1euQKPR4OjRo4+cd+PGjWjUqBHc3d3h6uqKWrVqYezYscr0FStWQKPRICwsLM+yX3/9NTQaDQIDA/NMS0tLg6enJypWrIiMjIzH6veiRYtQrVo1NGnS5LHmf1pDhw7F4cOHsXv37hJ9HCJjkZGR+O9//4t3330Xq1evRkpKCpKSknDw4EEMGDDA3N0rMWrNDTC7GrOrNTfA7GrNTupgb+4OEJW2K1euoGnTpvDw8MCHH36IiIgIZGVlYdu2bRg5cqTJ8ZBUPKZOnYrFixfjk08+Qf369ZGYmIiDBw8iPj6+2B9rx44d6N27N2bMmIFu3bpBo9Hg1KlT2L59u8l8Li4uuHPnDvbu3YvGjRsr7cuWLUPVqlXzXfeGDRtQq1YtiAg2bdqE3r17F9oXEcEnn3yCadOmFT3YI5QtWxb9+vXD/Pnz0bx58xJ/PCKD6dOnIz4+HhMnTsRnn32GW7duwcXFBXPmzDF310qUWnMDzK7G7GrNDTC7WrOTCph7SApRaevYsaNUrlw53+ubx8fHK7evXr0q3bp1ExcXF3F1dZV//vOfcuvWLWX65MmTJTIyUpYtWyb+/v7i4uIiI0aMkOzsbHn//felUqVK4uXlJdOnTzd5DACyaNEi6dy5szg5OUloaKjs2bNHzp8/Ly1bthRnZ2dp3LixySXLLly4IN26dRNvb29xcXGR+vXry/bt203WGxAQIDNmzJAhQ4ZIuXLlxN/fXxYvXmwyz759+yQqKkocHBykXr168s033+Q5TOPPP/+UDh06iIuLi3h7e8uAAQMkNjZWmZ6cnCwvvviiuLi4iI+Pj8yePfuRh8ZERkbKlClTCpwuIvLjjz9K06ZNxd3dXTw9PaVz584mzwEAk38tW7bMdz2vvPKKtGrVqtDHWr58ubi7u8uoUaPkpZdeUtqvX78uDg4OMn78eAkICMizXKtWrWTRokWycOFCadeuXaGPISJy4MAB0Wq1kpiYqLTlPjQmOztbhgwZIjVr1pSrV68qWZ/0PSIismvXLilbtqykpqY+sm9ExSktLU0OHz4sS5culdWrV5u7O6VGrblFmF2N2dWaW4TZ1ZqdbBsLIaQq9+7dE41GIzNnzix0Pp1OJ1FRUdKsWTM5ePCg/PHHH1KvXj2Tje/JkydLuXLl5B//+IecPHlSvvvuOylbtqy0b99eRo8eLWfOnJHPP/9cAMgff/yhLAdAKleuLF9++aWcPXtWevToIYGBgfLss8/K1q1b5dSpU9KoUSPp0KGDsszRo0dl0aJF8ueff8q5c+dkwoQJ4ujoqGw4i+QUQjw9PeXTTz+V8+fPy6xZs0Sr1cqZM2dERCQpKUm8vLykX79+cuLECdm8ebMEBQWZbJTHx8eLl5eXvPXWW3L69Gk5fPiwtGvXTlq3bq08zogRI6Rq1ary008/yfHjx6VLly7i6upaaCGkffv20qJFC7lz506B8/zvf/+TDRs2yPnz5+XIkSPStWtXiYiIEJ1OJyIi+/fvFwDy008/yc2bN+XevXv5rmfWrFni5eUlf/75Z4GPZSiEHD58WNzc3CQlJUVERN59913p3r27fPzxx3kKIRcuXBAHBweJi4uTe/fuiaOjo1y5cqXAxxARmTNnjoSGhpq0GRdC0tPTpWfPnhIdHW3y3DzNe0REJCUlRbRarfz888+F9ouIiIiISM1YCCFV2bdvnwCQb775ptD5YmJixM7OTq5du6a0nTx5UgDI/v37RSSnEOLs7Gyyt799+/YSGBiobLyLiNSsWVNmzZql3AcgEyZMUO7v3btXAMiyZcuUtvXr14ujo2OhfaxVq5YsWLBAuR8QECADBgxQ7uv1evH29paFCxeKiMjixYulQoUKkpaWpsyzcOFCk0LIu+++K88995zJ41y/fl0AyNmzZyUpKUnKli0rX331lTL93r174uTkVGgh5OTJkxIWFiZarVYiIiJk+PDhsmXLlkLzxcbGCgCloPG4JxlNTk6WTp06CQAJCAiQ3r17y7JlyyQ9PV2Zx1AIERGJioqSlStXil6vl+rVq8u3336bbyHk7bfflh49eij3u3fvLpMnTy60L6+88oo8++yzJm2GHLt375Y2bdpIs2bNJCEhwWSeorxHypcvLytWrCi0X0REREREasaTpZKqiMhjzXf69Gn4+/vD399faQsPD4eHhwdOnz6ttAUGBsLV1VW5X6lSJYSHh0Or1Zq03blzx2T9derUMZkOABERESZt6enpSExMBAAkJyfj9ddfR1hYGDw8PFCuXDmcPn0a165dK3C9Go0GPj4+ymOfPn0aderUgaOjozKP8bkxAODYsWP4+eefUa5cOeVfaGgoAODixYu4ePEiMjMz0bBhQ2UZT09P1KxZM/8n0ui5O3HiBP744w8MHToUd+7cQdeuXfHSSy8p85w/fx59+/ZFUFAQ3NzclJOV5s74KC4uLvjhhx9w4cIFTJgwAeXKlcNrr72GZ555BqmpqXnmHzp0KJYvX45du3YhJSUFnTp1yjOPTqfDypUrTU4ONmDAAKxYsUK5fFx+0tLSTJ5vY3379kVKSgpiYmLg7u6eZ/qTvkcMnJyc8s1JREREREQ5WAghVQkODoZGoym2E6KWKVPG5L5Go8m3LffGsvE8Go2mwDbDcq+//jo2btyImTNnYvfu3Th69CgiIiKQmZn5yP4UtqGeW3JyMrp27YqjR4+a/Dt//jxatGjx2OvJj1arRYMGDTB27Fh88803WLFiBZYtW4bLly8DALp27Yq4uDh89tln2LdvH/bt2wcAeTI+rurVq+Oll17C0qVLcfjwYZw6dQpffvllnvn69++PP/74A1OmTMGLL74Ie/u855Detm0b/v77b/Tu3Rv29vawt7dHnz59cPXq1UKvNFSxYsUCTwjbqVMnHD9+HHv37s13+pO+Rwzi4uLg5eVVYJ+IiIiIiNSOhRBSFU9PT7Rv3x6ffvopUlJS8kxPSEgAAISFheH69eu4fv26Mu3UqVNISEhAeHh4aXVX8fvvv2Pw4MHo2bMnIiIi4OPjgytXrjzROsLCwnD8+HGkp6crbX/88YfJPHXr1sXJkycRGBiIGjVqmPxzcXFB9erVUaZMGaVIAQDx8fE4d+7cE2cyPI8pKSm4d+8ezp49iwkTJqBNmzYICwvLU0AoW7YsgJzRGU8qMDAQzs7O+b7mnp6e6NatG3bt2oWhQ4fmu/yyZcvQp0+fPAWiPn36YNmyZQU+bnR0NM6cOZPvSKQRI0bgvffeUx67OFy8eBHp6emIjo4ulvUREREREdkiFkJIdT799FPodDo888wz2LBhA86fP4/Tp09j/vz5yqEibdu2RUREBPr374/Dhw9j//79GDhwIFq2bIn69euXep+Dg4PxzTff4OjRozh27Bj69ev3RCM9AKBfv37QaDQYNmwYTp06hS1btmD27Nkm84wcORJxcXHo27cvDhw4gIsXL2Lbtm0YMmQIdDodypUrh3/961944403sHPnTpw4cQKDBw82ORQoP//4xz/w8ccfY9++fbh69Sp++eUXjBw5EiEhIQgNDUX58uVRoUIFLFmyBBcuXMDOnTsxbtw4k3V4e3vDyckJW7duxe3bt3H//n0AwMaNG5XDdwBgypQpePPNN/HLL7/g8uXLOHLkCIYOHYqsrCy0a9cu3/6tWLECd+/eNVmPQWxsLDZv3oxBgwahdu3aJv8GDhyITZs2IS4uLt/1tm7dGsnJyTh58mS+00ePHo3p06ejS5cu+O233wp9Dh/H7t27ERQUhOrVqxd5XUREREREtoqFEFKdoKAgHD58GK1bt8Zrr72G2rVro127dtixYwcWLlwIIOewg2+//Rbly5dHixYt0LZtWwQFBeV7aEVpmDNnDsqXL48mTZqga9euaN++PerWrftE6yhXrhw2b96MP//8E9HR0XjnnXfw/vvvm8zj5+eH33//HTqdDs899xwiIiIwduxYeHh4KMWODz/8EM2bN0fXrl3Rtm1bNGvWDPXq1Sv0sdu3b4/Nmzeja9euCAkJwaBBgxAaGoqYmBjY29tDq9Xiiy++wKFDh1C7dm28+uqr+PDDD03WYW9vj/nz52Px4sXw8/ND9+7dAQD379/H2bNnlflatmyJS5cuYeDAgQgNDUXHjh1x69YtxMTEFHguEycnJ1SoUCHfaatWrYKLiwvatGmTZ1qbNm3g5OSENWvW5LtshQoV0LNnT6xdu7bA52bs2LGYOnUqOnXqhD179hQ43+NYv349hg0bVqR1EBERERHZOo087tkjiYjoiR0/fhzt2rXDxYsXUa5cuRJ7nJMnT+LZZ5/FuXPn8j35KhERERER5eCIECKiElSnTh28//77yklhS8rNmzexatUqFkGIiIiIiB6BI0KIiIiIiIiISDU4IoSIiIiIyAa1atUKY8eOzdO+YsUKeHh4IDAwEBqNpsB/gwcPBgBcuHABQ4YMQZUqVeDg4IBq1aqhb9++OHjwYOkGIiIqJvbm7gAREREREZW+AwcOKJel37NnD55//nmcPXsWbm5uAHJOJn7w4EG0adMGtWvXxuLFixEaGoqkpCR8++23eO2114rtEvBERKWJhRAiIiIiIhXy8vJSbnt6egLIuVy9h4cHAEBEMHjwYAQHB2P37t3KFeQAICoqCq+88kqp9peIqLiwEEJERERERHkcPXoUJ0+exLp160yKIAaGggkRkbXhOUKIiIiIiCiP8+fPAwBCQ0PN3BMiouLFQggREREREeXBi0sSka1iIYSIiIiIyAa5ubnh/v37edoTEhLg7u7+yOVDQkIAAGfOnCn2vhERmRMLIURERERENqhmzZo4fPhwnvbDhw8rRY7CREVFITw8HB999BH0en2e6QkJCcXRTSKiUsdCCBERERGRDRoxYgTOnTuHMWPG4Pjx4zh79izmzJmD9evX47XXXnvk8hqNBsuXL8e5c+fQvHlzbNmyBZcuXcLx48cxY8YMdO/evRRSEBEVPxZCiIiIiIhsUFBQEH799VecOXMGbdu2RcOGDfHVV1/h66+/RocOHR5rHc888wwOHjyIGjVqYNiwYQgLC0O3bt1w8uRJzJ07t2QDEBGVEI3wLEhEREREREREpBIcEUJEREREREREqsFCCBERERERERGpBgshRERERERERKQaLIQQERERERERkWqwEEJEREREREREqsFCCBERERERERGpBgshRERERERERKQaLIQQERERERERkWqwEEJEREREREREqsFCCBERERERERGpBgshRERERERERKQaLIQQERERERERkWr8P3bvAwLv1JijAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 1100x400 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, (ax_summary, ax_traces) = plt.subplots(1, 2, figsize=(11, 4))\n",
+    "\n",
+    "ax_summary.plot(\n",
+    "    summary[\"SMA_km\"],\n",
+    "    summary[\"TerminalAltitude_km\"],\n",
+    "    marker=\"o\",\n",
+    "    linewidth=1.5,\n",
+    ")\n",
+    "ax_summary.set_xlabel(\"Commanded Sat.SMA (km)\")\n",
+    "ax_summary.set_ylabel(\"Terminal altitude (km)\")\n",
+    "ax_summary.set_title(\"Sweep summary\")\n",
+    "ax_summary.grid(True, alpha=0.3)\n",
+    "\n",
+    "for sma, run in combined.groupby(\"SMA_km\"):\n",
+    "    ax_traces.plot(\n",
+    "        run[\"Sat.UTCGregorian\"],\n",
+    "        run[\"Altitude_km\"],\n",
+    "        label=f\"{sma:.0f} km\",\n",
+    "        linewidth=1,\n",
+    "    )\n",
+    "ax_traces.set_xlabel(\"UTC\")\n",
+    "ax_traces.set_ylabel(\"Altitude (km)\")\n",
+    "ax_traces.set_title(\"Altitude trace per run\")\n",
+    "ax_traces.grid(True, alpha=0.3)\n",
+    "ax_traces.legend(title=\"SMA\", fontsize=8, loc=\"center left\", bbox_to_anchor=(1.01, 0.5))\n",
+    "\n",
+    "fig.autofmt_xdate()\n",
+    "fig.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45fdf39b",
+   "metadata": {},
+   "source": [
+    "## Single-machine demo\n",
+    "\n",
+    "This loop runs the eight cases sequentially in the current Python process — fine for demos, prototyping, and small grids, but it scales linearly in wall-clock with the run count. Distributed sweeps (thousands of cases, Monte Carlo, parallel workers) are out of scope for `gmat-run` by design — that's the job of the future [`astro-tools/gmat-sweep`](https://github.com/astro-tools) library, which will reuse the same `Mission.load` + override pattern under the hood. The library boundary stays at *one process, one script*; everything above lives in tools that wrap it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a51a0598",
+   "metadata": {},
+   "source": [
+    "## Where to next\n",
+    "\n",
+    "- **Sweep something else.** Any field that the script writes to is   fair game — `Sat.ECC`, `Sat.INC`, `FM.PrimaryBodies`,   `Prop.Accuracy`, propagation duration via   `mission[\"Prop.InitialStepSize\"]`, etc.\n",
+    "- **Persist the artefacts.**   `result.persist(\"./run_outputs\")` after each run copies the   per-case ReportFile / EphemerisFile / log into a permanent location   before the temp workspace is reaped.\n",
+    "- **Combine with other outputs.** `result.ephemerides` and   `result.contacts` work the same way — load once, override, run,   consume each output as a DataFrame."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/leo_keplerian.script
+++ b/docs/examples/leo_keplerian.script
@@ -1,0 +1,38 @@
+%  Minimal LEO mission used by docs/examples/02_parameter_sweep.ipynb to
+%  demonstrate the field-override + multi-run pattern. Avoids
+%  OpenFramesInterface / OrbitView so it parses headlessly through gmatpy.
+%  1-hour propagation, Keplerian initial state, position written to a
+%  ReportFile so altitude can be derived per timestep.
+
+Create Spacecraft Sat
+Sat.DateFormat = UTCGregorian
+Sat.Epoch = '01 Jan 2026 12:00:00.000'
+Sat.CoordinateSystem = EarthMJ2000Eq
+Sat.DisplayStateType = Keplerian
+Sat.SMA = 7000
+Sat.ECC = 0.001
+Sat.INC = 28.5
+Sat.RAAN = 75
+Sat.AOP = 90
+Sat.TA = 0
+
+Create ForceModel FM
+FM.CentralBody = Earth
+FM.PointMasses = {Earth}
+FM.Drag = None
+FM.SRP = Off
+
+Create Propagator Prop
+Prop.FM = FM
+Prop.Type = PrinceDormand78
+Prop.InitialStepSize = 60
+Prop.Accuracy = 1e-9
+
+Create ReportFile RF
+RF.Filename = 'leo_keplerian_report.txt'
+RF.Precision = 16
+RF.WriteHeaders = true
+RF.Add = {Sat.UTCGregorian, Sat.X, Sat.Y, Sat.Z}
+
+BeginMissionSequence
+Propagate Prop(Sat) {Sat.ElapsedSecs = 3600}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
   - CLI usage: cli.md
   - Examples:
       - Load / run / plot: examples/01_load_run_plot.ipynb
+      - Parameter sweep: examples/02_parameter_sweep.ipynb
   - API reference: reference.md
 
 plugins:

--- a/src/gmat_run/mission.py
+++ b/src/gmat_run/mission.py
@@ -165,6 +165,23 @@ class Mission:
                 f"GMAT could not parse '{script_path}'; "
                 "check the GMAT log file for the underlying error"
             )
+        # Resolve every loaded Spacecraft against itself so that pre-run field
+        # writes (e.g. ``mission["Sat.SMA"] = 7100``) see a fully-coupled state.
+        # Without this, GMAT's setter validator runs against an unresolved
+        # internal Cartesian state and rejects otherwise-valid Keplerian writes
+        # with a bogus "ECC > 1" error. The sandbox-wide ``gmat.Initialize()``
+        # would also work but breaks scripts with EventLocator resources
+        # (Ex_ContactLocatorAllFormats: a second pre-run init flips
+        # ``RunScript`` to a failure status), so target Spacecraft only.
+        # ``RunScript`` re-initialises internally, so this only enables the
+        # pre-run write path; it does not change run-time semantics.
+        api_exception = _get_api_exception(gmat)
+        try:
+            _initialize_spacecraft(gmat)
+        except api_exception as exc:
+            raise GmatLoadError(
+                f"GMAT raised {type(exc).__name__} initialising '{script_path}': {exc}"
+            ) from exc
         return cls(gmat=gmat, install=install, script_path=script_path)
 
     @property
@@ -678,6 +695,35 @@ def _safe_read(path: Path) -> str:
         return path.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return ""
+
+
+def _initialize_spacecraft(gmat: ModuleType) -> None:
+    """Call ``Initialize`` on every Spacecraft loaded into the sandbox.
+
+    Walks the Spacecraft registry via ``Moderator.GetListOfObjects`` keyed by
+    the ``SPACECRAFT`` enum and invokes ``Initialize`` on each handle that
+    exposes one. Missing enums, missing moderator, or objects without
+    ``Initialize`` are tolerated silently — fakes vary, and the only callers
+    that need this method to succeed are the Keplerian-field-write tests on
+    real GMAT, which always have all three.
+    """
+    type_id = getattr(gmat, _SPACECRAFT_TYPE_ENUM_ATTR, None)
+    if type_id is None:
+        return
+    moderator_proxy = getattr(gmat, "Moderator", None)
+    if moderator_proxy is None:
+        return
+    moderator = moderator_proxy.Instance()
+    try:
+        names = list(moderator.GetListOfObjects(type_id))
+    except Exception:
+        return
+    for name in names:
+        obj = gmat.GetObject(name)
+        init = getattr(obj, "Initialize", None) if obj is not None else None
+        if init is None:
+            continue
+        init()
 
 
 def _get_api_exception(gmat: ModuleType) -> type[BaseException]:

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -93,3 +93,29 @@ def test_minimal_mission_runs_end_to_end(
 
     # The output dir holds the actual report file written by GMAT.
     assert (result.output_dir / "leo_state.txt").is_file()
+
+
+def test_keplerian_field_override_after_load_runs_clean(
+    gmat_available: None,
+    minimal_script: Path,
+) -> None:
+    """Pre-run subscript writes against Keplerian fields actually take effect.
+
+    Regression guard: prior to the ``gmat.Initialize()`` call inside
+    ``Mission.load``, writing ``mission["Sat.SMA"]`` after load raised a
+    spurious "ECC > 1" validation error from GMAT, even though the loaded
+    spacecraft was clearly elliptical. The pattern is documented in
+    ``docs/getting-started.md`` and demonstrated in
+    ``docs/examples/02_parameter_sweep.ipynb``, so it has to survive engine
+    upgrades.
+    """
+    new_sma = 7500.0
+
+    mission = Mission.load(minimal_script)
+    mission["Sat.SMA"] = new_sma
+    result = mission.run()
+
+    # Override survives the run — the report's first SMA row reflects the
+    # written value, modulo numerical round-trip through Cartesian.
+    df = result.reports["RF"]
+    assert df["Sat.SMA"].iloc[0] == pytest.approx(new_sma, rel=1e-6)

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -71,6 +71,8 @@ class _FakeObject:
         type_name: str,
         name: str,
         fields: dict[str, tuple[int, Any, bool]],
+        *,
+        initialize_raises: BaseException | None = None,
     ) -> None:
         # fields: {field_name: (type_code, value, read_only)}
         self._type = type_name
@@ -78,6 +80,8 @@ class _FakeObject:
         self._fields = fields
         self._order = list(fields.keys())
         self.set_calls: list[tuple[str, Any]] = []
+        self.init_calls: int = 0
+        self._initialize_raises = initialize_raises
 
     def GetTypeName(self) -> str:
         return self._type
@@ -141,6 +145,11 @@ class _FakeObject:
             raise RuntimeError(f"field '{name}' is read-only")
         self._fields[name] = (type_code, value, read_only)
         self.set_calls.append((name, value))
+
+    def Initialize(self) -> None:
+        self.init_calls += 1
+        if self._initialize_raises is not None:
+            raise self._initialize_raises
 
 
 # --- fake gmat module factory -------------------------------------------------
@@ -408,6 +417,46 @@ def test_load_passes_explicit_gmat_root_through(
 
     Mission.load(tmp_path / "x.script", gmat_root="/explicit/path")
     assert captured["root"] == "/explicit/path"
+
+
+def test_load_initialises_each_spacecraft_after_parse(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    install = _make_install(tmp_path / "gmat")
+    sat_a = _spacecraft("SatA")
+    sat_b = _spacecraft("SatB")
+    gmat = _make_fake_gmat({"SatA": sat_a, "SatB": sat_b})
+    monkeypatch.setattr("gmat_run.mission.locate_gmat", lambda gmat_root=None: install)
+    monkeypatch.setattr("gmat_run.mission.bootstrap", lambda _install: gmat)
+
+    script = tmp_path / "any.script"
+    script.write_text("# fake\n", encoding="utf-8")
+
+    Mission.load(script)
+
+    assert sat_a.init_calls == 1
+    assert sat_b.init_calls == 1
+
+
+def test_load_wraps_spacecraft_initialize_failure_as_gmat_load_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    install = _make_install(tmp_path / "gmat")
+    sat = _FakeObject(
+        "Spacecraft",
+        "Sat",
+        {"SMA": (_TYPE_CODES["REAL_TYPE"], 7000.0, False)},
+        initialize_raises=_FakeAPIException("bad force model"),
+    )
+    gmat = _make_fake_gmat({"Sat": sat})
+    monkeypatch.setattr("gmat_run.mission.locate_gmat", lambda gmat_root=None: install)
+    monkeypatch.setattr("gmat_run.mission.bootstrap", lambda _install: gmat)
+
+    with pytest.raises(GmatLoadError) as excinfo:
+        Mission.load(tmp_path / "bad.script")
+
+    assert "bad.script" in str(excinfo.value)
+    assert "bad force model" in str(excinfo.value)
 
 
 # --- gmat property ------------------------------------------------------------


### PR DESCRIPTION
## Summary
- New `docs/examples/02_parameter_sweep.ipynb` + `docs/examples/leo_keplerian.script`: load → override `Sat.SMA` → run → tabulate terminal altitude → plot, eight values across a 1400 km SMA grid. Wired into the MkDocs nav and the CI smoke-execute step.
- Library fix in `Mission.load`: initialize each loaded `Spacecraft` so pre-run subscript writes against derived Keplerian fields (`Sat.SMA`, `Sat.ECC`, …) actually take effect on real GMAT R2026a. Targets `Spacecraft` only — sandbox-wide `gmat.Initialize()` would also fix the writes but breaks `EventLocator` scripts. Covered by a new integration smoke test plus updated unit tests for the load path.
- Charter callout in the notebook: distributed sweeps belong to a future `astro-tools/gmat-sweep`, not this library.

## Test plan
- [x] `uv run pytest` — 505 passed
- [x] `uv run pytest -m integration` — 10 passed (incl. new `test_keplerian_field_override_after_load_runs_clean`)
- [x] `uv run ruff check`, `uv run ruff format --check`, `uv run mypy` — all clean
- [x] `uv run jupyter execute docs/examples/02_parameter_sweep.ipynb` — completes in ~18 s with sensible outputs (well under the 2 min DoD)
- [x] `uv run mkdocs build --strict` — new notebook renders under Examples in the nav

Closes #41