### PR TITLE
Add macos-latest to CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         python-version: ['3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
@@ -101,6 +101,40 @@ jobs:
           Move-Item -Path $gmatRoot -Destination (Join-Path $env:RUNNER_TEMP 'gmat')
           Remove-Item gmat.zip
           Remove-Item $extractDir -Recurse -Force -ErrorAction SilentlyContinue
+
+      - name: Download and extract GMAT (macOS)
+        if: runner.os == 'macOS' && steps.cache-gmat.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          url="https://sourceforge.net/projects/gmat/files/GMAT/GMAT-${GMAT_VERSION}/gmat-mac-x64-${GMAT_VERSION}-signed.dmg/download"
+          # --retry-all-errors covers mid-stream connection drops from slow SourceForge mirrors
+          # (plain --retry only retries on initial connection failures).
+          curl -fL --retry 5 --retry-delay 10 --retry-all-errors --connect-timeout 30 \
+            -o gmat.dmg "$url"
+          # The R2026a macOS DMG is ~455 MB; threshold is conservatively 400 MB.
+          size=$(stat -f%z gmat.dmg)
+          echo "Downloaded gmat.dmg size: $size bytes"
+          if [ "$size" -lt 419430400 ]; then
+            echo "::error::Downloaded archive looks truncated ($size bytes); aborting"
+            exit 1
+          fi
+          mount_point="${RUNNER_TEMP}/gmat-dmg"
+          # -nobrowse keeps the volume out of Finder; </dev/null guards against any
+          # interactive SLA prompt blocking the runner.
+          hdiutil attach -nobrowse -readonly -noautoopen -mountpoint "$mount_point" gmat.dmg < /dev/null
+          api_script=$(find "$mount_point" -name BuildApiStartupFile.py -print -quit)
+          if [ -z "$api_script" ]; then
+            echo "::error::Could not locate BuildApiStartupFile.py in mounted DMG"
+            find "$mount_point" -maxdepth 3 -type d
+            hdiutil detach "$mount_point" || true
+            exit 1
+          fi
+          gmat_root=$(dirname "$(dirname "$api_script")")
+          # cp -R because mv across the DMG mount boundary would fail (read-only volume).
+          cp -R "$gmat_root" "${RUNNER_TEMP}/gmat"
+          hdiutil detach "$mount_point"
+          rm gmat.dmg
 
       - name: Resolve GMAT_ROOT
         shell: bash

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ gmat-run loads it, lets you override fields from Python, runs the mission headle
 
 | GMAT release | Status | CI |
 |---|---|---|
-| R2026a | Primary development target | Exercised on every PR (Ubuntu + Windows) |
+| R2026a | Primary development target | Exercised on every PR (Ubuntu + Windows + macOS) |
 | R2025a | Expected to work | Not exercised in CI for v0.1 |
 | R2024a | Expected to work | Not exercised in CI for v0.1 |
 | R2023a | Expected to work | Not exercised in CI for v0.1 |

--- a/src/gmat_run/install.py
+++ b/src/gmat_run/install.py
@@ -165,7 +165,9 @@ def _glob_patterns_for_platform(platform: str) -> list[str]:
     if platform == "win32":
         return [r"C:\Program Files\GMAT*", r"C:\Program Files (x86)\GMAT*"]
     if platform == "darwin":
-        return ["/Applications/GMAT*"]
+        # Upstream allows either /Applications or ~/Applications; plugin loading
+        # only works from one of these two locations.
+        return ["/Applications/GMAT*", "~/Applications/GMAT*"]
     return ["~/gmat-*", "/opt/gmat-*"]
 
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -191,6 +191,14 @@ def test_glob_patterns_per_platform(platform: str, expected_pattern_substr: str)
     assert any(expected_pattern_substr in p for p in patterns)
 
 
+def test_darwin_globs_cover_both_applications_dirs() -> None:
+    # Upstream supports installing under /Applications or ~/Applications;
+    # both must be discoverable.
+    patterns = install._glob_patterns_for_platform("darwin")
+    assert any(p.startswith("/Applications/") for p in patterns)
+    assert any(p.startswith("~/Applications/") for p in patterns)
+
+
 # --- PATH ---------------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

- Add `macos-latest` to the `test` job matrix in `ci.yml` so R2026a × Python 3.10/3.11/3.12 is exercised on macOS alongside Ubuntu and Windows.
- New "Download and extract GMAT (macOS)" step pulls `gmat-mac-x64-R2026a-signed.dmg` from SourceForge, mounts it via `hdiutil`, and copies the GMAT root into `${RUNNER_TEMP}/gmat` — same end shape as the Linux/Windows steps so the shared `Resolve GMAT_ROOT` / startup-file / pytest / coverage steps work unchanged.
- Extend `_glob_patterns_for_platform("darwin")` to include `~/Applications/GMAT*` (upstream allows either `/Applications` or `~/Applications`), with a focused test asserting both are covered.
- README supported-versions table: R2026a CI column now lists Ubuntu + Windows + macOS.

Coverage gates and the example-notebook smoke stay Linux-only — one runner is enough since their inputs are platform-independent.

## Test plan

- [x] CI green on `macos-latest` × Python 3.10/3.11/3.12 (both unit and integration suites).
- [x] CI still green on Ubuntu and Windows — no regression in the existing two platforms.
- [ ] First macOS run actually finds `bin/gmatpy/` in the unpacked DMG (this is the load-bearing assumption — the upstream R2026a macOS layout was inferred from the README, not directly verified).
- [x] DMG download stays under the 30-min job timeout on a cold cache; subsequent runs hit the GMAT cache.

Closes #43.