### PR TITLE
Polish README for v0.2: showcase ephemerides/contacts, refresh CI matrix, link all example notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ gmat-run loads it, lets you override fields from Python, runs the mission headle
 | GMAT release | Status | CI |
 |---|---|---|
 | R2026a | Primary development target | Exercised on every PR (Ubuntu + Windows + macOS) |
-| R2025a | Expected to work | Not exercised in CI for v0.1 |
-| R2024a | Expected to work | Not exercised in CI for v0.1 |
-| R2023a | Expected to work | Not exercised in CI for v0.1 |
-| R2022a | Expected to work | Not exercised in CI for v0.1 |
+| R2025a | Expected to work | Not exercised in CI |
+| R2024a | Expected to work | Not exercised in CI |
+| R2023a | Expected to work | Not exercised in CI |
+| R2022a | Expected to work | Not exercised in CI |
 
 A wider CI matrix is planned for a follow-up release; report any version-specific breakage as
 an issue and we'll add a CI cell for it.
@@ -46,9 +46,15 @@ an issue and we'll add a CI cell for it.
 pip install gmat-run
 ```
 
+For SPK ephemerides, install the `spiceypy` extra:
+
+```bash
+pip install gmat-run[spiceypy]
+```
+
 ## Quick start
 
-Load a script, override a field, run the mission, and read the resulting `ReportFile` as a
+Load a script, override a field, run the mission, and read each output GMAT wrote as a
 pandas DataFrame:
 
 ```python
@@ -57,15 +63,25 @@ from gmat_run import Mission
 mission = Mission.load("flyby.script")
 mission["Sat.SMA"] = 7000
 result = mission.run()
+
+# ReportFile → DataFrame, with UTCGregorian / *ModJulian epoch columns
+# promoted to datetime64[ns].
 result.reports["ReportFile1"].plot(x="UTCGregorian", y="Sat.Earth.Altitude")
+
+# EphemerisFile → DataFrame, dispatching on file format.
+ephem = result.ephemerides["EphemerisFile1"]
+
+# ContactLocator → DataFrame; df.attrs["report_format"] carries the variant.
+contacts = result.contacts["ContactLocator1"]
 ```
 
 `Mission.load` discovers a local GMAT install (honouring the `GMAT_ROOT` environment variable
 or a `gmat_root=` argument), bootstraps `gmatpy`, and parses the script into the live GMAT
 object graph. Subscript access reads and writes fields against that graph with type coercion.
 `mission.run()` executes the mission sequence headlessly, captures GMAT's log, and returns a
-`Results` whose `reports` mapping parses each `ReportFile` to a DataFrame on first access —
-with `UTCGregorian` and `*ModJulian` epoch columns promoted to `datetime64[ns]`.
+`Results` exposing three lazy mappings — `reports`, `ephemerides`, and `contacts` — each
+keyed by the GMAT resource name and parsing to a DataFrame on first access. See
+[Outputs](#outputs) below for the formats covered.
 
 A `gmat-run` console script is also installed for shell-script and smoke-test use:
 
@@ -76,9 +92,19 @@ gmat-run run flyby.script --out results/
 See the [CLI reference](https://astro-tools.github.io/gmat-run/cli/) for flags, exit codes,
 and sample output.
 
-For a runnable walkthrough, see the [Load / run / plot example
-notebook](https://astro-tools.github.io/gmat-run/examples/01_load_run_plot/) — it loads a
-stock GMAT sample, runs it, and plots altitude over time end-to-end.
+## Outputs
+
+`Results` exposes three mappings, each keyed by the GMAT resource name as declared in the
+`.script`:
+
+- **`ReportFile`** → DataFrame, with `UTCGregorian` and `*ModJulian` epoch columns promoted
+  to `datetime64[ns]`.
+- **`EphemerisFile`** → DataFrame, dispatching on file format: **CCSDS-OEM** and
+  **STK-TimePosVel** are read out of the box; **SPK** (NASA SPICE binary) is read with the
+  `[spiceypy]` extra installed. **Code-500** (GSFC binary) is tracked for v0.3 (#50).
+- **`ContactLocator`** → DataFrame, supporting Legacy and the five tabular `ReportFormat`
+  variants. `df.attrs["report_format"]` carries the variant name so downstream code can
+  branch on it without inspecting the column set.
 
 ## Documentation
 
@@ -87,6 +113,17 @@ Full docs at **<https://astro-tools.github.io/gmat-run/>**, including a
 [GMAT install instructions](https://astro-tools.github.io/gmat-run/install-gmat/),
 the [CLI reference](https://astro-tools.github.io/gmat-run/cli/),
 and the [API reference](https://astro-tools.github.io/gmat-run/reference/).
+
+Runnable example notebooks:
+
+- [Load / run / plot](https://astro-tools.github.io/gmat-run/examples/01_load_run_plot/) —
+  load a stock GMAT sample, run it, and plot altitude over time end-to-end.
+- [Parameter sweep](https://astro-tools.github.io/gmat-run/examples/02_parameter_sweep/) —
+  vary `Sat.SMA` across a range, run the same script for each, and overlay the resulting
+  orbits.
+- [Ground track](https://astro-tools.github.io/gmat-run/examples/03_ground_track/) — read an
+  `EphemerisFile` from `Results.ephemerides` and plot the spacecraft's ground track on a
+  Cartopy world map.
 
 ## Development
 


### PR DESCRIPTION
## Summary

- Extend Quick start to show all three `Results` mappings (`reports`, `ephemerides`, `contacts`) and add an Outputs section covering the v0.2 parser surface (CCSDS-OEM, STK-TimePosVel, SPK via the `[spiceypy]` extra; Code-500 still tracked for v0.3).
- Note the `[spiceypy]` extra under Installation so SPK users know what to install.
- Drop `"for v0.1"` from the Supported GMAT versions table; link all three example notebooks (load/run/plot, parameter sweep, ground track) under Documentation instead of only the first.

## Test plan

- [ ] README renders cleanly on GitHub (table, code blocks, anchors).
- [ ] `[Outputs](#outputs)` anchor in Quick start resolves to the new section.
- [ ] All three example-notebook links resolve on the docs site.
- [ ] PyPI render is sane on the next release (no broken relative links).

Closes #58