### PR TITLE
Cut v0.2.0: bump version, add CHANGELOG, sync getting-started CI matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,70 @@
+# Changelog
+
+All notable changes to gmat-run are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.2.0] — 2026-04-26
+
+### Added
+
+- `EphemerisFile` parser → `pandas.DataFrame`, dispatching on file format:
+  CCSDS-OEM (#46), STK-TimePosVel (#51), and SPK via the `[spiceypy]` extra (#60).
+- CCSDS-AEM attitude ephemeris parser, exposed through `Mission.attitude_inputs`
+  for files referenced by a `Spacecraft.AttitudeFileName` (#52).
+- `ContactLocator` parser → `Results.contacts`, supporting the Legacy report and
+  the five tabular `ReportFormat` variants. `df.attrs["report_format"]` carries
+  the variant so downstream code can branch without inspecting columns (#53).
+- `gmat-run` CLI: `gmat-run run SCRIPT [--out DIR]` runs a script headlessly
+  and writes outputs to a chosen directory, with documented exit codes (#54).
+- Example notebooks, runnable end-to-end and rendered into the docs site:
+  load / run / plot a stock GMAT sample (#55), parameter sweep across
+  `Sat.SMA` (#56), and a ground-track plot from `EphemerisFile` (#57).
+- macOS runner in the CI test matrix (#59).
+- Coverage gating in CI: ≥ 80 % overall and ≥ 95 % on
+  `src/gmat_run/parsers/`, both enforced on the Ubuntu / Python 3.12 cell (#59).
+- API reference site polish: per-module navigation, a "Known limitations"
+  page, and full coverage of the public API surface (#61).
+
+### Changed
+
+- README and getting-started docs refreshed for v0.2 — showcases ephemeris
+  and contact support, links every example notebook, and updates the
+  supported-GMAT / CI matrix tables (#62, #63).
+
+## [0.1.1] — 2026-04-25
+
+### Fixed
+
+- Stale install instructions in README and the docs site (#36).
+
+## [0.1.0] — 2026-04-24
+
+Initial public release.
+
+### Added
+
+- `Mission.load` parses a `.script` into the live GMAT object graph;
+  dotted-path subscript access reads and writes fields with type coercion (#26).
+- `Mission.run` executes the mission sequence headlessly, captures GMAT's
+  stdout/stderr, and surfaces failures as typed exceptions (#27).
+- `Results` exposes lazy, name-keyed mappings over GMAT's output files
+  (#25), with `Results.persist` to copy artefacts out of the temp
+  workspace (#28).
+- `ReportFile` parser → `DataFrame`, with `UTCGregorian` and `*ModJulian`
+  epoch columns promoted to `datetime64[ns]` (#21, #22).
+- `locate_gmat` cross-platform GMAT install discovery and `bootstrap` to
+  load `gmatpy` for a resolved install (#18, #19).
+- Typed exception hierarchy under `gmat_run.errors` rooted at
+  `GmatError` (#20).
+- CI on Ubuntu and Windows (Python 3.10 / 3.11 / 3.12), with integration
+  tests against stock GMAT samples (#17, #29).
+- MkDocs-Material documentation site, auto-deployed to GitHub Pages on
+  tag pushes (#30).
+- Release workflow: build, PyPI trusted publishing, and
+  `gh release create --generate-notes` on `v*` tags (#31).
+
+[0.2.0]: https://github.com/astro-tools/gmat-run/compare/v0.1.1...v0.2.0
+[0.1.1]: https://github.com/astro-tools/gmat-run/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/astro-tools/gmat-run/releases/tag/v0.1.0

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -8,13 +8,13 @@
 
 ### Supported GMAT versions
 
-| GMAT release | Status                       | CI                                            |
-| ------------ | ---------------------------- | --------------------------------------------- |
-| R2026a       | Primary development target   | Exercised on every PR (Ubuntu + Windows)      |
-| R2025a       | Expected to work             | Not exercised in CI for v0.1                  |
-| R2024a       | Expected to work             | Not exercised in CI for v0.1                  |
-| R2023a       | Expected to work             | Not exercised in CI for v0.1                  |
-| R2022a       | Expected to work             | Not exercised in CI for v0.1                  |
+| GMAT release | Status                     | CI                                                 |
+| ------------ | -------------------------- | -------------------------------------------------- |
+| R2026a       | Primary development target | Exercised on every PR (Ubuntu + Windows + macOS)   |
+| R2025a       | Expected to work           | Not exercised in CI                                |
+| R2024a       | Expected to work           | Not exercised in CI                                |
+| R2023a       | Expected to work           | Not exercised in CI                                |
+| R2022a       | Expected to work           | Not exercised in CI                                |
 
 A wider CI matrix is planned for a follow-up release; report any version-specific
 breakage as an issue and we'll add a CI cell for it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gmat-run"
-version = "0.1.1"
+version = "0.2.0"
 description = "Run GMAT mission scripts from Python and get results as pandas DataFrames."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/gmat_run/__init__.py
+++ b/src/gmat_run/__init__.py
@@ -13,7 +13,7 @@ from gmat_run.mission import Mission
 from gmat_run.results import Results
 from gmat_run.runtime import bootstrap
 
-__version__ = "0.1.1"
+__version__ = "0.2.0"
 
 __all__ = [
     "GmatError",

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -4,4 +4,4 @@ import gmat_run
 
 
 def test_import() -> None:
-    assert gmat_run.__version__ == "0.1.1"
+    assert gmat_run.__version__ == "0.2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -847,7 +847,7 @@ wheels = [
 
 [[package]]
 name = "gmat-run"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

- Bump `__version__` to `0.2.0` in `pyproject.toml`, `gmat_run/__init__.py`, and the smoke test.
- Add `CHANGELOG.md` (Keep a Changelog) with the v0.2.0 entry plus backfilled v0.1.1 and v0.1.0 entries.
- Refresh the supported-GMAT / CI table in `docs/getting-started.md` to match the README — adds macOS to R2026a and drops the stale `for v0.1` suffix.

The tag push to `v0.2.0` (which triggers PyPI publish + docs deploy + GitHub Release) is not part of this PR — it happens after merge.

## Test plan

- [x] `uv run pytest` — 544 passed.
- [x] `uv run ruff check` — clean.
- [x] `uv run ruff format --check` — clean.
- [x] `uv run mypy` — clean.
- [x] `uv build` — sdist + wheel build cleanly as `gmat_run-0.2.0`.
- [x] `uv run mkdocs build --strict` — site builds without warnings.

Closes #45.