### PR TITLE
Add convert_to= to promote_epochs and the four file-format parsers

### DIFF
--- a/docs/reference/time.md
+++ b/docs/reference/time.md
@@ -37,6 +37,35 @@ df["Sat.TAIGregorian"] = convert(df["Sat.TAIGregorian"], "TAI", "UTC")
 convert_column(df, "Sat.TAIGregorian", "UTC")
 ```
 
+## Parser-level `convert_to`
+
+For the common case of "I want every epoch column on a single scale", the
+parsers and [`promote_epochs`][gmat_run.parsers.epoch.promote_epochs] take
+a `convert_to=` keyword that runs the conversion in one call:
+
+```python
+from gmat_run.parsers.reportfile import parse
+
+# Mixed-scale ReportFile (TAIGregorian + UTCModJulian) → all UTC.
+df = parse("flyby.report", convert_to="UTC")
+
+assert all(scale == "UTC" for scale in df.attrs["epoch_scales"].values())
+```
+
+The same keyword works on every parser whose output carries an
+`epoch_scales` attr:
+
+- [`gmat_run.parsers.reportfile.parse`][gmat_run.parsers.reportfile.parse]
+- [`gmat_run.parsers.ephemeris.parse`][gmat_run.parsers.ephemeris.parse] (CCSDS-OEM)
+- [`gmat_run.parsers.stk_ephemeris.parse`][gmat_run.parsers.stk_ephemeris.parse]
+- [`gmat_run.parsers.aem_ephemeris.parse`][gmat_run.parsers.aem_ephemeris.parse]
+
+CCSDS-OEM and CCSDS-AEM permit `TIME_SYSTEM` values (`UT1`, `GPS`, `TCG`, …)
+that fall outside the five GMAT scales. Calling these parsers with
+`convert_to=` on such a file raises `ValueError` rather than silently
+mis-converting; reach for the underlying [`convert`][gmat_run.time.convert]
+once you have a mapping you trust.
+
 ::: gmat_run.time.convert
 
 ::: gmat_run.time.convert_column

--- a/src/gmat_run/parsers/aem_ephemeris.py
+++ b/src/gmat_run/parsers/aem_ephemeris.py
@@ -47,6 +47,7 @@ from typing import Any, Final
 import pandas as pd
 
 from gmat_run.errors import GmatOutputParseError
+from gmat_run.parsers.epoch import promote_epochs
 
 __all__ = ["is_aem_ephemeris", "parse"]
 
@@ -117,11 +118,19 @@ class _Segment:
     data_start_lineno: int = 0
 
 
-def parse(path: str | os.PathLike[str]) -> pd.DataFrame:
+def parse(path: str | os.PathLike[str], *, convert_to: str | None = None) -> pd.DataFrame:
     """Parse a CCSDS-AEM attitude ephemeris file into a :class:`pandas.DataFrame`.
 
     Args:
         path: Path to the ``.aem`` file on disk.
+        convert_to: If set, the ``Epoch`` column is converted from the file's
+            ``TIME_SYSTEM`` scale to ``convert_to``. Must be one of the five
+            recognised GMAT scales (``A1``, ``TAI``, ``UTC``, ``TT``,
+            ``TDB``); the file's ``TIME_SYSTEM`` must also resolve to one of
+            those (CCSDS-AEM permits values like ``UT1`` or ``GPS`` that
+            ``gmat-run`` does not convert). Conversion is delegated to
+            :func:`gmat_run.parsers.epoch.promote_epochs`, which is gated
+            behind the ``[astropy]`` extra.
 
     Returns:
         A DataFrame with one row per attitude record. Columns depend on the
@@ -155,6 +164,10 @@ def parse(path: str | os.PathLike[str]) -> pd.DataFrame:
             unbalanced, segments declare different ``ATTITUDE_TYPE``s, a
             record's column count is wrong, or an epoch / numeric value
             cannot be parsed.
+        ValueError: ``convert_to`` is set to an unrecognised GMAT scale, or
+            the file's ``TIME_SYSTEM`` is not one of the five GMAT scales.
+        ImportError: ``convert_to`` is set, a non-trivial conversion is
+            required, and ``astropy`` is not installed.
     """
     path = Path(path)
     with path.open(encoding="utf-8-sig", newline=None) as fh:
@@ -197,6 +210,10 @@ def parse(path: str | os.PathLike[str]) -> pd.DataFrame:
     if len(metas) > 1:
         result.attrs["segments"] = [dict(m) for m in metas]
     result.attrs["file_header"] = dict(file_header)
+    if convert_to is not None:
+        # ``Epoch`` has no recognised suffix, so promote_epochs's promotion
+        # loop is a no-op; only its convert_to branch runs.
+        promote_epochs(result, convert_to=convert_to)
     return result
 
 

--- a/src/gmat_run/parsers/ephemeris.py
+++ b/src/gmat_run/parsers/ephemeris.py
@@ -40,6 +40,7 @@ from typing import Any, Final
 import pandas as pd
 
 from gmat_run.errors import GmatOutputParseError
+from gmat_run.parsers.epoch import promote_epochs
 
 __all__ = ["parse"]
 
@@ -89,11 +90,19 @@ class _Segment:
     data_start_lineno: int = 0
 
 
-def parse(path: str | os.PathLike[str]) -> pd.DataFrame:
+def parse(path: str | os.PathLike[str], *, convert_to: str | None = None) -> pd.DataFrame:
     """Parse a CCSDS-OEM ephemeris file into a :class:`pandas.DataFrame`.
 
     Args:
         path: Path to the ``.oem`` (or ``.eph``) file on disk.
+        convert_to: If set, the ``Epoch`` column is converted from the file's
+            ``TIME_SYSTEM`` scale to ``convert_to``. Must be one of the five
+            recognised GMAT scales (``A1``, ``TAI``, ``UTC``, ``TT``,
+            ``TDB``); the file's ``TIME_SYSTEM`` must also resolve to one of
+            those (CCSDS-OEM permits values like ``UT1`` or ``GPS`` that
+            ``gmat-run`` does not convert). Conversion is delegated to
+            :func:`gmat_run.parsers.epoch.promote_epochs`, which is gated
+            behind the ``[astropy]`` extra.
 
     Returns:
         A DataFrame with one row per state record. Columns are ``Epoch`` (a
@@ -116,6 +125,10 @@ def parse(path: str | os.PathLike[str]) -> pd.DataFrame:
         GmatOutputParseError: The file is empty, no ``META_START`` block was
             found, a meta line is malformed, a record's column count is wrong,
             or an epoch / state value cannot be parsed.
+        ValueError: ``convert_to`` is set to an unrecognised GMAT scale, or
+            the file's ``TIME_SYSTEM`` is not one of the five GMAT scales.
+        ImportError: ``convert_to`` is set, a non-trivial conversion is
+            required, and ``astropy`` is not installed.
     """
     path = Path(path)
     with path.open(encoding="utf-8-sig", newline=None) as fh:
@@ -149,6 +162,10 @@ def parse(path: str | os.PathLike[str]) -> pd.DataFrame:
     if len(metas) > 1:
         result.attrs["segments"] = [dict(m) for m in metas]
     result.attrs["file_header"] = dict(file_header)
+    if convert_to is not None:
+        # ``Epoch`` has no recognised suffix, so promote_epochs's promotion
+        # loop is a no-op; only its convert_to branch runs.
+        promote_epochs(result, convert_to=convert_to)
     return result
 
 

--- a/src/gmat_run/parsers/epoch.py
+++ b/src/gmat_run/parsers/epoch.py
@@ -7,11 +7,14 @@ the column name's last dotted segment, converts each to ``datetime64[ns]``,
 and records the time scale on ``df.attrs["epoch_scales"]`` so downstream code
 can branch on it without re-parsing the column name.
 
-No leap-second-correct time-scale *conversion* happens here: a
+No leap-second-correct time-scale *conversion* happens by default: a
 ``TAIModJulian`` column becomes a ``datetime64[ns]`` representing the TAI
-instant, labelled ``"TAI"``. For converting between scales (UTC ↔ TAI / TT /
-TDB / A1) on a promoted DataFrame, see :mod:`gmat_run.time`, which is gated
-behind the ``[astropy]`` extra.
+instant, labelled ``"TAI"``. Pass ``convert_to=`` to convert every promoted
+column to a single target scale in one call — that path delegates to
+:mod:`gmat_run.time` and inherits the ``[astropy]`` extra requirement; see
+:func:`promote_epochs` for the details. For ad-hoc conversion of an
+already-promoted DataFrame, call :func:`gmat_run.time.convert_column`
+directly.
 
 Columns whose name ends in ``Gregorian`` or ``ModJulian`` but are not one of
 the ten recognised names trigger a ``UserWarning`` and are left untouched —
@@ -64,7 +67,7 @@ _MODJULIAN_SUFFIXES: Final[dict[str, str]] = {
 _UNKNOWN_EPOCH_SUFFIX_RE: Final = re.compile(r".+(?:Gregorian|ModJulian)$")
 
 
-def promote_epochs(df: pd.DataFrame) -> pd.DataFrame:
+def promote_epochs(df: pd.DataFrame, *, convert_to: str | None = None) -> pd.DataFrame:
     """Promote recognised epoch columns in ``df`` to ``datetime64[ns]`` in place.
 
     The DataFrame is mutated and returned so callers can chain. Time scales for
@@ -80,6 +83,13 @@ def promote_epochs(df: pd.DataFrame) -> pd.DataFrame:
         df: DataFrame whose columns follow GMAT's ``{resource}.{field}``
             naming convention. Columns whose last segment is one of the ten
             recognised epoch suffixes are promoted.
+        convert_to: If set, every column listed in ``df.attrs["epoch_scales"]``
+            after promotion is converted from its detected scale to
+            ``convert_to`` and ``df.attrs["epoch_scales"]`` is updated
+            accordingly. Must be one of ``"A1"``, ``"TAI"``, ``"UTC"``,
+            ``"TT"``, ``"TDB"``. Conversion is delegated to
+            :func:`gmat_run.time.convert_column`, which is gated behind the
+            ``[astropy]`` extra.
 
     Returns:
         ``df`` itself, mutated in place.
@@ -88,6 +98,13 @@ def promote_epochs(df: pd.DataFrame) -> pd.DataFrame:
         GmatOutputParseError: A recognised epoch column contains values that
             cannot be parsed (malformed Gregorian text, non-numeric ModJulian,
             or a ModJulian value that overflows ``datetime64[ns]``'s range).
+        ValueError: ``convert_to`` is set to a value that is not one of the
+            five recognised GMAT scales, or one of the recorded source scales
+            on ``df`` is not recognised (e.g. a CCSDS ``TIME_SYSTEM`` of
+            ``UT1`` or ``GPS``).
+        ImportError: ``convert_to`` is set, a non-trivial conversion is
+            required, and ``astropy`` is not installed. The message points at
+            the ``gmat-run[astropy]`` extra.
     """
     for column in df.columns:
         suffix = _suffix(str(column))
@@ -113,7 +130,24 @@ def promote_epochs(df: pd.DataFrame) -> pd.DataFrame:
                 UserWarning,
                 stacklevel=2,
             )
+    if convert_to is not None:
+        _convert_all_to(df, convert_to)
     return df
+
+
+def _convert_all_to(df: pd.DataFrame, target: str) -> None:
+    """Convert every entry in ``df.attrs["epoch_scales"]`` to ``target`` in place.
+
+    Imports :mod:`gmat_run.time` lazily so the default ``promote_epochs`` path
+    stays astropy-free. ``convert_column`` validates ``target`` and each
+    source scale, and surfaces the ``[astropy]`` install hint when needed.
+    """
+    from gmat_run.time import convert_column
+
+    scales: dict[str, str] = df.attrs.get("epoch_scales", {})
+    # Snapshot the keys: ``convert_column`` mutates this dict as it goes.
+    for column in list(scales):
+        convert_column(df, column, target)
 
 
 def _suffix(column: str) -> str:

--- a/src/gmat_run/parsers/reportfile.py
+++ b/src/gmat_run/parsers/reportfile.py
@@ -35,7 +35,7 @@ __all__ = ["parse"]
 _COLUMN_SEP = re.compile(r"\s{2,}")
 
 
-def parse(path: str | os.PathLike[str]) -> pd.DataFrame:
+def parse(path: str | os.PathLike[str], *, convert_to: str | None = None) -> pd.DataFrame:
     """Parse a GMAT ``ReportFile`` into a :class:`pandas.DataFrame`.
 
     Column names are taken verbatim from the header row (dots preserved, e.g.
@@ -44,6 +44,10 @@ def parse(path: str | os.PathLike[str]) -> pd.DataFrame:
 
     Args:
         path: Path to the ``ReportFile`` on disk.
+        convert_to: If set, every recognised epoch column is converted from
+            its detected scale to ``convert_to`` after promotion. Forwarded
+            to :func:`gmat_run.parsers.epoch.promote_epochs`; see its
+            docstring for the validation and astropy-extra semantics.
 
     Returns:
         A DataFrame with one row per report event and one column per header
@@ -52,6 +56,10 @@ def parse(path: str | os.PathLike[str]) -> pd.DataFrame:
     Raises:
         GmatOutputParseError: The file is empty, or a data row's column count
             does not match the header.
+        ValueError: ``convert_to`` is not one of the five recognised GMAT
+            scales.
+        ImportError: ``convert_to`` is set, a non-trivial conversion is
+            required, and ``astropy`` is not installed.
     """
     path = Path(path)
 
@@ -82,7 +90,7 @@ def parse(path: str | os.PathLike[str]) -> pd.DataFrame:
     df = pd.DataFrame(rows, columns=column_names)
     for column in df.columns:
         df[column] = _coerce_numeric(df[column])
-    return promote_epochs(df)
+    return promote_epochs(df, convert_to=convert_to)
 
 
 def _find_header(lines: list[str], path: Path) -> tuple[int, str]:

--- a/src/gmat_run/parsers/stk_ephemeris.py
+++ b/src/gmat_run/parsers/stk_ephemeris.py
@@ -42,6 +42,7 @@ from typing import Any, Final
 import pandas as pd
 
 from gmat_run.errors import GmatOutputParseError
+from gmat_run.parsers.epoch import promote_epochs
 
 __all__ = ["is_stk_ephemeris", "parse"]
 
@@ -95,11 +96,17 @@ class _Header:
     comments: list[str] = field(default_factory=list)
 
 
-def parse(path: str | os.PathLike[str]) -> pd.DataFrame:
+def parse(path: str | os.PathLike[str], *, convert_to: str | None = None) -> pd.DataFrame:
     """Parse an STK-TimePosVel ephemeris file into a :class:`pandas.DataFrame`.
 
     Args:
         path: Path to the ``.e`` file on disk.
+        convert_to: If set, the ``Epoch`` column is converted from UTC (the
+            assumed scale for STK-TimePosVel; see module docstring) to
+            ``convert_to``. Must be one of the five recognised GMAT scales.
+            Conversion is delegated to
+            :func:`gmat_run.parsers.epoch.promote_epochs`, which is gated
+            behind the ``[astropy]`` extra.
 
     Returns:
         A DataFrame with one row per state record. Columns are ``Epoch`` (a
@@ -126,6 +133,10 @@ def parse(path: str | os.PathLike[str]) -> pd.DataFrame:
             (``EphemerisTimePos``, ``EphemerisTimePosVelAcc``), or contains a
             malformed meta line, record column count, offset, state value, or
             ``ScenarioEpoch``.
+        ValueError: ``convert_to`` is not one of the five recognised GMAT
+            scales.
+        ImportError: ``convert_to`` is set, a non-trivial conversion is
+            required, and ``astropy`` is not installed.
     """
     path = Path(path)
     with path.open(encoding="utf-8-sig", newline=None) as fh:
@@ -158,6 +169,10 @@ def parse(path: str | os.PathLike[str]) -> pd.DataFrame:
         "version": header.version,
         "comments": list(header.comments),
     }
+    if convert_to is not None:
+        # ``Epoch`` has no recognised suffix, so promote_epochs's promotion
+        # loop is a no-op; only its convert_to branch runs.
+        promote_epochs(df, convert_to=convert_to)
     return df
 
 

--- a/tests/test_parsers_aem_ephemeris.py
+++ b/tests/test_parsers_aem_ephemeris.py
@@ -537,3 +537,31 @@ def test_is_aem_ephemeris_strips_bom(tmp_path: Path) -> None:
     path = tmp_path / "bom.aem"
     path.write_bytes(b"\xef\xbb\xbf" + _QUAT_BASIC.encode("utf-8"))
     assert is_aem_ephemeris(path) is True
+
+
+# --- convert_to -------------------------------------------------------------
+
+
+def test_convert_to_changes_epoch_scale(tmp_path: Path) -> None:
+    """File is TIME_SYSTEM=UTC; convert_to=TAI shifts the Epoch by the leap-second offset."""
+    df = parse(_write(tmp_path / "q.aem", _QUAT_BASIC), convert_to="TAI")
+    assert df.attrs["epoch_scales"] == {"Epoch": "TAI"}
+    # 2026 is past the 2017 leap second, so TAI - UTC = 37 s.
+    assert df["Epoch"].iloc[0] == pd.Timestamp("2026-01-01 12:00:37")
+
+
+def test_convert_to_unrecognised_source_scale_raises(tmp_path: Path) -> None:
+    """A CCSDS TIME_SYSTEM that gmat-run can't convert (e.g. UT1) surfaces a typed error."""
+    content = (
+        _HEADER
+        + _QUAT_META_BASE.replace("TIME_SYSTEM          = UTC", "TIME_SYSTEM          = UT1")
+        + _QUAT_DATA_BASE
+    )
+    with pytest.raises(ValueError, match=r"from_scale"):
+        parse(_write(tmp_path / "ut1.aem", content), convert_to="UTC")
+
+
+def test_convert_to_default_none_keeps_native_scale(tmp_path: Path) -> None:
+    """Regression: the default returns ``Epoch`` in the file's TIME_SYSTEM scale."""
+    df = parse(_write(tmp_path / "q.aem", _QUAT_BASIC))
+    assert df.attrs["epoch_scales"] == {"Epoch": "UTC"}

--- a/tests/test_parsers_ephemeris.py
+++ b/tests/test_parsers_ephemeris.py
@@ -334,3 +334,31 @@ def test_unterminated_covariance_raises(tmp_path: Path) -> None:
     with pytest.raises(GmatOutputParseError) as excinfo:
         parse(path)
     assert "COVARIANCE" in str(excinfo.value)
+
+
+# --- convert_to -------------------------------------------------------------
+
+
+def test_convert_to_changes_epoch_scale(tmp_path: Path) -> None:
+    """File is TIME_SYSTEM=UTC; convert_to=TAI shifts the Epoch by the leap-second offset."""
+    df = parse(_write(tmp_path / "basic.oem", _BASIC), convert_to="TAI")
+    assert df.attrs["epoch_scales"] == {"Epoch": "TAI"}
+    # Past the 2017-01-01 leap, TAI - UTC = 37 s.
+    assert df["Epoch"].iloc[0] == pd.Timestamp("2026-01-01 12:00:37")
+
+
+def test_convert_to_unrecognised_source_scale_raises(tmp_path: Path) -> None:
+    """A CCSDS TIME_SYSTEM that gmat-run can't convert (e.g. UT1) surfaces a typed error."""
+    content = (
+        _HEADER
+        + _META_BASE.replace("TIME_SYSTEM          = UTC", "TIME_SYSTEM          = UT1")
+        + _DATA_BASE
+    )
+    with pytest.raises(ValueError, match=r"from_scale"):
+        parse(_write(tmp_path / "ut1.oem", content), convert_to="UTC")
+
+
+def test_convert_to_default_none_keeps_native_scale(tmp_path: Path) -> None:
+    """Regression: the default returns ``Epoch`` in the file's TIME_SYSTEM scale."""
+    df = parse(_write(tmp_path / "basic.oem", _BASIC))
+    assert df.attrs["epoch_scales"] == {"Epoch": "UTC"}

--- a/tests/test_parsers_epoch.py
+++ b/tests/test_parsers_epoch.py
@@ -5,6 +5,7 @@ End-to-end tests through ``reportfile.parse`` live in
 ``test_parsers_reportfile.py``.
 """
 
+import sys
 import warnings
 
 import numpy as np
@@ -210,3 +211,78 @@ def test_returns_same_frame_for_chaining() -> None:
     df = pd.DataFrame({"Sat.UTCGregorian": ["01 Jan 2000 12:00:00.000"]})
     result = promote_epochs(df)
     assert result is df
+
+
+# --- convert_to --------------------------------------------------------------
+
+
+def test_convert_to_unifies_mixed_scales() -> None:
+    """Multiple columns labelled in different scales all land on the target."""
+    # Same physical instant expressed in two different scales. UTC 2026-01-15
+    # 12:00:00 == TAI 2026-01-15 12:00:37 (37 s leap-second offset in 2026).
+    df = pd.DataFrame(
+        {
+            "Sat.UTCGregorian": ["15 Jan 2026 12:00:00.000"],
+            "Sat.TAIGregorian": ["15 Jan 2026 12:00:37.000"],
+        }
+    )
+    promote_epochs(df, convert_to="UTC")
+    assert df.attrs["epoch_scales"] == {
+        "Sat.UTCGregorian": "UTC",
+        "Sat.TAIGregorian": "UTC",
+    }
+    # Both columns now hold the same UTC instant.
+    assert df["Sat.UTCGregorian"].iloc[0] == df["Sat.TAIGregorian"].iloc[0]
+    assert df["Sat.UTCGregorian"].iloc[0] == pd.Timestamp("2026-01-15 12:00:00")
+
+
+def test_convert_to_same_as_source_is_attrs_noop() -> None:
+    """convert_to equal to the detected scale leaves data and attrs intact."""
+    df = pd.DataFrame({"Sat.UTCGregorian": ["15 Jan 2026 12:00:00.000"]})
+    promote_epochs(df, convert_to="UTC")
+    assert df.attrs["epoch_scales"] == {"Sat.UTCGregorian": "UTC"}
+    assert df["Sat.UTCGregorian"].iloc[0] == pd.Timestamp("2026-01-15 12:00:00")
+
+
+def test_convert_to_unrecognised_target_raises() -> None:
+    df = pd.DataFrame({"Sat.UTCGregorian": ["15 Jan 2026 12:00:00.000"]})
+    with pytest.raises(ValueError, match=r"to_scale"):
+        promote_epochs(df, convert_to="GPS")
+
+
+def test_convert_to_with_no_promoted_columns_is_a_noop() -> None:
+    """No epoch columns → no astropy import, no errors, no attrs."""
+    df = pd.DataFrame({"Sat.Earth.SMA": [6578.136]})
+    snapshot = df.copy(deep=True)
+    promote_epochs(df, convert_to="UTC")
+    pd.testing.assert_frame_equal(df, snapshot)
+    assert "epoch_scales" not in df.attrs
+
+
+def test_convert_to_missing_astropy_raises_friendly_importerror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-trivial convert_to with astropy missing surfaces the install hint."""
+    monkeypatch.setitem(sys.modules, "astropy", None)
+    monkeypatch.setitem(sys.modules, "astropy.time", None)
+    df = pd.DataFrame({"Sat.UTCGregorian": ["15 Jan 2026 12:00:00.000"]})
+    with pytest.raises(ImportError, match=r"astropy.*\[astropy\]"):
+        promote_epochs(df, convert_to="TAI")
+
+
+def test_convert_to_default_none_is_legacy_behaviour() -> None:
+    """Regression: ``convert_to=None`` (the default) leaves scales detected only."""
+    df = pd.DataFrame(
+        {
+            "Sat.UTCGregorian": ["15 Jan 2026 12:00:00.000"],
+            "Sat.TAIModJulian": [21545.0],
+        }
+    )
+    promote_epochs(df)
+    assert df.attrs["epoch_scales"] == {
+        "Sat.UTCGregorian": "UTC",
+        "Sat.TAIModJulian": "TAI",
+    }
+    # Each column still reads in its native scale — nothing was converted.
+    assert df["Sat.UTCGregorian"].iloc[0] == pd.Timestamp("2026-01-15 12:00:00")
+    assert df["Sat.TAIModJulian"].iloc[0] == pd.Timestamp("2000-01-01 12:00:00")

--- a/tests/test_parsers_reportfile.py
+++ b/tests/test_parsers_reportfile.py
@@ -196,3 +196,37 @@ def test_accepts_str_path(tmp_path: Path) -> None:
     path = _write(tmp_path / "strpath.report", _BASIC)
     df = parse(str(path))
     assert len(df) == 2
+
+
+# --- convert_to --------------------------------------------------------------
+
+
+def test_convert_to_unifies_mixed_scale_columns(tmp_path: Path) -> None:
+    """Acceptance criterion from issue #66: a mixed-scale ReportFile reads
+    out with every epoch column on the same scale and the same Timestamp
+    values for a known epoch row.
+
+    The file emits the same physical instant in TAI Gregorian and UTC
+    ModJulian. Past the 2017-01-01 leap second, TAI - UTC = 37 s, so:
+        TAI Gregorian: 15 Jan 2026 12:00:37.000
+        UTC ModJulian: 27770.50000 (2026-01-15 12:00:00 UTC; MJD 0 = 1941-01-05 12:00 UT).
+    Note: GMAT's ModJulian epoch is 1941-01-05 12:00:00, so 2026-01-15 12:00
+    is exactly (2026-01-15 12:00) - (1941-01-05 12:00) = 31055 days.
+    """
+    # 2026-01-15 12:00 - 1941-01-05 12:00 = 31055 days (verified below).
+    days = (pd.Timestamp("2026-01-15 12:00:00") - pd.Timestamp("1941-01-05 12:00:00")).days
+    content = f"Sat.TAIGregorian          Sat.UTCModJulian\n15 Jan 2026 12:00:37.000  {days}.0\n"
+    df = parse(_write(tmp_path / "mixed.report", content), convert_to="UTC")
+    assert df.attrs["epoch_scales"] == {
+        "Sat.TAIGregorian": "UTC",
+        "Sat.UTCModJulian": "UTC",
+    }
+    assert df["Sat.TAIGregorian"].iloc[0] == df["Sat.UTCModJulian"].iloc[0]
+    assert df["Sat.TAIGregorian"].iloc[0] == pd.Timestamp("2026-01-15 12:00:00")
+
+
+def test_convert_to_default_none_is_legacy_behaviour(tmp_path: Path) -> None:
+    """Regression: the default keeps each column in its native scale."""
+    df = parse(_write(tmp_path / "basic.report", _BASIC))
+    assert df.attrs["epoch_scales"] == {"Sat.UTCGregorian": "UTC"}
+    assert df["Sat.UTCGregorian"].iloc[0] == pd.Timestamp("2026-11-26 12:00:00")

--- a/tests/test_parsers_stk_ephemeris.py
+++ b/tests/test_parsers_stk_ephemeris.py
@@ -416,3 +416,25 @@ def test_is_stk_ephemeris_false_for_missing_file(tmp_path: Path) -> None:
 def test_is_stk_ephemeris_false_for_empty_file(tmp_path: Path) -> None:
     path = _write(tmp_path / "empty.e", "")
     assert is_stk_ephemeris(path) is False
+
+
+# --- convert_to -------------------------------------------------------------
+
+
+def test_convert_to_changes_epoch_scale(tmp_path: Path) -> None:
+    """STK files default to UTC; convert_to=TAI shifts by the leap-second offset."""
+    df = parse(_write(tmp_path / "basic.e", _BASIC), convert_to="TAI")
+    assert df.attrs["epoch_scales"] == {"Epoch": "TAI"}
+    # 2026 is past the 2017 leap second, so TAI - UTC = 37 s.
+    assert df["Epoch"].iloc[0] == pd.Timestamp("2026-01-01 12:00:37")
+
+
+def test_convert_to_unrecognised_target_raises(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match=r"to_scale"):
+        parse(_write(tmp_path / "basic.e", _BASIC), convert_to="GPS")
+
+
+def test_convert_to_default_none_keeps_native_scale(tmp_path: Path) -> None:
+    """Regression: the default leaves Epoch tagged UTC."""
+    df = parse(_write(tmp_path / "basic.e", _BASIC))
+    assert df.attrs["epoch_scales"] == {"Epoch": "UTC"}


### PR DESCRIPTION
## Summary

- Extend `promote_epochs(df, *, convert_to=None)` so callers get a single, uniformly-scaled DataFrame in one call. When set, every column listed in `df.attrs["epoch_scales"]` (after promotion) is converted from its detected scale to the target via `gmat_run.time.convert_column`, with the `[astropy]` extra as the only conversion gate.
- Plumb the same keyword through `parsers.reportfile.parse`, `parsers.ephemeris.parse` (CCSDS-OEM), `parsers.stk_ephemeris.parse`, and `parsers.aem_ephemeris.parse`. The three non-reportfile parsers don't currently call `promote_epochs` (their `Epoch` column has no recognised suffix); they now route through it only when `convert_to` is set, so the promotion loop is a no-op and only the conversion branch runs — keeping all conversion logic in `epoch.py`.
- Tests across all five parser test files: the headline mixed-scale ReportFile (`TAIGregorian` + `UTCModJulian` → unified `UTC`), per-parser `convert_to=TAI` shifts the leap-second offset, regression tests for `convert_to=None`, `ValueError` on unknown target scales and on CCSDS files whose `TIME_SYSTEM` is not one of the five GMAT scales, and `ImportError` plumbing when astropy is missing. Adds a "Parser-level `convert_to`" section to `docs/reference/time.md`.

## Test plan

- [x] `uv run pytest` — 588 unit tests pass.
- [x] `uv run ruff check` / `ruff format --check` — clean.
- [x] `uv run mypy` — clean.
- [x] `uv run mkdocs build` — clean.
- [x] Coverage gate: `src/gmat_run/parsers/` at 97% (above the 95% minimum); `parsers/epoch.py` at 100%.

## Notes for reviewers

- CCSDS-OEM and CCSDS-AEM permit `TIME_SYSTEM` values outside the five GMAT scales (`UT1`, `GPS`, `TCG`, …). Calling those parsers with `convert_to=` on such a file raises `ValueError` from the underlying `convert()`, surfacing the format mismatch rather than silently mis-converting. Tests pin both behaviours.
- No CHANGELOG edit — #72 (Cut v0.3.0) consolidates the v0.3 changelog, matching the convention from #75.

Closes #66.