### PR TITLE
Add Results.write_oem(): emit CCSDS-OEM from an ephemeris DataFrame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,22 +5,6 @@ All notable changes to gmat-run are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Added
-
-- `Results.write_oem(name, path)` and `Results.write_oem_all(dirpath)` emit a
-  CCSDS-OEM (KVN) file from `Results.ephemerides[name]` via `ccsds-ndm`,
-  with a built-in frame-name mapping (`EarthMJ2000Eq` ↔ `EME2000`,
-  `EarthICRF` ↔ `ICRF`, `J2000` ↔ `EME2000`) and rejection of unknown
-  frames or unsupported time systems. Gated behind the `[ccsds-ndm]`
-  extra (#67).
-
-### Changed
-
-- `[ccsds-ndm]` extra floor bumped from `>=2.0` to `>=3.0`; the v3 line
-  is the surface the OEM writer is tested against.
-
 ## [0.2.0] — 2026-04-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to gmat-run are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `Results.write_oem(name, path)` and `Results.write_oem_all(dirpath)` emit a
+  CCSDS-OEM (KVN) file from `Results.ephemerides[name]` via `ccsds-ndm`,
+  with a built-in frame-name mapping (`EarthMJ2000Eq` ↔ `EME2000`,
+  `EarthICRF` ↔ `ICRF`, `J2000` ↔ `EME2000`) and rejection of unknown
+  frames or unsupported time systems. Gated behind the `[ccsds-ndm]`
+  extra (#67).
+
+### Changed
+
+- `[ccsds-ndm]` extra floor bumped from `>=2.0` to `>=3.0`; the v3 line
+  is the surface the OEM writer is tested against.
+
 ## [0.2.0] — 2026-04-26
 
 ### Added

--- a/docs/reference/results.md
+++ b/docs/reference/results.md
@@ -16,4 +16,21 @@ when the [`Results`][gmat_run.Results] is garbage-collected. Call
 [`Results.persist`][gmat_run.Results.persist] to copy the artefacts to a
 permanent location before the temp dir disappears.
 
+[`Results.write_oem`][gmat_run.Results.write_oem] and
+[`Results.write_oem_all`][gmat_run.Results.write_oem_all] re-emit
+ephemerides as CCSDS-OEM files via `ccsds-ndm` (gated behind the
+`[ccsds-ndm]` extra). Coordinate-system names are rewritten through a
+small alias table on output:
+
+| Source name | Written as | Notes |
+|-------------|------------|-------|
+| `EME2000`, `GCRF`, `ICRF`, `ITRF2000`, `TEME`, `TOD`, … | (passthrough) | CCSDS 502.0-B-2 §A.5 canonical frames |
+| `EarthMJ2000Eq` | `EME2000` | GMAT internal |
+| `EarthICRF` | `ICRF` | GMAT internal |
+| `J2000` | `EME2000` | STK-TimePosVel convention |
+
+Anything else raises `ValueError` rather than emitting a header
+downstream tools cannot interpret. Time systems are restricted to
+`A1`, `TAI`, `UTC`, `TT`, and `TDB` — the five GMAT speaks end-to-end.
+
 ::: gmat_run.Results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 
 [project.optional-dependencies]
 astropy = ["astropy>=6.0"]
-ccsds-ndm = ["ccsds-ndm>=2.0"]
+ccsds-ndm = ["ccsds-ndm>=3.0"]
 examples = ["matplotlib>=3.8"]
 spiceypy = ["spiceypy>=6.0"]
 
@@ -55,7 +55,7 @@ dev = [
   "mypy>=1.11",
   "pandas-stubs",
   "astropy>=6.0",
-  "ccsds-ndm>=2.0",
+  "ccsds-ndm>=3.0",
   "spiceypy>=6.0",
 ]
 docs = [
@@ -103,6 +103,12 @@ ignore_missing_imports = true
 # import as Any inside the small surface used by gmat_run.time.
 [[tool.mypy.overrides]]
 module = ["astropy", "astropy.*"]
+ignore_missing_imports = true
+
+# ccsds-ndm 3.x has no py.typed marker; the OEM writer imports the xsdata
+# dataclasses and KVN serialiser locally and treats the surface as Any.
+[[tool.mypy.overrides]]
+module = ["ccsds_ndm", "ccsds_ndm.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/src/gmat_run/results.py
+++ b/src/gmat_run/results.py
@@ -36,6 +36,7 @@ from gmat_run.parsers.spk import is_spk_ephemeris as _is_spk_ephemeris
 from gmat_run.parsers.spk import parse as _parse_spk_ephemeris
 from gmat_run.parsers.stk_ephemeris import is_stk_ephemeris as _is_stk_ephemeris
 from gmat_run.parsers.stk_ephemeris import parse as _parse_stk_ephemeris
+from gmat_run.writers.oem import write_oem as _write_oem
 
 __all__ = ["Results"]
 
@@ -284,3 +285,65 @@ class Results:
             self._workspace.cleanup()
             self._workspace = None
         return self
+
+    def write_oem(
+        self,
+        name: str,
+        path: str | os.PathLike[str],
+        *,
+        originator: str = "gmat-run",
+        object_name: str | None = None,
+    ) -> Path:
+        """Write the ephemeris keyed by ``name`` to ``path`` as a CCSDS-OEM file.
+
+        The DataFrame is materialised through :attr:`ephemerides` (so the
+        same lazy-parse and cache contract applies) and emitted via
+        :func:`gmat_run.writers.oem.write_oem`. Requires the
+        ``[ccsds-ndm]`` extra; raises :class:`ImportError` with an install
+        hint if it is missing.
+
+        Args:
+            name: Resource name under :attr:`ephemerides`.
+            path: Destination ``.oem`` file. Parent directories are created.
+            originator: ``ORIGINATOR`` header value. Defaults to
+                ``"gmat-run"``.
+            object_name: Override for the ``OBJECT_NAME`` meta field. When
+                ``None``, falls back to ``df.attrs["object_name"]``.
+
+        Returns:
+            The destination ``Path``.
+
+        Raises:
+            KeyError: ``name`` is not a known ephemeris resource.
+            ImportError: ``ccsds-ndm`` is not installed.
+            ValueError: the ephemeris DataFrame is missing required
+                metadata for OEM emission. See
+                :func:`gmat_run.writers.oem.write_oem` for the full list.
+        """
+        df = self.ephemerides[name]
+        return _write_oem(df, path, originator=originator, object_name=object_name)
+
+    def write_oem_all(
+        self,
+        dirpath: str | os.PathLike[str],
+        *,
+        originator: str = "gmat-run",
+    ) -> Path:
+        """Write every ephemeris in :attr:`ephemerides` to ``dirpath`` as OEM.
+
+        Each file is named ``<name>.oem`` after its resource key. ``dirpath``
+        is created if missing. A run with no ephemerides is a no-op (the
+        directory is still created).
+
+        Args:
+            dirpath: Destination directory.
+            originator: ``ORIGINATOR`` header for every emitted file.
+
+        Returns:
+            ``dirpath`` as a resolved :class:`pathlib.Path`.
+        """
+        dest_dir = Path(dirpath)
+        dest_dir.mkdir(parents=True, exist_ok=True)
+        for name in self.ephemerides:
+            self.write_oem(name, dest_dir / f"{name}.oem", originator=originator)
+        return dest_dir

--- a/src/gmat_run/writers/__init__.py
+++ b/src/gmat_run/writers/__init__.py
@@ -1,0 +1,1 @@
+"""Writers that emit standard interchange formats from gmat-run DataFrames."""

--- a/src/gmat_run/writers/oem.py
+++ b/src/gmat_run/writers/oem.py
@@ -1,0 +1,253 @@
+"""Emit a CCSDS-OEM file from an ephemeris :class:`pandas.DataFrame`.
+
+Round-trip companion to :mod:`gmat_run.parsers.ephemeris`. The DataFrame shape
+expected here is exactly the one that parser produces — columns
+``Epoch`` plus ``X``, ``Y``, ``Z``, ``VX``, ``VY``, ``VZ``, with the source
+metadata surfaced on ``df.attrs`` (``coordinate_system``, ``central_body``,
+``time_scale`` / ``epoch_scales``, ``object_name``, ``interpolation``,
+``interpolation_degree``).
+
+The writer is gated behind the ``[ccsds-ndm]`` extra; importing this module
+without ``ccsds-ndm`` installed surfaces an :class:`ImportError` with a hint
+the moment :func:`write_oem` is called.
+
+Multi-segment OEM output is deliberately not supported in v0.3 — every call
+emits a single segment containing every row of the DataFrame in file order.
+``df.attrs["segments"]`` is ignored. Covariance blocks are also out of scope.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import os
+from pathlib import Path
+from typing import Any, Final
+
+import pandas as pd
+
+__all__ = ["write_oem"]
+
+# CCSDS 502.0-B-2 §A.5 reference frames the writer accepts as canonical.
+# Anything in this set passes through to ``REF_FRAME`` unchanged. The set is
+# intentionally narrow — additions should be made when a real GMAT output
+# surfaces them, not speculatively.
+_CCSDS_FRAMES: Final = frozenset(
+    {
+        "EME2000",
+        "GCRF",
+        "GRC",
+        "ICRF",
+        "ITRF-93",
+        "ITRF-97",
+        "ITRF2000",
+        "MCI",
+        "TDR",
+        "TEME",
+        "TOD",
+        "EFG",
+        "GTOD",
+    }
+)
+
+# Aliases from the names other parsers / GMAT internals surface to the CCSDS
+# canonical name. The right-hand side must be a member of ``_CCSDS_FRAMES``.
+_FRAME_ALIASES: Final = {
+    # GMAT-internal coordinate-system names — the OEM text writer normally
+    # already translates these, but a user feeding a hand-edited or non-OEM
+    # DataFrame may still see them.
+    "EarthMJ2000Eq": "EME2000",
+    "EarthICRF": "ICRF",
+    # STK's ``CoordinateSystem`` token for inertial J2000.
+    "J2000": "EME2000",
+}
+
+# Time scales we accept on output. CCSDS-OEM permits more (UT1, GPS, …) but
+# the writer is scoped to the five GMAT recognises end-to-end so a typo in
+# ``df.attrs`` surfaces here instead of inside a downstream consumer.
+_ALLOWED_TIME_SCALES: Final = frozenset({"A1", "TAI", "UTC", "TT", "TDB"})
+
+
+def write_oem(
+    df: pd.DataFrame,
+    path: str | os.PathLike[str],
+    *,
+    originator: str = "gmat-run",
+    object_name: str | None = None,
+) -> Path:
+    """Write ``df`` to ``path`` as a CCSDS-OEM (KVN) file.
+
+    Args:
+        df: Ephemeris DataFrame in the shape produced by
+            :func:`gmat_run.parsers.ephemeris.parse` — columns ``Epoch``,
+            ``X``, ``Y``, ``Z``, ``VX``, ``VY``, ``VZ`` and the metadata
+            attrs the parser surfaces (``coordinate_system``,
+            ``central_body``, ``time_scale`` / ``epoch_scales``, optionally
+            ``object_name``, ``interpolation``, ``interpolation_degree``).
+        path: Destination ``.oem`` file. Parent directories are created.
+        originator: Value for the ``ORIGINATOR`` header field. Defaults to
+            ``"gmat-run"`` (the file header from the source ephemeris is
+            *not* preserved — the new file is a new artefact).
+        object_name: Override for the ``OBJECT_NAME`` meta field. When
+            ``None``, falls back to ``df.attrs["object_name"]``, then to
+            ``"UNKNOWN"`` if neither is set.
+
+    Returns:
+        The destination ``Path``.
+
+    Raises:
+        ImportError: ``ccsds-ndm`` is not installed.
+        ValueError: a required attr (``coordinate_system``, ``central_body``,
+            time scale) is missing, the time scale is not one of
+            ``A1`` / ``TAI`` / ``UTC`` / ``TT`` / ``TDB``, or the
+            coordinate system is neither a CCSDS canonical name nor a known
+            alias (see the module-level frame mapping table).
+    """
+    try:
+        from ccsds_ndm.models.ndmxml4 import (
+            OdmHeader,
+            Oem,
+            OemBody,
+            OemData,
+            OemMetadata,
+            OemSegment,
+            PositionTypeUo,
+            PositionUnits,
+            StateVectorAccType,
+            VelocityTypeUo,
+            VelocityUnits,
+        )
+        from ccsds_ndm.ndm_kvn_io import NdmKvnIo
+    except ImportError as exc:
+        raise ImportError(
+            "Results.write_oem requires the [ccsds-ndm] extra: pip install gmat-run[ccsds-ndm]"
+        ) from exc
+
+    ref_frame = _resolve_frame(df.attrs.get("coordinate_system"))
+    central_body = _require_attr(df, "central_body")
+    time_system = _resolve_time_scale(df)
+    object_name_resolved = object_name or df.attrs.get("object_name") or "UNKNOWN"
+    object_id = df.attrs.get("object_id") or object_name_resolved
+
+    if not len(df):
+        raise ValueError("cannot write an OEM from an empty DataFrame")
+
+    epochs = [_format_epoch(ts) for ts in df["Epoch"]]
+    xs = df["X"].to_numpy(dtype=float)
+    ys = df["Y"].to_numpy(dtype=float)
+    zs = df["Z"].to_numpy(dtype=float)
+    vxs = df["VX"].to_numpy(dtype=float)
+    vys = df["VY"].to_numpy(dtype=float)
+    vzs = df["VZ"].to_numpy(dtype=float)
+    state_vectors = [
+        StateVectorAccType(
+            epoch=epoch,
+            x=PositionTypeUo(value=float(xs[i]), units=PositionUnits.KM),
+            y=PositionTypeUo(value=float(ys[i]), units=PositionUnits.KM),
+            z=PositionTypeUo(value=float(zs[i]), units=PositionUnits.KM),
+            x_dot=VelocityTypeUo(value=float(vxs[i]), units=VelocityUnits.KM_S),
+            y_dot=VelocityTypeUo(value=float(vys[i]), units=VelocityUnits.KM_S),
+            z_dot=VelocityTypeUo(value=float(vzs[i]), units=VelocityUnits.KM_S),
+            x_ddot=None,
+            y_ddot=None,
+            z_ddot=None,
+        )
+        for i, epoch in enumerate(epochs)
+    ]
+
+    interpolation = df.attrs.get("interpolation")
+    interpolation_degree = df.attrs.get("interpolation_degree")
+
+    metadata = OemMetadata(
+        comment=[],
+        object_name=str(object_name_resolved),
+        object_id=str(object_id),
+        center_name=str(central_body),
+        ref_frame=ref_frame,
+        ref_frame_epoch=None,
+        time_system=time_system,
+        start_time=epochs[0],
+        useable_start_time=None,
+        useable_stop_time=None,
+        stop_time=epochs[-1],
+        interpolation=str(interpolation) if interpolation is not None else None,
+        interpolation_degree=(
+            int(interpolation_degree) if interpolation_degree is not None else None
+        ),
+    )
+    oem = Oem(
+        header=OdmHeader(
+            comment=[],
+            classification=None,
+            creation_date=_now_iso(),
+            originator=originator,
+            message_id=None,
+        ),
+        body=OemBody(
+            segment=[
+                OemSegment(
+                    metadata=metadata,
+                    data=OemData(comment=[], state_vector=state_vectors, covariance_matrix=[]),
+                )
+            ]
+        ),
+    )
+
+    dest = Path(path)
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    NdmKvnIo().to_file(oem, dest)
+    return dest
+
+
+def _resolve_frame(value: Any) -> str:
+    if value is None:
+        raise ValueError(
+            "df.attrs['coordinate_system'] is required to write an OEM "
+            "(set it to a CCSDS-OEM frame name or a recognised GMAT alias)"
+        )
+    name = str(value)
+    if name in _CCSDS_FRAMES:
+        return name
+    if name in _FRAME_ALIASES:
+        return _FRAME_ALIASES[name]
+    canonical = sorted(_CCSDS_FRAMES)
+    aliases = sorted(_FRAME_ALIASES)
+    raise ValueError(
+        f"unknown coordinate system {name!r}; supply a CCSDS-OEM frame "
+        f"({', '.join(canonical)}) or a known alias ({', '.join(aliases)})"
+    )
+
+
+def _resolve_time_scale(df: pd.DataFrame) -> str:
+    epoch_scales = df.attrs.get("epoch_scales")
+    if isinstance(epoch_scales, dict) and "Epoch" in epoch_scales:
+        scale = str(epoch_scales["Epoch"])
+    elif "time_scale" in df.attrs:
+        scale = str(df.attrs["time_scale"])
+    else:
+        raise ValueError(
+            "df.attrs is missing the time scale "
+            "(set df.attrs['epoch_scales'] = {'Epoch': '<scale>'} "
+            "or df.attrs['time_scale'] = '<scale>')"
+        )
+    if scale not in _ALLOWED_TIME_SCALES:
+        raise ValueError(
+            f"unsupported TIME_SYSTEM {scale!r}; expected one of {sorted(_ALLOWED_TIME_SCALES)}"
+        )
+    return scale
+
+
+def _require_attr(df: pd.DataFrame, key: str) -> Any:
+    if key not in df.attrs:
+        raise ValueError(f"df.attrs[{key!r}] is required to write an OEM")
+    return df.attrs[key]
+
+
+def _format_epoch(ts: Any) -> str:
+    """ISO-8601 with millisecond precision, matching GMAT's stock OEM format."""
+    return pd.Timestamp(ts).isoformat(timespec="milliseconds")
+
+
+def _now_iso() -> str:
+    return (
+        _dt.datetime.now(_dt.timezone.utc).replace(tzinfo=None).isoformat(timespec="milliseconds")
+    )

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -555,3 +555,47 @@ class TestPersist:
         assert result.output_dir == second
         assert (second / "r1.txt").exists()
         assert result.reports._paths["R1"] == second / "r1.txt"  # type: ignore[attr-defined]
+
+
+# --- write_oem / write_oem_all ----------------------------------------------
+
+
+def test_write_oem_returns_path_and_writes_file(tmp_path: Path) -> None:
+    """``Results.write_oem`` materialises the lazy parse and emits a file."""
+    eph = _write_eph(tmp_path / "E1.oem")
+    result = Results(output_dir=tmp_path, log="", ephemeris_paths={"E1": eph})
+
+    out = result.write_oem("E1", tmp_path / "out.oem")
+
+    assert out == tmp_path / "out.oem"
+    assert out.exists()
+    assert "CCSDS_OEM_VERS" in out.read_text(encoding="utf-8")
+
+
+def test_write_oem_unknown_ephemeris_raises_keyerror(tmp_path: Path) -> None:
+    result = Results(output_dir=tmp_path, log="")
+    with pytest.raises(KeyError):
+        result.write_oem("nope", tmp_path / "out.oem")
+
+
+def test_write_oem_all_writes_one_file_per_ephemeris(tmp_path: Path) -> None:
+    e1 = _write_eph(tmp_path / "E1.oem")
+    e2 = _write_eph(tmp_path / "E2.oem")
+    result = Results(
+        output_dir=tmp_path,
+        log="",
+        ephemeris_paths={"EphemerisFile1": e1, "EphemerisFile2": e2},
+    )
+
+    dest = result.write_oem_all(tmp_path / "out")
+
+    assert dest == tmp_path / "out"
+    assert (dest / "EphemerisFile1.oem").is_file()
+    assert (dest / "EphemerisFile2.oem").is_file()
+
+
+def test_write_oem_all_with_no_ephemerides_creates_empty_dir(tmp_path: Path) -> None:
+    result = Results(output_dir=tmp_path, log="")
+    dest = result.write_oem_all(tmp_path / "empty")
+    assert dest.is_dir()
+    assert list(dest.iterdir()) == []

--- a/tests/test_writers_oem.py
+++ b/tests/test_writers_oem.py
@@ -1,0 +1,216 @@
+"""Unit tests for :func:`gmat_run.writers.oem.write_oem`.
+
+The round-trip tests pair the writer with :func:`gmat_run.parsers.ephemeris.parse`
+and assert that an ephemeris emitted by the writer is read back with the same
+columns, row count, and surfaced attrs. Hand-built DataFrames cover the error
+paths (missing required attrs, unknown frame, unsupported time scale) so a
+typo in caller code surfaces here rather than as a malformed file downstream.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from gmat_run.parsers.ephemeris import parse as parse_oem
+from gmat_run.writers.oem import write_oem
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "ephemeris" / "Ex_LEOEphemeris.oem"
+
+
+def _hand_built_oem_frame() -> pd.DataFrame:
+    """Smallest legal OEM DataFrame, matching the parser's output shape."""
+    df = pd.DataFrame(
+        {
+            "Epoch": pd.to_datetime(["2026-01-01T12:00:00.000", "2026-01-01T12:01:00.000"]),
+            "X": [-5936.0, -6040.0],
+            "Y": [1590.0, 1149.0],
+            "Z": [3336.0, 3329.0],
+            "VX": [-1.95, -1.53],
+            "VY": [-7.29, -7.39],
+            "VZ": [0.0, -0.23],
+        }
+    )
+    df.attrs["coordinate_system"] = "EME2000"
+    df.attrs["central_body"] = "Earth"
+    df.attrs["epoch_scales"] = {"Epoch": "UTC"}
+    df.attrs["time_scale"] = "UTC"
+    df.attrs["object_name"] = "Sat"
+    return df
+
+
+# --- happy path -------------------------------------------------------------
+
+
+def test_round_trip_preserves_state_columns_and_attrs(tmp_path: Path) -> None:
+    """Parse a GMAT-emitted OEM, write it, re-parse: state and attrs survive."""
+    original = parse_oem(_FIXTURE)
+    out = write_oem(original, tmp_path / "round_trip.oem")
+    reparsed = parse_oem(out)
+
+    assert list(reparsed.columns) == ["Epoch", "X", "Y", "Z", "VX", "VY", "VZ"]
+    assert len(reparsed) == len(original)
+    assert reparsed.attrs["coordinate_system"] == original.attrs["coordinate_system"]
+    assert reparsed.attrs["central_body"] == original.attrs["central_body"]
+    assert reparsed.attrs["object_name"] == original.attrs["object_name"]
+    assert reparsed.attrs["epoch_scales"] == original.attrs["epoch_scales"]
+    assert reparsed["Epoch"].iloc[0] == original["Epoch"].iloc[0]
+    assert reparsed["X"].iloc[0] == pytest.approx(original["X"].iloc[0])
+
+
+def test_returns_destination_path(tmp_path: Path) -> None:
+    df = _hand_built_oem_frame()
+    out = write_oem(df, tmp_path / "out.oem")
+    assert out == tmp_path / "out.oem"
+    assert out.exists()
+
+
+def test_creates_missing_parent_directories(tmp_path: Path) -> None:
+    df = _hand_built_oem_frame()
+    nested = tmp_path / "nested" / "dirs" / "out.oem"
+    write_oem(df, nested)
+    assert nested.exists()
+
+
+def test_originator_kwarg_overrides_default(tmp_path: Path) -> None:
+    df = _hand_built_oem_frame()
+    out = write_oem(df, tmp_path / "out.oem", originator="ACME Aerospace")
+    text = out.read_text(encoding="utf-8")
+    assert "ORIGINATOR" in text
+    assert "ACME Aerospace" in text
+
+
+def test_object_name_kwarg_overrides_attr(tmp_path: Path) -> None:
+    df = _hand_built_oem_frame()
+    df.attrs["object_name"] = "Sat"
+    out = write_oem(df, tmp_path / "out.oem", object_name="OverrideSat")
+    text = out.read_text(encoding="utf-8")
+    assert "OverrideSat" in text
+    # The attr value must not leak through when the kwarg is set.
+    assert "OBJECT_NAME              = Sat\n" not in text
+
+
+def test_object_name_falls_back_to_unknown(tmp_path: Path) -> None:
+    df = _hand_built_oem_frame()
+    df.attrs.pop("object_name")
+    out = write_oem(df, tmp_path / "out.oem")
+    text = out.read_text(encoding="utf-8")
+    assert "UNKNOWN" in text
+
+
+def test_interpolation_metadata_survives_round_trip(tmp_path: Path) -> None:
+    df = _hand_built_oem_frame()
+    df.attrs["interpolation"] = "LAGRANGE"
+    df.attrs["interpolation_degree"] = 7
+    out = write_oem(df, tmp_path / "out.oem")
+    reparsed = parse_oem(out)
+    assert reparsed.attrs["interpolation"] == "LAGRANGE"
+    assert reparsed.attrs["interpolation_degree"] == 7
+
+
+# --- frame mapping ----------------------------------------------------------
+
+
+def test_gmat_frame_alias_maps_to_ccsds(tmp_path: Path) -> None:
+    """A GMAT-style coordinate-system name is rewritten to its CCSDS equivalent."""
+    df = _hand_built_oem_frame()
+    df.attrs["coordinate_system"] = "EarthMJ2000Eq"
+    out = write_oem(df, tmp_path / "out.oem")
+    text = out.read_text(encoding="utf-8")
+    assert "REF_FRAME" in text
+    assert "EME2000" in text
+    assert "EarthMJ2000Eq" not in text
+
+
+def test_stk_j2000_maps_to_eme2000(tmp_path: Path) -> None:
+    df = _hand_built_oem_frame()
+    df.attrs["coordinate_system"] = "J2000"
+    out = write_oem(df, tmp_path / "out.oem")
+    assert "EME2000" in out.read_text(encoding="utf-8")
+
+
+def test_unknown_frame_raises_value_error(tmp_path: Path) -> None:
+    df = _hand_built_oem_frame()
+    df.attrs["coordinate_system"] = "MadeUpFrame"
+    with pytest.raises(ValueError, match="unknown coordinate system"):
+        write_oem(df, tmp_path / "out.oem")
+
+
+def test_missing_frame_raises_value_error(tmp_path: Path) -> None:
+    df = _hand_built_oem_frame()
+    df.attrs.pop("coordinate_system")
+    with pytest.raises(ValueError, match="coordinate_system"):
+        write_oem(df, tmp_path / "out.oem")
+
+
+# --- time scale validation --------------------------------------------------
+
+
+@pytest.mark.parametrize("scale", ["A1", "TAI", "UTC", "TT", "TDB"])
+def test_supported_time_scales_round_trip(tmp_path: Path, scale: str) -> None:
+    df = _hand_built_oem_frame()
+    df.attrs["epoch_scales"] = {"Epoch": scale}
+    df.attrs["time_scale"] = scale
+    out = write_oem(df, tmp_path / "out.oem")
+    text = out.read_text(encoding="utf-8")
+    assert "TIME_SYSTEM" in text
+    assert scale in text
+
+
+def test_unsupported_time_scale_raises_value_error(tmp_path: Path) -> None:
+    df = _hand_built_oem_frame()
+    df.attrs["epoch_scales"] = {"Epoch": "GPS"}
+    df.attrs["time_scale"] = "GPS"
+    with pytest.raises(ValueError, match="unsupported TIME_SYSTEM"):
+        write_oem(df, tmp_path / "out.oem")
+
+
+def test_falls_back_to_time_scale_attr_when_epoch_scales_missing(tmp_path: Path) -> None:
+    df = _hand_built_oem_frame()
+    df.attrs.pop("epoch_scales")
+    df.attrs["time_scale"] = "TAI"
+    out = write_oem(df, tmp_path / "out.oem")
+    assert "TAI" in out.read_text(encoding="utf-8")
+
+
+def test_missing_time_scale_raises_value_error(tmp_path: Path) -> None:
+    df = _hand_built_oem_frame()
+    df.attrs.pop("epoch_scales")
+    df.attrs.pop("time_scale")
+    with pytest.raises(ValueError, match="time scale"):
+        write_oem(df, tmp_path / "out.oem")
+
+
+# --- other guards -----------------------------------------------------------
+
+
+def test_missing_central_body_raises_value_error(tmp_path: Path) -> None:
+    df = _hand_built_oem_frame()
+    df.attrs.pop("central_body")
+    with pytest.raises(ValueError, match="central_body"):
+        write_oem(df, tmp_path / "out.oem")
+
+
+def test_empty_dataframe_raises_value_error(tmp_path: Path) -> None:
+    df = _hand_built_oem_frame().iloc[0:0].copy()
+    df.attrs["coordinate_system"] = "EME2000"
+    df.attrs["central_body"] = "Earth"
+    df.attrs["epoch_scales"] = {"Epoch": "UTC"}
+    df.attrs["time_scale"] = "UTC"
+    with pytest.raises(ValueError, match="empty DataFrame"):
+        write_oem(df, tmp_path / "out.oem")
+
+
+def test_missing_extra_raises_import_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """If ``ccsds_ndm`` is not importable, surface a hint to install the extra."""
+    df = _hand_built_oem_frame()
+    # Hide every cached ccsds_ndm submodule so the writer's local import path runs
+    # cold and trips ImportError. The hint string is the load-bearing assertion.
+    for name in [n for n in sys.modules if n == "ccsds_ndm" or n.startswith("ccsds_ndm.")]:
+        monkeypatch.setitem(sys.modules, name, None)
+
+    with pytest.raises(ImportError, match=r"\[ccsds-ndm\]"):
+        write_oem(df, tmp_path / "out.oem")

--- a/uv.lock
+++ b/uv.lock
@@ -907,7 +907,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "astropy", marker = "extra == 'astropy'", specifier = ">=6.0" },
-    { name = "ccsds-ndm", marker = "extra == 'ccsds-ndm'", specifier = ">=2.0" },
+    { name = "ccsds-ndm", marker = "extra == 'ccsds-ndm'", specifier = ">=3.0" },
     { name = "matplotlib", marker = "extra == 'examples'", specifier = ">=3.8" },
     { name = "numpy", specifier = ">=1.24" },
     { name = "pandas", specifier = ">=2.0" },
@@ -918,7 +918,7 @@ provides-extras = ["astropy", "ccsds-ndm", "examples", "spiceypy"]
 [package.metadata.requires-dev]
 dev = [
     { name = "astropy", specifier = ">=6.0" },
-    { name = "ccsds-ndm", specifier = ">=2.0" },
+    { name = "ccsds-ndm", specifier = ">=3.0" },
     { name = "mypy", specifier = ">=1.11" },
     { name = "pandas-stubs" },
     { name = "pytest", specifier = ">=8.0" },


### PR DESCRIPTION
## Summary

- New `Results.write_oem(name, path, *, originator, object_name)` and `Results.write_oem_all(dirpath)` round-trip an ephemeris DataFrame back to a CCSDS-OEM (KVN) file via `ccsds-ndm`, gated behind the `[ccsds-ndm]` extra.
- Built-in frame-name table rewrites GMAT/STK aliases on output (`EarthMJ2000Eq` → `EME2000`, `EarthICRF` → `ICRF`, `J2000` → `EME2000`); unknown frames or unsupported time systems raise `ValueError` rather than emitting headers downstream tools cannot interpret.
- Implementation lives in a new `gmat_run/writers/` package, mirroring `parsers/`. `[ccsds-ndm]` floor bumped from `>=2.0` to `>=3.0` — the v3 line is the writer surface tested here.

## Out of scope

- Multi-segment output and covariance blocks (deliberately deferred to follow-ups; `df.attrs["segments"]` is ignored, single-segment output only).
- Round-trip-through-GMAT verification — owned by a separate golden-file regression issue per the original DoD.

## Test plan

- [x] `uv run pytest` — 614 passed, 10 deselected.
- [x] `uv run ruff check` — clean.
- [x] `uv run ruff format --check` — clean.
- [x] `uv run mypy` — clean.
- [x] `uv run pytest --cov` — overall 96 % (gate ≥ 80 %), parsers 97 % (gate ≥ 95 %), new `writers/oem.py` at 100 %.
- [ ] Round-trip through GMAT (`EphemerisFile.FileFormat = CCSDS-OEM`) — explicitly deferred to the follow-up regression issue.

Closes #67.