### PR TITLE
Fix gmat_run.time *->UTC raise on leap-second instants

### DIFF
--- a/src/gmat_run/time.py
+++ b/src/gmat_run/time.py
@@ -21,6 +21,7 @@ without astropy installed is fine; calling :func:`convert` or
 
 from typing import Any, Final
 
+import numpy as np
 import pandas as pd
 
 __all__ = ["convert", "convert_column"]
@@ -53,6 +54,13 @@ def convert(
     Both scales must be one of ``"A1"``, ``"TAI"``, ``"UTC"``, ``"TT"``,
     ``"TDB"``. Same-scale conversion returns a copy of ``series`` without
     importing astropy.
+
+    Leap-second instants on the ``to_scale="UTC"`` path collapse to the
+    post-jump second — matching what GMAT does internally — at microsecond
+    precision. ``numpy.datetime64`` cannot represent ``23:59:60`` so this
+    is the only sensible representation; non-leap-second rows keep full
+    ``datetime64[ns]`` precision even when a sibling row in the same
+    series lands on a leap second.
 
     Args:
         series: ``datetime64[ns]`` ``Series`` representing the labelled
@@ -105,7 +113,10 @@ def convert(
     astropy_to = "tai" if to_scale == "A1" else _ASTROPY_SCALE[to_scale]
 
     t = Time(values, format="datetime64", scale=astropy_from)
-    converted_values = getattr(t, astropy_to).datetime64
+    if astropy_to == "utc":
+        converted_values = _utc_to_datetime64(t.utc)
+    else:
+        converted_values = getattr(t, astropy_to).datetime64
 
     if to_scale == "A1":
         converted_values = converted_values + _A1_TAI_OFFSET.to_numpy()
@@ -170,6 +181,32 @@ def _require_datetime_dtype(series: pd.Series) -> None:
             f"expected a datetime64 Series (the dtype produced by "
             f"promote_epochs); got dtype={series.dtype}"
         )
+
+
+def _utc_to_datetime64(t_in_utc: Any) -> np.ndarray:
+    """Materialise an astropy UTC ``Time`` as ``datetime64[ns]``.
+
+    Astropy renders the leap-second instant as ``YYYY-MM-DD HH:MM:60.x`` in
+    UTC, which ``numpy.datetime64`` cannot represent. The fast path uses
+    ``Time.datetime64`` (full nanosecond precision); for rows inside a
+    leap-second window we fall back to
+    ``Time.to_datetime(leap_second_strict='silent')``, which collapses the
+    1-second window to the post-jump second at microsecond precision.
+
+    Leap-window detection inspects ``Time.iso``: astropy's default ISO
+    subfmt always renders the seconds field at character offset 17:19, so
+    matching the literal ``"60"`` there is enough.
+    """
+    iso = np.asarray(t_in_utc.iso)
+    in_leap = np.fromiter((s[17:19] == "60" for s in iso), dtype=bool, count=len(iso))
+    if not in_leap.any():
+        return np.asarray(t_in_utc.datetime64)
+    out = np.empty(len(iso), dtype="datetime64[ns]")
+    if (~in_leap).any():
+        out[~in_leap] = t_in_utc[~in_leap].datetime64
+    leap_dt = t_in_utc[in_leap].to_datetime(leap_second_strict="silent")
+    out[in_leap] = np.asarray(leap_dt, dtype="datetime64[ns]")
+    return out
 
 
 def _import_astropy_time() -> Any:

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -106,6 +106,85 @@ def test_utc_to_tai_jumps_one_second_across_2017_leap() -> None:
     assert offset_after - offset_before == pytest.approx(1.0, abs=1e-9)
 
 
+# --- target=UTC at a leap-second instant ------------------------------------
+
+# An input epoch whose physical instant astropy renders as ``23:59:60.x`` in
+# UTC cannot be expressed as ``numpy.datetime64`` — it raises rather than
+# silently truncating. The fix funnels these rows through
+# ``Time.to_datetime(leap_second_strict='silent')`` and pins each one to the
+# post-jump second; non-leap rows in the same series keep full ns precision.
+
+# TAI for the 2017-01-01 leap-second instant (offset went 36 s -> 37 s).
+_LEAP_2017_TAI = pd.Timestamp("2017-01-01 00:00:36")
+_LEAP_2017_UTC_POST_JUMP = pd.Timestamp("2017-01-01 00:00:00")
+
+
+def test_tai_to_utc_at_leap_second_instant_pins_to_post_jump_second() -> None:
+    s = pd.Series([_LEAP_2017_TAI], name="t")
+    out = convert(s, "TAI", "UTC")
+    assert out.iloc[0] == _LEAP_2017_UTC_POST_JUMP
+    assert out.dtype == np.dtype("datetime64[ns]")
+
+
+def test_tt_to_utc_at_leap_second_instant_pins_to_post_jump_second() -> None:
+    # TT - TAI = 32.184 s exactly (constant offset).
+    tt_value = _LEAP_2017_TAI + pd.Timedelta(seconds=32, microseconds=184_000)
+    s = pd.Series([tt_value], name="t")
+    out = convert(s, "TT", "UTC")
+    assert out.iloc[0] == _LEAP_2017_UTC_POST_JUMP
+
+
+def test_a1_to_utc_at_leap_second_instant_pins_to_post_jump_second() -> None:
+    # A1 leads TAI by 0.0343817 s; A1 -> UTC routes through TAI.
+    a1_value = _LEAP_2017_TAI + pd.Timedelta("0.0343817s")
+    s = pd.Series([a1_value], name="t")
+    out = convert(s, "A1", "UTC")
+    assert out.iloc[0] == _LEAP_2017_UTC_POST_JUMP
+
+
+def test_convert_column_through_leap_second_instant() -> None:
+    """``convert_column`` (and therefore ``promote_epochs(..., convert_to=)`` and
+    every parser-level ``convert_to=``) inherits the fix transitively."""
+    df = pd.DataFrame({"Sat.TAIGregorian": [_LEAP_2017_TAI]})
+    df.attrs["epoch_scales"] = {"Sat.TAIGregorian": "TAI"}
+    convert_column(df, "Sat.TAIGregorian", "UTC")
+    assert df.attrs["epoch_scales"]["Sat.TAIGregorian"] == "UTC"
+    assert df["Sat.TAIGregorian"].iloc[0] == _LEAP_2017_UTC_POST_JUMP
+
+
+def test_to_utc_mixed_series_preserves_ns_on_non_leap_rows() -> None:
+    """One leap row in a series must not drag every other row down to µs."""
+    # 2026 is past the last leap second, so TAI - UTC = 37 s here; the
+    # nanosecond digit (789) survives the round-trip.
+    ns_precise_tai = pd.Timestamp("2026-01-15 12:00:00.123456789")
+    s = pd.Series([_LEAP_2017_TAI, ns_precise_tai], name="t")
+
+    out = convert(s, "TAI", "UTC")
+
+    assert out.iloc[0] == _LEAP_2017_UTC_POST_JUMP
+    assert out.iloc[1] == ns_precise_tai - pd.Timedelta(seconds=37)
+    assert pd.Timestamp(out.iloc[1]).nanosecond == 789
+
+
+@pytest.mark.parametrize(
+    "tai_str, expected_utc_str",
+    [
+        ("2012-07-01 00:00:34", "2012-07-01 00:00:00"),  # offset 34 -> 35
+        ("2017-01-01 00:00:36", "2017-01-01 00:00:00"),  # offset 36 -> 37
+    ],
+    ids=["2012-07-01", "2017-01-01"],
+)
+def test_historical_leap_second_instants_convert_cleanly(
+    tai_str: str, expected_utc_str: str
+) -> None:
+    """Each TAI instant astropy renders as UTC ``23:59:60`` is pinned to the
+    post-jump second. Two distinct boundaries cover the helper's split path
+    on both sides of the ns-vs-µs precision threshold."""
+    s = pd.Series([pd.Timestamp(tai_str)], name="t")
+    out = convert(s, "TAI", "UTC")
+    assert out.iloc[0] == pd.Timestamp(expected_utc_str)
+
+
 # --- ImportError plumbing ----------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

- `gmat_run.time.convert(..., to_scale="UTC")` raised `ValueError` from astropy's `Time.utc.datetime64` accessor when any input row landed exactly on a leap-second instant — astropy renders the leap-second as `23:59:60.x` and `numpy.datetime64` cannot represent that. The bug propagated transitively to `convert_column`, `promote_epochs(..., convert_to=)`, and every parser-level `convert_to=` keyword.
- Route the `*->UTC` astropy step through a new private `_utc_to_datetime64` helper that splits the array: non-leap rows take the existing `.datetime64` fast path (full nanosecond precision), only leap-window rows fall back to `Time.to_datetime(leap_second_strict='silent')` (microsecond precision, pinned to the post-jump second to match GMAT's internal labelling convention). All other code paths (same-scale copy, A1<->TAI offset, non-UTC targets) are unchanged.
- New regression tests cover TAI/TT/A1 -> UTC at the 2017-01-01 leap-second instant, the `convert_column` route, the mixed-row precision invariant (a leap row in a series doesn't drag non-leap rows down to µs), and a parametrized sweep over historical leap seconds (2012-07-01, 2017-01-01).
- Public API surface, extras, and astropy floor (`>=6.0`) are unchanged. The `convert` docstring gains a one-paragraph note on the leap-second collapse.

## Test plan

- [x] `uv run pytest` — 622 passed, 14 deselected.
- [x] `uv run ruff check`
- [x] `uv run ruff format --check`
- [x] `uv run mypy`
- [x] Original repro from #80 returns `2017-01-01 00:00:00` cleanly.
- [x] End-to-end: the inline #71 demo script (`leap_second_demo.script`, propagates a LEO across 2017-01-01 with a 30 s fixed step) now converts every column to UTC via `parsers.reportfile.parse(..., convert_to="UTC")` without raising.
- [ ] CI passes on Ubuntu / Windows / macOS.

Closes #80.