### PR TITLE
Add example notebook: time-scale conversion across a leap-second boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,7 @@ jobs:
           uv run jupyter execute docs/examples/01_load_run_plot.ipynb
           uv run jupyter execute docs/examples/02_parameter_sweep.ipynb
           uv run jupyter execute docs/examples/04_export_oem.ipynb
+          uv run jupyter execute docs/examples/05_time_scales.ipynb
 
   lint:
     name: lint

--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ Runnable example notebooks:
 - [Export to CCSDS-OEM](https://astro-tools.github.io/gmat-run/examples/04_export_oem/) —
   run a stock GMAT sample that emits an STK ephemeris, convert it to a CCSDS-OEM file
   with `Results.write_oem`, re-parse the result, and visualise the trajectory in 3D.
+- [Time-scale conversion](https://astro-tools.github.io/gmat-run/examples/05_time_scales/) —
+  propagate across the 2017-01-01 leap-second boundary and convert the resulting
+  ReportFile's epoch columns between A1, TAI, UTC, TT, and TDB with `gmat_run.time`
+  and the parser-level `convert_to=` keyword.
 
 ## Development
 

--- a/docs/examples/05_time_scales.ipynb
+++ b/docs/examples/05_time_scales.ipynb
@@ -1,0 +1,716 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "161bc6fa",
+   "metadata": {},
+   "source": [
+    "# Time-scale conversion across a leap-second boundary\n",
+    "\n",
+    "GMAT emits epoch columns labelled with one of five time scales — A1, TAI, UTC, TT, TDB — and `gmat-run` promotes each one to `datetime64[ns]` *in its native scale*. When you want every column on a single time axis (say, plotting two missions against each other, or aligning a `ContactLocator` window with a ReportFile sample), `gmat_run.time` converts between scales using astropy's IERS-backed leap-second table.\n",
+    "\n",
+    "This notebook demonstrates the conversion path end-to-end on a propagation that crosses the **2017-01-01** leap-second boundary, where TAI − UTC ticked from 36 s to 37 s. We:\n",
+    "\n",
+    "1. Run a small mission whose `ReportFile` emits the same epoch in four scales (UTC / TAI / TT / TDB) plus an A1 numeric column.\n",
+    "2. Look at the per-column scale labels on `df.attrs[\"epoch_scales\"]` before any conversion.\n",
+    "3. Convert one column with [`gmat_run.time.convert_column`][gmat_run.time.convert_column], then the whole frame with the parser-level `convert_to=` keyword.\n",
+    "4. Show A1 separately — it's GMAT-specific (astropy doesn't recognise it) and routes through TAI internally.\n",
+    "5. Plot TAI − UTC across the boundary so the 1-second leap-second jump is visible.\n",
+    "\n",
+    "**Prerequisites.** A local GMAT install (R2026a is the primary development target) and `pip install gmat-run[astropy,examples]` for the time-scale module and matplotlib.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d264c0e3",
+   "metadata": {},
+   "source": [
+    "## Locate the script\n",
+    "\n",
+    "The mission lives next to this notebook (`leap_second_demo.script`) — a minimal LEO whose epoch starts at 23:55:00 UTC on 2016-12-31, propagates 600 s with a fixed 30 s step, and writes a `ReportFile` carrying epoch columns in four scales side-by-side plus `Sat.A1ModJulian`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "d2d9071d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T17:06:35.852440Z",
+     "iopub.status.busy": "2026-04-28T17:06:35.852291Z",
+     "iopub.status.idle": "2026-04-28T17:06:39.678988Z",
+     "shell.execute_reply": "2026-04-28T17:06:39.677896Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "GMAT version: R2026a\n",
+      "Script:       leap_second_demo.script\n",
+      "Exists:       True\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pathlib import Path\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "\n",
+    "from gmat_run import Mission, locate_gmat\n",
+    "from gmat_run.parsers.reportfile import parse as parse_report\n",
+    "from gmat_run.time import convert, convert_column\n",
+    "\n",
+    "install = locate_gmat()\n",
+    "script_path = Path(\"leap_second_demo.script\").resolve()\n",
+    "\n",
+    "print(f\"GMAT version: {install.version}\")\n",
+    "print(f\"Script:       {script_path.name}\")\n",
+    "print(f\"Exists:       {script_path.exists()}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b01d7a20",
+   "metadata": {},
+   "source": [
+    "## Run and inspect the native scales\n",
+    "\n",
+    "`Mission.load(...).run()` parses the script, executes it headlessly, and exposes the resulting `ReportFile` lazily through `result.reports[\"RF\"]`. The five epoch columns come back as `datetime64[ns]` — already typed timestamps, no further parsing required — and the *labelled* time scale for each column is recorded on `df.attrs[\"epoch_scales\"]`. No conversion has happened yet: `Sat.UTCGregorian` is the UTC instant, `Sat.TAIGregorian` is the TAI instant of the same physical moment, etc.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "af1a5290",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T17:06:39.680592Z",
+     "iopub.status.busy": "2026-04-28T17:06:39.680352Z",
+     "iopub.status.idle": "2026-04-28T17:06:40.254039Z",
+     "shell.execute_reply": "2026-04-28T17:06:40.252936Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Rows: 21\n",
+      "\n",
+      "Native scale per column (df.attrs['epoch_scales']):\n",
+      "  Sat.UTCGregorian: UTC\n",
+      "  Sat.TAIGregorian: TAI\n",
+      "  Sat.TTGregorian: TT\n",
+      "  Sat.TDBGregorian: TDB\n",
+      "  Sat.A1ModJulian: A1\n",
+      "\n",
+      "Dtypes:\n",
+      "Sat.UTCGregorian    datetime64[ns]\n",
+      "Sat.TAIGregorian    datetime64[ns]\n",
+      "Sat.TTGregorian     datetime64[ns]\n",
+      "Sat.TDBGregorian    datetime64[ns]\n",
+      "Sat.A1ModJulian     datetime64[ns]\n",
+      "Sat.X                      float64\n",
+      "Sat.Y                      float64\n",
+      "Sat.Z                      float64\n",
+      "dtype: object\n"
+     ]
+    }
+   ],
+   "source": [
+    "mission = Mission.load(script_path)\n",
+    "result = mission.run()\n",
+    "df = result.reports[\"RF\"]\n",
+    "\n",
+    "print(f\"Rows: {len(df)}\")\n",
+    "print()\n",
+    "print(\"Native scale per column (df.attrs['epoch_scales']):\")\n",
+    "for col, scale in df.attrs[\"epoch_scales\"].items():\n",
+    "    print(f\"  {col}: {scale}\")\n",
+    "print()\n",
+    "print(\"Dtypes:\")\n",
+    "print(df.dtypes)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b772e54",
+   "metadata": {},
+   "source": [
+    "## See the leap-second jump\n",
+    "\n",
+    "GMAT integrates the propagation in atomic time, so TAI advances at a fixed 30 s per row. UTC, on the other hand, has a 1-second leap inserted at 2017-01-01 00:00:00. Before the boundary, TAI − UTC = 36 s; after, 37 s. The ReportFile carries both scales side-by-side, so we can read the offset directly off the DataFrame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "4da32df2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T17:06:40.255513Z",
+     "iopub.status.busy": "2026-04-28T17:06:40.255345Z",
+     "iopub.status.idle": "2026-04-28T17:06:40.281192Z",
+     "shell.execute_reply": "2026-04-28T17:06:40.280200Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Sat.UTCGregorian</th>\n",
+       "      <th>TAI - UTC (s)</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2016-12-31 23:55:00</td>\n",
+       "      <td>36.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2016-12-31 23:55:30</td>\n",
+       "      <td>36.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2016-12-31 23:56:00</td>\n",
+       "      <td>36.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2016-12-31 23:56:30</td>\n",
+       "      <td>36.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2016-12-31 23:57:00</td>\n",
+       "      <td>36.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>2016-12-31 23:57:30</td>\n",
+       "      <td>36.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>2016-12-31 23:58:00</td>\n",
+       "      <td>36.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>2016-12-31 23:58:30</td>\n",
+       "      <td>36.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>2016-12-31 23:59:00</td>\n",
+       "      <td>36.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>2016-12-31 23:59:30</td>\n",
+       "      <td>36.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>2017-01-01 00:00:00</td>\n",
+       "      <td>36.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>2017-01-01 00:00:29</td>\n",
+       "      <td>37.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>2017-01-01 00:00:59</td>\n",
+       "      <td>37.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>2017-01-01 00:01:29</td>\n",
+       "      <td>37.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>14</th>\n",
+       "      <td>2017-01-01 00:01:59</td>\n",
+       "      <td>37.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>2017-01-01 00:02:29</td>\n",
+       "      <td>37.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>16</th>\n",
+       "      <td>2017-01-01 00:02:59</td>\n",
+       "      <td>37.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>17</th>\n",
+       "      <td>2017-01-01 00:03:29</td>\n",
+       "      <td>37.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>18</th>\n",
+       "      <td>2017-01-01 00:03:59</td>\n",
+       "      <td>37.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19</th>\n",
+       "      <td>2017-01-01 00:04:29</td>\n",
+       "      <td>37.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20</th>\n",
+       "      <td>2017-01-01 00:04:59</td>\n",
+       "      <td>37.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      Sat.UTCGregorian  TAI - UTC (s)\n",
+       "0  2016-12-31 23:55:00           36.0\n",
+       "1  2016-12-31 23:55:30           36.0\n",
+       "2  2016-12-31 23:56:00           36.0\n",
+       "3  2016-12-31 23:56:30           36.0\n",
+       "4  2016-12-31 23:57:00           36.0\n",
+       "5  2016-12-31 23:57:30           36.0\n",
+       "6  2016-12-31 23:58:00           36.0\n",
+       "7  2016-12-31 23:58:30           36.0\n",
+       "8  2016-12-31 23:59:00           36.0\n",
+       "9  2016-12-31 23:59:30           36.0\n",
+       "10 2017-01-01 00:00:00           36.0\n",
+       "11 2017-01-01 00:00:29           37.0\n",
+       "12 2017-01-01 00:00:59           37.0\n",
+       "13 2017-01-01 00:01:29           37.0\n",
+       "14 2017-01-01 00:01:59           37.0\n",
+       "15 2017-01-01 00:02:29           37.0\n",
+       "16 2017-01-01 00:02:59           37.0\n",
+       "17 2017-01-01 00:03:29           37.0\n",
+       "18 2017-01-01 00:03:59           37.0\n",
+       "19 2017-01-01 00:04:29           37.0\n",
+       "20 2017-01-01 00:04:59           37.0"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "delta = (df[\"Sat.TAIGregorian\"] - df[\"Sat.UTCGregorian\"]).dt.total_seconds()\n",
+    "pd.DataFrame(\n",
+    "    {\n",
+    "        \"Sat.UTCGregorian\": df[\"Sat.UTCGregorian\"],\n",
+    "        \"TAI - UTC (s)\": delta,\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07201195",
+   "metadata": {},
+   "source": [
+    "## Per-column conversion\n",
+    "\n",
+    "`gmat_run.time.convert_column(df, column, to_scale)` converts one promoted epoch column from its recorded source scale to a new target scale, updating `df.attrs[\"epoch_scales\"][column]` in place. It is the right tool when you want to align *one* column without touching the others.\n",
+    "\n",
+    "Below: convert `Sat.UTCGregorian` to TAI on a copy of the frame. The values shift by ~36–37 s (depending on which side of the leap second each row falls on), and the recorded scale label updates from `UTC` → `TAI`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "bc6c1f35",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T17:06:40.282711Z",
+     "iopub.status.busy": "2026-04-28T17:06:40.282551Z",
+     "iopub.status.idle": "2026-04-28T17:06:48.706218Z",
+     "shell.execute_reply": "2026-04-28T17:06:48.705185Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "epoch_scales['Sat.UTCGregorian'] is now: 'TAI'\n",
+      "First row: 2016-12-31 23:55:00  ->  2016-12-31 23:55:36\n",
+      "Last row:  2017-01-01 00:04:59  ->  2017-01-01 00:05:36\n"
+     ]
+    }
+   ],
+   "source": [
+    "df_one = df.copy()\n",
+    "df_one.attrs[\"epoch_scales\"] = dict(df.attrs[\"epoch_scales\"])\n",
+    "\n",
+    "before = df_one[\"Sat.UTCGregorian\"].iloc[[0, -1]].tolist()\n",
+    "convert_column(df_one, \"Sat.UTCGregorian\", \"TAI\")\n",
+    "after = df_one[\"Sat.UTCGregorian\"].iloc[[0, -1]].tolist()\n",
+    "\n",
+    "scale = df_one.attrs[\"epoch_scales\"][\"Sat.UTCGregorian\"]\n",
+    "print(f\"epoch_scales['Sat.UTCGregorian'] is now: {scale!r}\")\n",
+    "print(f\"First row: {before[0]}  ->  {after[0]}\")\n",
+    "print(f\"Last row:  {before[1]}  ->  {after[1]}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5f92b492",
+   "metadata": {},
+   "source": [
+    "## Whole-frame conversion via the parser\n",
+    "\n",
+    "When you want *every* epoch column on a single scale (for joining DataFrames from different mission runs, or feeding a single time axis into downstream tooling), the parsers expose a `convert_to=` keyword that runs the whole conversion in one call. The same keyword is available on `parsers.reportfile.parse`, the three `EphemerisFile` parsers, and `parsers.aem_ephemeris.parse`.\n",
+    "\n",
+    "We re-parse the report GMAT just wrote, asking for everything in UTC. After the call every entry in `df.attrs[\"epoch_scales\"]` reads `UTC`, and the four other-scale columns line up with `Sat.UTCGregorian` row-by-row."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "f477627b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T17:06:48.708227Z",
+     "iopub.status.busy": "2026-04-28T17:06:48.708011Z",
+     "iopub.status.idle": "2026-04-28T17:06:48.726766Z",
+     "shell.execute_reply": "2026-04-28T17:06:48.725573Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "All scales after convert_to='UTC':\n",
+      "  Sat.UTCGregorian: UTC\n",
+      "  Sat.TAIGregorian: UTC\n",
+      "  Sat.TTGregorian: UTC\n",
+      "  Sat.TDBGregorian: UTC\n",
+      "  Sat.A1ModJulian: UTC\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Sat.UTCGregorian</th>\n",
+       "      <th>Sat.TAIGregorian</th>\n",
+       "      <th>Sat.TTGregorian</th>\n",
+       "      <th>Sat.TDBGregorian</th>\n",
+       "      <th>Sat.A1ModJulian</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2016-12-31 23:55:00</td>\n",
+       "      <td>2016-12-31 23:55:00</td>\n",
+       "      <td>2016-12-31 23:55:00</td>\n",
+       "      <td>2016-12-31 23:55:00.000049599</td>\n",
+       "      <td>2016-12-31 23:54:59.999999923</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2016-12-31 23:55:30</td>\n",
+       "      <td>2016-12-31 23:55:30</td>\n",
+       "      <td>2016-12-31 23:55:30</td>\n",
+       "      <td>2016-12-31 23:55:30.000049588</td>\n",
+       "      <td>2016-12-31 23:55:29.999999705</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2016-12-31 23:56:00</td>\n",
+       "      <td>2016-12-31 23:56:00</td>\n",
+       "      <td>2016-12-31 23:56:00</td>\n",
+       "      <td>2016-12-31 23:56:00.000049578</td>\n",
+       "      <td>2016-12-31 23:55:59.999999487</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     Sat.UTCGregorian    Sat.TAIGregorian     Sat.TTGregorian  \\\n",
+       "0 2016-12-31 23:55:00 2016-12-31 23:55:00 2016-12-31 23:55:00   \n",
+       "1 2016-12-31 23:55:30 2016-12-31 23:55:30 2016-12-31 23:55:30   \n",
+       "2 2016-12-31 23:56:00 2016-12-31 23:56:00 2016-12-31 23:56:00   \n",
+       "\n",
+       "               Sat.TDBGregorian               Sat.A1ModJulian  \n",
+       "0 2016-12-31 23:55:00.000049599 2016-12-31 23:54:59.999999923  \n",
+       "1 2016-12-31 23:55:30.000049588 2016-12-31 23:55:29.999999705  \n",
+       "2 2016-12-31 23:56:00.000049578 2016-12-31 23:55:59.999999487  "
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "report_path = result.output_dir / \"leap_second_demo_report.txt\"\n",
+    "df_utc = parse_report(report_path, convert_to=\"UTC\")\n",
+    "\n",
+    "print(\"All scales after convert_to='UTC':\")\n",
+    "for col, scale in df_utc.attrs[\"epoch_scales\"].items():\n",
+    "    print(f\"  {col}: {scale}\")\n",
+    "\n",
+    "epoch_cols = [\n",
+    "    \"Sat.UTCGregorian\",\n",
+    "    \"Sat.TAIGregorian\",\n",
+    "    \"Sat.TTGregorian\",\n",
+    "    \"Sat.TDBGregorian\",\n",
+    "    \"Sat.A1ModJulian\",\n",
+    "]\n",
+    "df_utc[epoch_cols].head(3)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "87c08579",
+   "metadata": {},
+   "source": [
+    "## A1: a GMAT-specific scale\n",
+    "\n",
+    "Astropy's leap-second table doesn't know A1. Per the GMAT Mathematical Specification §2.1, A1 leads TAI by a fixed 0.0343817 s, so `gmat_run.time` routes A1 through TAI by applying that offset before/after the astropy step. From a caller's perspective A1 is just another scale name — `convert(series, \"A1\", \"UTC\")` works exactly like the other directions.\n",
+    "\n",
+    "Below we take the GMAT-emitted A1 column, ask `convert` for UTC, and check it agrees with the GMAT-emitted `Sat.UTCGregorian` column to within a few hundred nanoseconds (GMAT's own A1↔TAI offset is rounded internally — see the [Time scales reference](../reference/time.md) for the exact value `gmat_run.time` uses)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "a97794f8",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T17:06:48.728417Z",
+     "iopub.status.busy": "2026-04-28T17:06:48.728241Z",
+     "iopub.status.idle": "2026-04-28T17:06:48.738316Z",
+     "shell.execute_reply": "2026-04-28T17:06:48.737136Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "max |convert(A1 -> UTC) - GMAT UTC| = 0 days 00:00:00.000000513\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Sat.A1ModJulian (A1)</th>\n",
+       "      <th>convert(A1 -&gt; UTC)</th>\n",
+       "      <th>Sat.UTCGregorian (GMAT)</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2016-12-31 23:55:36.034381623</td>\n",
+       "      <td>2016-12-31 23:54:59.999999923</td>\n",
+       "      <td>2016-12-31 23:55:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2016-12-31 23:56:06.034381405</td>\n",
+       "      <td>2016-12-31 23:55:29.999999705</td>\n",
+       "      <td>2016-12-31 23:55:30</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2016-12-31 23:56:36.034381187</td>\n",
+       "      <td>2016-12-31 23:55:59.999999487</td>\n",
+       "      <td>2016-12-31 23:56:00</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           Sat.A1ModJulian (A1)            convert(A1 -> UTC)  \\\n",
+       "0 2016-12-31 23:55:36.034381623 2016-12-31 23:54:59.999999923   \n",
+       "1 2016-12-31 23:56:06.034381405 2016-12-31 23:55:29.999999705   \n",
+       "2 2016-12-31 23:56:36.034381187 2016-12-31 23:55:59.999999487   \n",
+       "\n",
+       "  Sat.UTCGregorian (GMAT)  \n",
+       "0     2016-12-31 23:55:00  \n",
+       "1     2016-12-31 23:55:30  \n",
+       "2     2016-12-31 23:56:00  "
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "a1_to_utc = convert(df[\"Sat.A1ModJulian\"], \"A1\", \"UTC\")\n",
+    "max_diff = (a1_to_utc - df[\"Sat.UTCGregorian\"]).abs().max()\n",
+    "print(f\"max |convert(A1 -> UTC) - GMAT UTC| = {max_diff}\")\n",
+    "\n",
+    "pd.DataFrame(\n",
+    "    {\n",
+    "        \"Sat.A1ModJulian (A1)\": df[\"Sat.A1ModJulian\"].iloc[:3],\n",
+    "        \"convert(A1 -> UTC)\": a1_to_utc.iloc[:3],\n",
+    "        \"Sat.UTCGregorian (GMAT)\": df[\"Sat.UTCGregorian\"].iloc[:3],\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "650b8716",
+   "metadata": {},
+   "source": [
+    "## Plot TAI − UTC across the boundary\n",
+    "\n",
+    "The 1-second leap second sits right between rows 10 and 11 (UTC 2016-12-31 23:59:30 → 2017-01-01 00:00:00). Stepping the offset through the propagation makes the discontinuity obvious — and matches the IERS leap-second history for 2017-01-01."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "14151a9b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-28T17:06:48.739910Z",
+     "iopub.status.busy": "2026-04-28T17:06:48.739620Z",
+     "iopub.status.idle": "2026-04-28T17:06:49.062728Z",
+     "shell.execute_reply": "2026-04-28T17:06:49.061765Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA90AAAGGCAYAAABmGOKbAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjksIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvJkbTWQAAAAlwSFlzAAAPYQAAD2EBqD+naQAAYm1JREFUeJzt3Xd4FPXaxvF700NCEkoSCL2ELlVEkCKKoiKggIhiQRSPIgdR5D1WpGPFgoJ6BBQFUUQFOSpNmhUQFaQjhA4JJQVC6v7ePziZw5IAAWaZZPl+risXZmZ25tnb2d08O7+ZcRljjAAAAAAAgO38nC4AAAAAAABfRdMNAAAAAICX0HQDAAAAAOAlNN0AAAAAAHgJTTcAAAAAAF5C0w0AAAAAgJfQdAMAAAAA4CU03QAAAAAAeAlNNwAAAAAAXkLTDQDARTRs2DC5XC4dPHjQ6VLggKpVq6pPnz5Ol3FJynvtAcDFRtMNAIXkcrkK9bNkyRLrMRMmTJDL5VKLFi3OuN4BAwbYWmvVqlV18803Fzhv1apVcrlc+uCDD5SQkFDo55WQkCBJOnDggJ544gnVqVNHJUqUUFhYmJo1a6ZRo0YpOTnZ1udRnI0ZM0ZfffWVY9tfuXKlBgwYoPr16yssLEyVK1dWz549tXnz5gKX37Bhg2644QaFh4erdOnSuvvuu5WUlJRvudGjR6tLly6KjY2Vy+XSsGHDClxf1apVT7svxcfHF+o5uN1uvfTSS6pWrZpCQkLUsGFDffLJJ/mWW7Fihfr3769mzZopMDDwvBqri7ktAMClJcDpAgCguPjoo488fp86daoWLFiQb3rdunWt/542bZqqVq2qFStWaOvWrapZs+ZFqbWwoqOj89X/6quvavfu3XrttdfyLbty5UrddNNNOnr0qO666y41a9ZM0olG/oUXXtCyZcs0f/78i1Z/UTZmzBj16NFDt9xyiyPbf/HFF/Xjjz/qtttuU8OGDbV//3699dZbatq0qX755Rc1aNDAWnb37t1q27atIiMjNWbMGB09elSvvPKK1q5dqxUrVigoKMha9tlnn1W5cuXUpEkTzZs377Tbf/3113X06FGPaTt27NCzzz6r66+/vlDP4ZlnntELL7ygfv36qXnz5po9e7buvPNOuVwu9erVy1rum2++0fvvv6+GDRuqevXqp/1ioahsCwBwiTEAgPPyyCOPmDO9jW7bts1IMl988YWJjo42w4YNK3A5SeaRRx6xtbYqVaqYTp06FThv5cqVRpKZMmVKgfM7depkqlSpkm/6kSNHTIUKFUxsbKzZsGFDvvn79+83I0eOvJCyL9jRo0cd3f7JwsLCzL333ptv+vPPP28kmaSkJK9u/8cffzSZmZke0zZv3myCg4NN7969PaY//PDDJjQ01OzYscOatmDBAiPJvPvuux7Lbt++3RhjTFJSkpFknn/++ULXNHLkSCPJ/Pjjj2dddvfu3SYwMNDjteF2u02bNm1MxYoVTU5OjjV9//79Jj093Rhz9tel09uqUqVKgfsFvC/vtQcAFxvDywHAS6ZNm6ZSpUqpU6dO6tGjh6ZNm+Z0SRfk3Xff1Z49ezRu3DjVqVMn3/zY2Fg9++yzZ1zHmjVr1KdPH1WvXl0hISEqV66c+vbtq0OHDuVbds+ePbr//vsVFxen4OBgVatWTQ8//LCysrIkSR988IFcLpeWLl2q/v37KyYmRhUrVrQeP2HCBNWvX1/BwcGKi4vTI488km/4+5YtW9S9e3eVK1dOISEhqlixonr16qWUlBRrmQULFqh169aKiopSeHi4ateuraeffvqMz9PlcunYsWP68MMPrSHVp57Hm5ycrD59+igqKkqRkZG67777lJ6enm9dH3/8sZo1a6bQ0FCVLl1avXr10q5du864fUlq1aqVxxFqSYqPj1f9+vW1YcMGj+mzZs3SzTffrMqVK1vTOnTooFq1aumzzz7zWLZq1apn3fbpTJ8+XdWqVVOrVq3Ouuzs2bOVnZ2t/v37W9NcLpcefvhh7d69Wz///LM1PTY2VqGhoedd18XcVkGSk5M1aNAgVapUScHBwapZs6ZefPFFud1uj+VeeeUVtWrVSmXKlFFoaKiaNWumzz//PN/68k5ZmTZtmmrXrq2QkBA1a9ZMy5YtK1Q948ePV/369VWiRAmVKlVKl19+uaZPn+6xzJ49e9S3b1/FxsYqODhY9evX1+TJk/OtKyMjQ8OGDVOtWrUUEhKi8uXLq1u3bvr777+tZY4dO6bBgwdbz7927dp65ZVXZIwp8Hl99dVXatCggbXd7777Lt92f/jhBzVv3lwhISGqUaOG3n333UI9dwDwBoaXA4CXTJs2Td26dVNQUJDuuOMOTZw4UStXrlTz5s2dLu28zJkzR6GhoerRo8d5r2PBggXatm2b7rvvPpUrV07r1q3Te++9p3Xr1umXX36xzo/du3evrrjiCiUnJ+vBBx9UnTp1tGfPHn3++edKT0/3aCb79++v6OhoDR06VMeOHZN04oJJw4cPV4cOHfTwww9r06ZNVv4//vijAgMDlZWVpY4dOyozM1P//Oc/Va5cOe3Zs0dz585VcnKyIiMjtW7dOt18881q2LChRowYoeDgYG3dulU//vjjGZ/nRx99pAceeEBXXHGFHnzwQUlSjRo1PJbp2bOnqlWrprFjx2r16tV6//33FRMToxdffNFaZvTo0XruuefUs2dPPfDAA0pKStL48ePVtm1b/f7774qKijqn/I0xOnDggOrXr29N27NnjxITE3X55ZfnW/6KK67QN998c07bOJ3ff/9dGzZs0DPPPFPo5cPCwjxO18irKW9+69atbavtYm3rVOnp6WrXrp327Nmjf/zjH6pcubJ++uknPfXUU9q3b59ef/11a9k33nhDXbp0Ue/evZWVlaUZM2botttu09y5c9WpUyeP9S5dulSffvqpBg4cqODgYE2YMEE33HCDVqxY4XFqwan+/e9/a+DAgerRo4ceffRRZWRkaM2aNfr111915513SjpxXYcrr7zSaoKjo6P17bff6v7771dqaqoGDRokScrNzdXNN9+sRYsWqVevXnr00UeVlpamBQsW6K+//lKNGjVkjFGXLl20ePFi3X///WrcuLHmzZunIUOGaM+ePflOc/nhhx/0xRdfqH///ipZsqTefPNNde/eXTt37lSZMmUkSWvXrtX111+v6OhoDRs2TDk5OXr++ecVGxtrw/8xADgPDh9pB4Bi60xDS1etWmUkmQULFhhjTgxVrVixonn00UfzLatiMry8VKlSplGjRhdUV96w3JN98sknRpJZtmyZNe2ee+4xfn5+ZuXKlfmWd7vdxhhjpkyZYiSZ1q1bewz/TUxMNEFBQeb66683ubm51vS33nrLSDKTJ082xhjz+++/G0lm5syZp633tddeO++h4GcbXt63b1+P6bfeeqspU6aM9XtCQoLx9/c3o0eP9lhu7dq1JiAgIN/0wvjoo4+MJDNp0iRrWt7+MHXq1HzLDxkyxEgyGRkZ+ead6/DywYMHG0lm/fr1hVq+U6dOpnr16vmmHzt2zEgyTz75ZIGPO58h3xdzW6cOLx85cqQJCwszmzdv9ljuySefNP7+/mbnzp3WtFNfP1lZWaZBgwbmmmuu8ZguyUgyq1atsqbt2LHDhISEmFtvvfWM9XXt2tXUr1//jMvcf//9pnz58ubgwYMe03v16mUiIyOtOidPnmwkmXHjxuVbR97r+KuvvjKSzKhRozzm9+jRw7hcLrN161aP5xUUFOQx7c8//zSSzPjx461pt9xyiwkJCfE4XWL9+vXG39+f4eUAHMHwcgDwgmnTpik2Nlbt27eXdGJY5O23364ZM2YoNzfX4erOT2pqqkqWLHlB6zh5WG5GRoYOHjyoK6+8UpK0evVqSSeuIv3VV1+pc+fOBR59PfVq0f369ZO/v7/1+8KFC5WVlaVBgwbJz8/PY7mIiAj95z//kSRFRkZKkubNm1fgsG5J1pHk2bNn5xvqe6Eeeughj9/btGmjQ4cOKTU1VZL0xRdfyO12q2fPnjp48KD1U65cOcXHx2vx4sXntL2NGzfqkUceUcuWLXXvvfda048fPy5JCg4OzveYkJAQj2XOl9vt1owZM9SkSZN8R5NP5/jx416tyaltnWrmzJlq06aNSpUq5fH/uUOHDsrNzfUYEn7y6+fIkSNKSUlRmzZtrNfOyVq2bGld6FCSKleurK5du2revHlnfA+KiorS7t27tXLlygLnG2M0a9Ysde7cWcYYj5o7duyolJQUq55Zs2apbNmy+uc//5lvPXmv42+++Ub+/v4aOHCgx/zBgwfLGKNvv/3WY3qHDh08Ro00bNhQERER2rZtm6QTR9fnzZunW265xeN0ibp166pjx46nfd4A4E003QBgs9zcXM2YMUPt27fX9u3btXXrVm3dulUtWrTQgQMHtGjRonNe5+HDh7V//37r5+Rzjs/Xud7qKCIiQmlpaRe0zcOHD+vRRx+1zouNjo5WtWrVJMl6TklJSUpNTT3jENiT5T0+z44dOyRJtWvX9pgeFBSk6tWrW/OrVaumxx9/XO+//77Kli2rjh076u233/bI9vbbb9dVV12lBx54QLGxserVq5c+++wzWxrwkxsCSSpVqpSkE82UdOJ8c2OM4uPjFR0d7fGzYcMGJSYmFnpb+/fvV6dOnRQZGanPP//c40uKvEYuMzMz3+MyMjI8ljlfS5cu1Z49e9S7d+8Cazv5J6/BDQ0Ntb2mi7mtwtqyZYu+++67fP+PO3ToIEke/5/nzp2rK6+8UiEhISpdurSio6M1ceLEAt8PCrotW61atZSenl7greDy/Otf/1J4eLiuuOIKxcfH65FHHvE4nSIpKUnJycl677338tV83333edT8999/q3bt2goIOP3ZjDt27FBcXFy+L/TyvpzJe73mOfV1I5147eS9bpKSknT8+PECn/+p7wkAcLFwTjcA2Oz777/Xvn37NGPGDM2YMSPf/GnTphX6lkl5unXrpqVLl1q/33vvvfrggw9Ou3xISMhpj87lHdXNO4pXWHXq1NEff/yhrKysfBfoKqyePXvqp59+0pAhQ9S4cWOFh4fL7XbrhhtuOO9G9kIaoldffVV9+vTR7NmzNX/+fA0cOFBjx47VL7/8oooVKyo0NFTLli3T4sWL9Z///EffffedPv30U11zzTWaP3++R/N6rk73WPPfi0e53W65XC59++23BS4bHh5eqO2kpKToxhtvVHJyspYvX664uDiP+eXLl5ck7du3L99j9+3bp9KlSxd4FPhcTJs2TX5+frrjjjvyzcvbfp4pU6aoT58+Kl++vBYvXixjjMcXRHl1nvo8CuNibquw3G63rrvuOv3f//1fgfNr1aolSVq+fLm6dOmitm3basKECSpfvrwCAwM1ZcqUfBc5uxB169bVpk2bNHfuXH333XeaNWuWJkyYoKFDh2r48OHW6/Suu+7yGDFxsoYNG9pWz6nO9roBgKKIphsAbDZt2jTFxMTo7bffzjfviy++0Jdffql33nnnnJrFV1991TqSI529CahSpYrWr19f4LxNmzZZy5yLzp076+eff9asWbMKbJ7O5siRI1q0aJGGDx+uoUOHWtO3bNnisVx0dLQiIiL0119/nfM2pP89r02bNql69erW9KysLG3fvt06gpjnsssu02WXXaZnn31WP/30k6666iq98847GjVqlCTJz89P1157ra699lqNGzdOY8aM0TPPPKPFixfnW9fJznUkwanyLjJVrVo1q/E6VxkZGercubM2b96shQsXql69evmWqVChgqKjo7Vq1ap881asWKHGjRuf17bzZGZmatasWbr66qsL3G8XLFjg8XveRd4aN26s999/Xxs2bPCo+9dff7Xmn6uLua3CqlGjho4ePXrGfUk6MVQ7JCRE8+bN8/gSZMqUKQUuf+rrSpI2b96sEiVKKDo6+ozbCgsL0+23367bb79dWVlZ6tatm0aPHq2nnnpK0dHRKlmypHJzc89ac40aNfTrr78qOztbgYGBBS5TpUoVLVy4UGlpaR5Huzdu3GjNPxfR0dEKDQ0t8PnnvfcBwMXG8HIAsNHx48f1xRdf6Oabb1aPHj3y/QwYMEBpaWmaM2fOOa23WbNm6tChg/VTUPN0sptuukm7d+/WV1995TE9MzPTukp206ZNz6mGhx56SOXLl9fgwYO1efPmfPMTExOtRrUgeUeoTj0idfLVmaUTTe4tt9yir7/+usBG8GxHtDp06KCgoCC9+eabHstOmjRJKSkp1lWeU1NTlZOT4/HYyy67TH5+ftZQ48OHD+dbf14DVtBw5JOFhYXlu0XZuejWrZv8/f01fPjwfM/ZGFPgbdZOlpubq9tvv10///yzZs6cqZYtW5522e7du2vu3LketyJbtGiRNm/erNtuu+28n4N04pzd5OTkAoeWS/LYrzt06GAdje7atasCAwM1YcIEa1ljjN555x1VqFChULcdc3JbhdWzZ0/9/PPPmjdvXr55ycnJ1j7q7+8vl8vlcT52QkJCvtd4np9//tnjXO9du3Zp9uzZuv766884QuPU/SooKEj16tWTMUbZ2dny9/dX9+7dNWvWrAK/GDt56Hr37t118OBBvfXWW/mWy9unb7rpJuXm5uZb5rXXXpPL5dKNN9542loL4u/vr44dO+qrr77Szp07rekbNmwoMGMAuBg40g0ANpozZ47S0tLUpUuXAudfeeWVio6O1rRp03T77bd7rY4HH3xQkydP1m233aa+ffuqSZMmOnTokD799FP99ddfmjp16jkPES9VqpS+/PJL3XTTTWrcuLHuuusu60JNq1ev1ieffHLGxi4iIkJt27bVSy+9pOzsbFWoUEHz58/X9u3b8y07ZswYzZ8/X+3atdODDz6ounXrat++fZo5c6Z++OGHM94qKzo6Wk899ZSGDx+uG264QV26dNGmTZs0YcIENW/eXHfddZekE6cBDBgwQLfddptq1aqlnJwcffTRR1ZTIUkjRozQsmXL1KlTJ1WpUkWJiYmaMGGCKlaseNZbSDVr1kwLFy7UuHHjFBcXp2rVqqlFixZni9lSo0YNjRo1Sk899ZQSEhJ0yy23qGTJktq+fbu+/PJLPfjgg3riiSdO+/jBgwdrzpw56ty5sw4fPqyPP/7YY35eDpL09NNPa+bMmWrfvr0effRRHT16VC+//LIuu+wy6zzdPB999JF27NhhnaawbNky68uWu+++O9+RyWnTpik4ONjKtLAqVqyoQYMG6eWXX1Z2draaN2+ur776SsuXL9e0adM8GscdO3boo48+kiTri5q8mqpUqaK77767yGzrVEOGDNGcOXN08803q0+fPmrWrJmOHTumtWvX6vPPP1dCQoLKli2rTp06ady4cbrhhht05513KjExUW+//bZq1qypNWvW5FtvgwYN1LFjR49bhknS8OHDz1jP9ddfr3Llyumqq65SbGysNmzYoLfeekudOnWyjkS/8MILWrx4sVq0aKF+/fqpXr16Onz4sFavXq2FCxdaX1bdc889mjp1qh5//HGtWLFCbdq00bFjx7Rw4UL1799fXbt2VefOndW+fXs988wzSkhIUKNGjTR//nzNnj1bgwYNynervcIYPny4vvvuO7Vp00b9+/dXTk6Ode/xgrICAK+72JdLBwBfUdDtgjp37mxCQkLMsWPHTvu4Pn36mMDAQOt2O/LCLcOMMebIkSPmscceM9WqVTOBgYEmIiLCtG/f3nz77bdnfNzpbhmWZ+/eveaxxx4ztWrVMiEhIaZEiRKmWbNmZvTo0SYlJeWM6969e7e59dZbTVRUlImMjDS33Xab2bt3b4G3ntqxY4e55557THR0tAkODjbVq1c3jzzyiMnMzDTG/O+WYQXdVsyYE7cIq1OnjgkMDDSxsbHm4YcfNkeOHLHmb9u2zfTt29fUqFHDhISEmNKlS5v27dubhQsXWsssWrTIdO3a1cTFxZmgoCATFxdn7rjjjny3dyrIxo0bTdu2bU1oaKiRZN0mKu+WYafehizv+Wzfvt1j+qxZs0zr1q1NWFiYCQsLM3Xq1DGPPPKI2bRp0xm3365dO+vWUQX9nOqvv/4y119/vSlRooSJiooyvXv3Nvv37z+n9S5evNhj2ZSUFBMSEmK6det21rwKkpuba8aMGWOqVKligoKCTP369c3HH3+cb7nFixeftqZ27doVqW2desswY4xJS0szTz31lKlZs6YJCgoyZcuWNa1atTKvvPKKycrKspabNGmSiY+PN8HBwaZOnTpmypQp1v50srz3lI8//thavkmTJvn+/xTk3XffNW3btjVlypQxwcHBpkaNGmbIkCH5XtsHDhwwjzzyiKlUqZIJDAw05cqVM9dee6157733PJZLT083zzzzjPU+VK5cOdOjRw/z999/ezz/xx57zMTFxZnAwEATHx9vXn75Zeu2Yqc+r8JkunTpUtOsWTMTFBRkqlevbt55550CswKAi8FlDFeeAAAA8BUul0uPPPJIgcO6AQAXH+d0AwAAAADgJTTdAAAAAAB4CU03AAAAAABewtXLAQAAfAiX6wGAooUj3QAAAAAAeAlNNwAAAAAAXuLzw8vdbrf27t2rkiVLyuVyOV0OAAAAAMAHGGOUlpamuLg4+fmd/ni2zzfde/fuVaVKlZwuAwAAAADgg3bt2qWKFSuedr7PN90lS5aUdCKIiIgIh6s5PbfbraSkJEVHR5/xWxIUDnnaizztRZ72Ik97ZW7frf1Dx6vciH8quNrp/4BA4bB/2os87UWe9iJPexWHPFNTU1WpUiWr5zwdn2+684aUR0REFPmmOyMjQxEREUV2pypOyNNe5Gkv8rQXedors2RJHQsMVkTJkgouwp+bxQX7p73I017kaS/ytFdxyvNspzEX7eoBAAAAACjGaLoBAIAlIC5GQc//QwFxMU6XAgCAT6DpBgAAFldQoPyiS8kVFOh0KQAA+ASabgAAYMlNPKzsD79WbuJhp0sBAMAn0HQDAACLO/24cleukzv9uNOlAADgExxtuidOnKiGDRtaVxZv2bKlvv32W0lSQkKCXC5XgT8zZ850smwAAAAAAArF0VuGVaxYUS+88ILi4+NljNGHH36orl276vfff1edOnW0b98+j+Xfe+89vfzyy7rxxhsdqhgAAAAAgMJztOnu3Lmzx++jR4/WxIkT9csvv6h+/foqV66cx/wvv/xSPXv2VHh4+MUsEwAAAACA8+Jo032y3NxczZw5U8eOHVPLli3zzf/tt9/0xx9/6O2333agOgAALg1+kSUVcONV8oss6XQpp2WM0fHsXKfLKBS3263j2blKz8qRnx+X0rlQ5Gkv8rQXedrL7XbLGON0GbZwvOleu3atWrZsqYyMDIWHh+vLL79UvXr18i03adIk1a1bV61atTrj+jIzM5WZmWn9npqaKunE/zS3221v8TbK26mKco3FCXnaizztRZ72Ik97uSLD5X9Ta7kiw4tkpsYY9Xz3F/22M9npUgAAXvZ9/0ZF8rMoT2Frc7zprl27tv744w+lpKTo888/17333qulS5d6NN7Hjx/X9OnT9dxzz511fWPHjtXw4cPzTU9KSlJGRoattdvJ7XYrJSVFxhi+GbMBedqLPO1FnvYiT3vlHjuutLWb5L6stvzDQp0uJ5/j2bk03ABwiUhJTlFigF+R/XxPS0sr1HIuU8SO2Xfo0EE1atTQu+++a0376KOPdP/992vPnj2Kjo4+4+MLOtJdqVIlHTlyRBEREV6r+0K53W4lJSUpOjq6yO5UxQl52os87UWe9iJPe2Vu26X9/xqnci8+ruDqlZwuJ5/0rBw1GLZAkrTi6WtUIsjf4YrOzO126+DBgypbtiz7pw3I017kaS/ytJfb7dbR5MOKiYkpsnmmpqaqVKlSSklJOWOv6fiR7lO53W6Pplk6MbS8S5cuZ224JSk4OFjBwcH5pvv5Fd1vSPK4XK5iUWdxQZ72Ik97kae9yNM+fn5+RTrPk2sKDwlUiaAi96eMB7fbrfSgAIWHBBXJPIsb8rQXedqLPO3ldruV/t/PoqKaZ2HrcvST6qmnntKNN96oypUrKy0tTdOnT9eSJUs0b948a5mtW7dq2bJl+uabbxysFAAAAACAc+do052YmKh77rlH+/btU2RkpBo2bKh58+bpuuuus5aZPHmyKlasqOuvv97BSgEAAAAAOHeONt2TJk066zJjxozRmDFjLkI1AADAFRAgV9kouQKK9rBtAACKCz5RAQCAJaBirIKHPaSAmBinSwEAwCcUzTPSAQAAAADwATTdAADAkr1znzL+9Yayd+5zuhQAAHwCTTcAAPgft1s6dvzEvwAA4ILRdAMAAAAA4CU03QAAAAAAeAlNNwAAAAAAXkLTDQAALP7lyiro8bvlX66s06UAAOATaLoBAIDFLyRYftUryC8k2OlSAADwCTTdAADAknsoWdmzFin3ULLTpQAA4BNougEAgMWddky5i1fKnXbM6VIAAPAJNN0AAAAAAHgJTTcAAAAAAF5C0w0AAAAAgJfQdAMAAItfeJj82zSRX3iY06UAAOATaLoBAIDFv2yUAm/vKP+yUU6XAgCAT6DpBgAAFpOZJfeu/TKZWU6XAgCAT6DpBgAAlpx9Scp68QPl7EtyuhQAAHwCTTcAAAAAAF5C0w0AAAAAgJfQdAMAAAAA4CU03QAA4CQuKTjoxL8AAOCCBThdAAAAKDoCq8Yp5NXHFRgT43QpAAD4BI50AwAAAADgJTTdAADAkrMnUZmj/q2cPYlOlwIAgE+g6QYAABaTnS2z/5BMdrbTpQAA4BNougEAAAAA8BKabgAAAAAAvISmGwAAAAAAL6HpBgAAFv/o0gp8sLv8o0s7XQoAAD6BphsAAFj8wkLl3zBefmGhTpcCAIBPoOkGAACW3OQ05cz7WbnJaU6XAgCAT6DpBgAAFndyqnK+Xip3cqrTpQAA4BNougEAAAAA8BKabgAAAAAAvISmGwAAAAAAL6HpBgAAFleJEPk1ri1XiRCnSwEAwCfQdAMAAEtATBkFPXCrAmLKOF0KAAA+gaYbAABYTE6OzJFUmZwcp0sBAMAn0HQDAABLzu4DynxugnJ2H3C6FAAAfAJNNwAAAAAAXkLTDQAAAACAl9B0AwAAAADgJTTdAAAAAAB4SYDTBQAAgKIjoEqcgl97QgFx5Z0uBQAAn8CRbgAAYHG5XHIFBsjlcjldCgAAPoGmGwAAWHL2JSnr9WnK2ZfkdCkAAPgEmm4AAGAxmVlyb90lk5nldCkAAPgEmm4AAAAAALyEphsAAAAAAC+h6QYAAAAAwEtougEAgMW/TJQC7rxR/mWinC4FAACfQNMNAAAsfiXDFNCqkfxKhjldCgAAPoGmGwAAWNxpx5Tz059ypx1zuhQAAHwCTTcAALDkHkpWzvRvlXso2elSAADwCTTdAAAAAAB4CU03AAAAAABeQtMNAAAAAICX0HQDAACLKzhIfjUryRUc5HQpAAD4hACnCwAAAEVHQPloBQ3qrYCYaKdLAQDAJ3CkGwAAWIwxMtk5MsY4XQoAAD6BphsAAFhyduxV5mOvKGfHXqdLAQDAJ9B0AwAAAADgJTTdAAAAAAB4CU03AAAAAABeQtMNAAAAAICX0HQDAABLQMVYBY/sr4CKsU6XAgCAT6DpBgAAFldAgFylIuQKCHC6FAAAfAJNNwAAsOQkHlLW+18qJ/GQ06UAAOATaLoBAIDFpGfI/ccmmfQMp0sBAMAn0HQDAAAAAOAlNN0AAAAAAHgJTTcAAAAAAF5C0w0AACx+UREK6NxOflERTpcCAIBPoOkGAAAW/6iSCujYUv5RJZ0uBQAAn0DTDQAALO5jx5W7Zovcx447XQoAAD6BphsAAFhykw4r+71Zyk067HQpAAD4BJpuAAAAAAC8JOB8HrRz507t2LFD6enpio6OVv369RUcHGx3bQAAAAAAFGuFbroTEhI0ceJEzZgxQ7t375YxxpoXFBSkNm3a6MEHH1T37t3l58cBdAAAAAAACtUdDxw4UI0aNdL27ds1atQorV+/XikpKcrKytL+/fv1zTffqHXr1ho6dKgaNmyolStXertuAADgBa7AQLnKlZErMNDpUgAA8AmFOtIdFhambdu2qUyZMvnmxcTE6JprrtE111yj559/Xt9995127dql5s2b214sAADwroAKMQp+tp8CYmKcLgUAAJ9QqKZ77NixhV7hDTfccN7FAAAAAADgS8755Ovjx48rPT3d+n3Hjh16/fXXNW/ePFsLAwAAF192wl5lDB6n7IS9TpcCAIBPOOemu2vXrpo6daokKTk5WS1atNCrr76qW265RRMnTrS9QAAAcDEZKTPrxL8AAOCCnXPTvXr1arVp00aS9Pnnnys2NlY7duzQ1KlT9eabb9peIAAAAAAAxdU5N93p6ekqWbKkJGn+/Pnq1q2b/Pz8dOWVV2rHjh22FwgAAAAAQHF1zk13zZo19dVXX2nXrl2aN2+err/+eklSYmKiIiIibC8QAAAAAIDi6pyb7qFDh+qJJ55Q1apV1aJFC7Vs2VLSiaPeTZo0sb1AAABw8QSUj1bQv/oooHy006UAAOATCnXLsJP16NFDrVu31r59+9SoUSNr+rXXXqtbb73V1uIAAMDF5QoOkl+lcnIFBzldCgAAPuGcm25JKleunMqVK+cx7YorrrClIAAA4Jzcg8nK/nSecu/oLL+Y0k6XAwBAsVeo4eUPPfSQdu/eXagVfvrpp5o2bdoFFQUAAJzhPnpMuct/l/voMadLAQDAJxTqSHd0dLTq16+vq666Sp07d9bll1+uuLg4hYSE6MiRI1q/fr1++OEHzZgxQ3FxcXrvvfe8XTcAAAAAAEVeoZrukSNHasCAAXr//fc1YcIErV+/3mN+yZIl1aFDB7333nu64YYbvFIoAAAAAADFTaHP6Y6NjdUzzzyjZ555RkeOHNHOnTt1/PhxlS1bVjVq1JDL5fJmnQAAAAAAFDvndSG1UqVKqVSpUnbXAgAAHOZXMkz+7ZvLr2SY06UAAOATzvk+3QAAwHf5l4lSYPdr5V8myulSAADwCTTdAADA4s7IlHvbHrkzMp0uBQAAn0DTDQAALLn7Dypr3EfK3X/Q6VIAAPAJNN0AAAAAAHhJoZvu48ePa86cOUpLS8s3LzU1VXPmzFFmJkPRAAAAAADIU+im+7333tMbb7yhkiVL5psXERGhN998U++//76txQEAAAAAUJwVuumeNm2aBg0adNr5gwYN0ocffmhHTQAAwCl+flJY6Il/AQDABSv0fbq3bNmiRo0anXZ+w4YNtWXLFluKAgAAzgisXF4hLz6qwJgYp0sBAMAnFPpr7JycHCUlJZ12flJSknJycmwpCgAAAAAAX1Doprt+/fpauHDhaefPnz9f9evXt6UoAADgjJzdB5Q57B3l7D7gdCkAAPiEQjfdffv21ciRIzV37tx8877++muNHj1affv2tbU4AABwcZmcHJmDyTKMXgMAwBaFPqf7wQcf1LJly9SlSxfVqVNHtWvXliRt3LhRmzdvVs+ePfXggw96rVAAAAAAAIqbQh/p3rlzp6ZOnaoZM2aoVq1a2rx5szZt2qTatWvrk08+0SeffOLNOgEAAAAAKHYKfaS7WrVq2rdvn3r27KmePXt6syYAAAAAAHxCoY90G2O8WQcAACgC/GPKKLB/T/nHlHG6FAAAfEKhm25Jcrlc3qoDAAAUAX4lQuRfr7r8SoQ4XQoAAD6h0MPLJem5555TiRIlzrjMuHHjLqggAADgnNwjqcr5z3Ll3nKd/MpEOV0OAADF3jk13WvXrlVQUNBp53MkHACA4s2dkqacb3+Uu/2VEk03AAAX7Jya7i+//FIxMTHeqgUAAAAAAJ9S6HO6OYoNAAAAAMC54erlAAAAAAB4SaGb7ilTpigyMtKbtQAAAIf5lQiVf/P68isR6nQpAAD4hEKf052SkqJ333033/TIyEjVqlVLLVu2tLUwAABw8fnHlFbgvZ3lH1Pa6VIAAPAJhW66X3vttQKnJycnKyUlRa1atdKcOXNUujQf0gAAFFcmK1vupCMyUaWkkGCnywEAoNgr9PDy7du3F/hz5MgRbd26VW63W88++6w3awUAAF6WszdRWcPfVc7eRKdLAQDAJxS66T6T6tWr64UXXtD8+fPtWB0AAAAAAD7BlqZbkipXrqz9+/fbtToAAAAAAIo925rutWvXqkqVKnatDgAAAACAYq/QF1JLTU0tcHpKSop+++03DR48WPfee69thQEAAAAAUNwVuumOioqSy+UqcJ7L5dIDDzygJ5980rbCAADAxRdYtYJC3npSgTExTpcCAIBPKHTTvXjx4gKnR0REKD4+XuHh4bYVBQAAAACALyh0092uXTtv1gEAAIqAnH1JynxtqnIeu1dBFWKdLgcAgGLPtgupAQCA4s9kZskk7JXJzHK6FAAAfAJNNwAAAAAAXkLTDQAAAACAl9B0AwAAAADgJRfUdL/wwgtKTk62qRQAAOA0/7KlFHjPzfIvW8rpUgAA8AkX1HSPGTNGhw8ftqsWAADgML/wEvK/ooH8wks4XQoAAD7hgppuY4xddQAAgCLAnXpUOct+kzv1qNOlAADgEzinGwAAWHIPpyjnswXKPZzidCkAAPiEgAt58Pr16xUXF2dXLQAAAAAA+JQLarorVapkVx0AAAAAAPgchpcDAAAAAOAlNN0AAMDiCgmWX52qcoUEO10KAAA+4YKGlwMAAN8SUK6sggb0UkBMWadLAQDAJ3CkGwAAWIzbLXM8U8btdroUAAB8QqGPdD/++OOFWm7cuHHnXQwAAHBWzs59yvy/15Tz0mD5V+eCqQAAXKhCN92///67N+sAAAAAAMDnFLrpXrx4sTfrAAAAAADA59h2TveGDRv0xBNP2LU6AAAAAACKvQtquo8dO6ZJkyapVatWql+/vr777ju76gIAAAAAoNg7r6b7xx9/VN++fRUbG6sHH3xQrVq10vr16/XXX3/ZXR8AALiIAirGKnjsPxVQMdbpUgAA8AmFbroTExP10ksvqU6dOurRo4eioqK0ZMkS+fn5qW/fvqpTp4436wQAABeBKyBArpJhcgUU+rIvAADgDAr9iVqlShX16NFDb7zxhq677jr5+XGLbwAAfE3OgUPKevdz5fzjdgWVj3a6HAAAir1Cd85VqlTRDz/8oGXLlmnz5s3erAkAADjEHM+Q+6+tMscznC4FAACfUOime+PGjfr444+1b98+NW/eXM2aNdNrr70mSXK5XF4rEAAAAACA4uqcxohfddVVmjx5svbt26eHHnpIM2fOVG5urvr3769///vfSkpK8ladAAAAAAAUO4VuukeMGKH09HRJUnh4uPr166effvpJ69atU7NmzfTss88qLi7Oa4UCAAAAAFDcFLrpHj58uI4ePZpvet26dfXKK69oz549+vTTT20tDgAAXFx+pSIUcOs18isV4XQpAAD4hEI33caYM84PCAhQt27dLrggAADgHP/Ikgq49gr5R5Z0uhQAAHzCOZ3TzQXTAADwbe5j6cpdvUHuY+lOlwIAgE8o9H26JalWrVpnbbwPHz58QQUBAADn5CYdUfbk2cqtU1MBJcOdLgcAgGLvnJru4cOHKzIy0lu1AAAAAADgU86p6e7Vq5diYmK8VQsAAAAAAD6l0Od0cz43AAAAAADnxrarlwMAgOLPFRgoV8UYuQIDnS4FAACfUOjh5W6325t1AACAIiCgQoyCn+yrAE4nAwDAFud0yzAAAAAAAFB4NN0AAMCSnbBXGY++pOyEvU6XAgCAT6DpBgAAJzFSrvvEvwAA4ILRdAMAAAAA4CU03QAAAAAAeAlNNwAAAAAAXkLTDQAALAFxMQp65n4FxHHLMAAA7EDTDQAALK6gQPmVj5YrKNDpUgAA8Ak03QAAwJKbdETZ075RbtIRp0sBAMAn0HQDAACL+1i6cn9eI/exdKdLAQDAJ9B0AwAAAADgJTTdAAAAAAB4CU03AAAAAABeQtMNAAAsfhHh8r/uSvlFhDtdCgAAPoGmGwAAWPxLRyqw69XyLx3pdCkAAPgEmm4AAGBxH8+Ue/MOuY9nOl0KAAA+gaYbAABYcg8cVNabnyj3wEGnSwEAwCfQdAMAAAAA4CU03QAAAAAAeAlNNwAAAAAAXkLTDQAA/sfPT67IcMmPPxEAALBDgNMFAACAoiOwcnkFjx6gwJgYp0sBAMAn8DU2AAAAAABeQtMNAAAs2Tv3KfOZt5S9c5/TpQAA4BNougEAwP+43TIpRyW32+lKAADwCTTdAAAAAAB4CU03AAAAAABeQtMNAAAAAICX0HQDAACLf2xZBQ28Q/6xZZ0uBQAAn0DTDQAALH6hwfKrVUV+ocFOlwIAgE+g6QYAAJbcwynKnr1EuYdTnC4FAACfQNMNAAAs7tSjyl3wi9ypR50uBQAAn0DTDQAAAACAl9B0AwAAAADgJTTdAAAAAAB4CU03AACw+IWVkH/LhvILK+F0KQAA+ASabgAAYPGPLqXA3jfJP7qU06UAAOATaLoBAIDFZGXLvS9JJivb6VIAAPAJNN0AAMCSszdRWaMnKWdvotOlAADgE2i6AQAAAADwEppuAAAAAAC8hKYbAAAAAAAvoekGAAAncUn+fif+BQAAFyzA6QIAAEDREVg1TiFv/J8CY2KcLgUAAJ/AkW4AAAAAALyEphsAAFhy9iQq84XJytnDLcMAALADTTcAALCY7GyZ3Yky2dlOlwIAgE+g6QYAAAAAwEtougEAAAAA8BKabgAAAAAAvISmGwAAWPyjSymwb1f5R5dyuhQAAHwCTTcAALD4hZWQf9O68gsr4XQpAAD4BJpuAABgyU1JU86iFcpNSXO6FAAAfAJNNwAAsLiPpCrny+/lPpLqdCkAAPgEmm4AAAAAALyEphsAAAAAAC+h6QYAAAAAwEtougEAgMUVGiK/BjXlCg1xuhQAAHxCgNMFAACAoiMgtoyCHuqhgJgyTpcCAIBP4Eg3AACwmJwcmbRjMjk5TpcCAIBPoOkGAACWnN0HlPnUeOXsPuB0KQAA+ASabgAAAAAAvISmGwAAAAAAL+FCagAAAADycbvdysrKcrqMYsPtdis7O1sZGRny8+PY5oUqKnkGBgbK39//gtZB0w0AAADAQ1ZWlrZv3y632+10KcWGMUZut1tpaWlyuVxOl1PsFaU8o6KiVK5cufOug6YbAABYAiqXV/DLjymgUnmnSwHgEGOM9u3bJ39/f1WqVImjtoVkjFFOTo4CAgIcbxJ9QVHI0xij9PR0JSYmSpLKlz+/z0aabgAAYHH5+ckVGiwXf2QDl6ycnBylp6crLi5OJUqUcLqcYqMoNIm+pKjkGRoaKklKTExUTEzMeQ015xMVAABYcvYfVNZbM5Sz/6DTpQBwSG5uriQpKCjI4UqAoiHvy6fs7OzzejxNNwAAsJiMTLk3JshkZDpdCgCHcbQWOOFCXws03QAAAADg4z744AM1btzY6TKKrD/++MNrXzTRdAMAAAAoVjIzM9WvXz9Vq1ZNJUuWVJ06dTR58mSPZVJTU3XnnXcqIiJCsbGxGjlypMf85557TpdddpkCAgI0aNAgj3nLly9XeHi4x4+fn58GDhx4xrr+/e9/q0qVKgoLC1OnTp20b98+a97ixYvVvn17RUZGKioqqlDPc8OGDbrqqqtUokQJ1apVS3PmzLHmZWVlqUePHqpatapcLpe++uqrQq0TFx9NNwAAAIBiJScnR+XLl9fChQuVmpqqDz74QIMHD9b8+fOtZf75z3/q8OHD2rlzp5YvX65///vfmjp1qjW/Zs2aeumll9SlS5d862/Tpo2OHj1q/fz999/y9/dXr169TlvT999/r6efflqfffaZEhMTFRsbq969e1vzw8LC1LdvX40bN65QzzE7O1udO3fWtddeq8OHD2vcuHG68847tXXrVmuZ1q1b66OPPlLFihULtU44g6YbAABY/EtHKqDndfIvHel0KQBwWmFhYRoxYoRq1Kghl8ulK6+8Uu3bt9cPP/wgSUpPT9eMGTM0atQoRUVFqVatWvrnP/+pSZMmWeu49957deONNyoiIuKs2/vwww8VHx+vVq1anXaZDz74QHfeeadatGihsLAwjR07VkuXLtW2bdskSVdccYXuvvtu1ahRo1DPcdmyZTp06JCee+45hYSE6Oabb1a7du300UcfSTpxobtBgwapTZs253VF7aNHj2rAgAGqXLmyYmJidM899yglJcWaf9dddykuLk4RERFq1qyZFi9e7PFcGzdurKefflplypRR5cqVNWHChNNua/Xq1bryyisVERGhsmXLqnPnzta8xMRE9e7dW+XLl1dcXJwGDRqkzMz/XVfkt99+0zXXXKPSpUsrOjpa//znP6158+fPV5MmTRQZGammTZtq4cKF1rw+ffqoX79+6tWrl0qWLKnatWtryZIl1vzk5GT17NlTUVFRqlOnjpYtW3bOGRYWTTcAALD4RYQroG0z+UWEO10KABRaRkaGVqxYoYYNG0qSNm3apKysLI9zmBs3bqw1a9ac1/onT56s+++//4zLrFmzRo0aNbJ+j42NVbly5bR27drz2uaaNWtUv359BQYGWtMu5Dmcqm/fvjp8+LDWrFmj7du3Kzs7WwMGDLDmX3vttdqwYYMOHTqkXr16qUePHkpLS7Pm//XXX3K5XNq3b58+/fRTPfnkk6dtXAcMGKDOnTsrOTlZe/bs0ZAhQySduC1Yly5dVK5cOf39999au3at/vzzT40aNUqStGfPHl177bXq0aOH9u7dqx07dqhnz56SpK1bt6pr16567rnndOjQIT399NPq0qWLtm/fbm33008/1UMPPaTk5GTdfffd6tOnjzVv4MCBSk5OVkJCgr7//nuPURB2o+kGAAAW99F05a74S+6j6U6XAqCIyT2Squztezx+chIPS5JMVna+ednb91iPzdmXlG9e3vtMbupRa1rukdRzrssYowceeEDx8fHq1q2bpBNHccPCwhQQEGAtFxUV5dE0Ftby5cu1bds23XPPPWdc7ujRo4qM9BwldL7bzFvfqed+X8j6TpaUlKRZs2bp7bffVlRUlDVy4NNPP7VuGXffffcpMjJSgYGBGjJkiNxut0fDHxYWpmHDhikoKEgtW7ZU7969T9u4BgYGaseOHdq7d6+Cg4PVtm1bSdKqVau0ZcsWvfzyyypRooTKlCmjp59+WtOnT5ckTZ8+Xc2aNVP//v0VEhKiEiVKqE2bNpJONNRXX321unXrpoCAAPXo0UOtW7fWJ598Ym33pptu0tVXXy1/f3/dd9992rFjhw4dOqTc3Fx9+umn1kiIuLg464sAbwg4+yIAAOBSkXvwiLKnzlVug9oK4Gg3gJOkf/+rjn6x0GNa6FVNFNW/l3IPp+jgs2/me0z5aS9KkpLf+UzZW3d6zIt6+HaFtm6qjF/WKPXD2ZKk8G4dVLL7dYWuyRij/v37a9OmTVq4cKH8/E4cUwwPD1d6erpycnKsxjslJUUlS5Ys/BP+r0mTJqlLly6Kjo62pj300EP6+OOPJZ0Yhv3OO+8oPDxcqameXxoUdpvLly/XjTfeaP1+9OhRhYeHewz3vpDncKqEhAS53W5Vq1bNY7qfn5/279+v8uXL67nnntNnn32mAwcOyM/PT6mpqTp48KC1bFxcnMdR+CpVqmjp0qUFbm/y5MkaPny4mjVrplKlSmnAgAEaMGCAEhISlJycrNKlS1vLGmOsxn/nzp2qWbNmgevcvXu3qlat6jGtevXq2r17t/V7uXLlrP8OCwuTJKWlpSknJ0dZWVmqUqWKR/3eQtMNAAAA4KxKXNNCIU3reUxzhYVKOnE9iLKjTn9l76iHespkZHlM848uJUkKubKhguJPNDx+UYVvKI0xeuSRR/Trr79q0aJFHkeZa9eurcDAQP35559q1qyZpBO3hLrssssKvX7pxBXQZ86cqVmzZnlMf+edd/TOO+94TGvYsKH+/PNP6/fExETt27evUNvMu3DbqesbOXKksrOzreb2jz/+UNOmTc/pORSkUqVK8vPz0969e1WiRIl88z/++GNNnz5d8+bNU3x8vFwul0qVKiVjjLXM3r17PWrbuXOnKlSoUOD2atSooalTp8oYox9//FEdOnRQy5YtValSJcXExHhc5T2PMUaVK1fWokWLClxnxYoVrXP48yQkJFhH0c+kbNmy1tH32NhYq35vcXR4+cSJE9WwYUNFREQoIiJCLVu21LfffuuxzM8//6xrrrlGYWFhioiIUNu2bXX8+HGHKgYAAAAuTf6lIhRYrYLHT0DMiSOUrqDAfPMCq/2vAQsoH51vnl/4iWbPPyLcmuZf6uwXNcszYMAA/fjjj1qwYIFKlSrlMa9EiRK6/fbb9dxzzyklJUVbtmzR+PHj9cADD1jLZGdnKyMjQ7m5ucrNzVVGRoays7M91vPJJ5+oTJkyuv76689aT58+fTR9+nStWLFC6enpevrpp9WuXTtVr15dkuR2u5WRkaGsrBNfPmRkZCgjI+O062vbtq1Kly6t0aNHKzMzU998842WLFniMcw9MzNTGRkZMsZ4PJ+zKVeunG655RYNGDDAOnq9f/9+ffnll5JOfNkQFBSksmXLKisrSyNGjMg3rP3YsWMaOXKksrKy9Ouvv2ratGkeV2s/2dSpU3XgwAG5XC5FRUXJz89P/v7+at68uSpVqqRnn31WaWlpMsZox44dVk94xx13aMWKFXrnnXeUmZmp9PR0LV++XJJ0++23a8mSJZo9e7ZycnL0xRdfaNmyZWe8wnwef39/9ezZU0OHDlVycrL27t2rl19++ayPO1+ONt0VK1bUCy+8oN9++02rVq3SNddco65du2rdunWSTjTcN9xwg66//nqtWLFCK1eu1IABA6xhIwAAAAAuPTt27NCECRO0adMmValSxbqX9kMPPWQt89ZbbykyMlIVK1bUVVddpfvvv9+jYe3Xr59CQ0P18ccf66233lJoaKj69evnsZ1JkybpvvvuK1T/cc0112jUqFHq3r27oqOjtXfvXk2bNs2av2zZMoWGhqpjx45KSUlRaGioQkNDT7u+wMBAzZkzRwsWLFBUVJQeffRRTZs2zWO4de3atRUaGqqdO3eqZ8+eCg0Nta5ufjYffPCBoqKi1Lx5c0VERKhNmzb67bffJJ24snv9+vVVpUoVVa9eXaGhofluS9agQQPr1m09evTQ6NGj1b59+wK3tXDhQjVq1Ejh4eHq2rWrXn75ZTVu3Fj+/v6aO3eu9uzZo7p16yoyMlKdOnWybotWsWJFLVy4UNOnT1dsbKyqVq2qzz//XNKJW7598cUXev7551W6dGmNGDFCX375pfUlx9mMHz9e4eHhqlKliq655hrdfffdhXrc+XCZk8cIFAGlS5fWyy+/rPvvv19XXnmlrrvuunw3sj8XqampioyMVEpKSqFuB+AEY4yOZWYrKSlJ0dHRfKlgA7fbTZ42Ik97kae9yNNe2XsO6OD4j1T2n3crsEKs0+Xkk56Vq8tHnTindP2IjioRVLTPlHO73UpMTFRMTAz7pw3I016nyzMjI0Pbt29XtWrVFBIS4mCFxYsxxjqH3OVyOV2OV33wwQd6/fXX9ccff3htG0Upz9O9JgrbaxaZT6rc3FzNnDlTx44dU8uWLZWYmKhff/1VvXv3VqtWrfT333+rTp06Gj16tFq3bn3a9WRmZnrc1y3vYgZut1tut9vrz+N8pGflqMGwBU6XAQDACUGXSe/+4XQVZ1WUP9vzuN1uGWOKfJ3FBXna63R55k3P+0Hh5eXl67ldrOdZVPLMey2c+rlT2Pcix5vutWvXqmXLlsrIyFB4eLi+/PJL1atXT7/88oskadiwYXrllVfUuHFjTZ06Vddee63++usvxcfHF7i+sWPHavjw4fmmJyUlnfGcCScdzz77eRcAAOB/GsaFKe3IIR0t4keT3G63UlJSZIzhyKwNyNNep8szOztbbrdbOTk5ysnJcbDC4uXkq247fWTW2/K+mPHm/lGU8szJyZHb7dahQ4c8rthe2Nu3OT68PCsrSzt37lRKSoo+//xzvf/++1q6dKmSk5N11VVX6amnntKYMWOs5Rs2bKhOnTpp7NixBa6voCPdlSpV0pEjR4r88PKDBw+qbNmyfIjYwO12k6eNyNNe5Gkv8rRX9vbdOvzMGyo9+lEFVqt49gc4JDTQ3/E/wgqD0x/sRZ72Ol2eGRkZSkhIYHj5eTj5at64cEUlz7zh5VWrVs03vLxUqVJFf3h5UFCQdTGAZs2aaeXKlXrjjTf05JNPSpLq1fO8LUHdunXPeDn34OBgBQcH55vu5+dXpN+cw0NcSg8KUHhIUJGus7hwu93kaSPytBd52os87ZUZHKgUP5dKBAcqOCTI6XJ8gsvlKvJ/hxQn5GmvgvL08/OTy+WyflA4xhgrL3K7cEUpz7zXQkGvlcIocu9WbrdbmZmZqlq1quLi4rRp0yaP+Zs3b/bqjcsBAAAAALCLo0e6n3rqKd14442qXLmy0tLSNH36dC1ZskTz5s2Ty+XSkCFD9Pzzz6tRo0Zq3LixPvzwQ23cuNG6TDwAAAAA73D64lVAUXGhF290tOlOTEzUPffco3379ikyMlINGzbUvHnzdN1110mSBg0apIyMDD322GM6fPiwGjVqpAULFqhGjRpOlg0AAAD4rMDAQLlcLut8b6eH9hYXRekWV76gKORpjFFWVpaSkpLk5+enoKDzO+3K0aZ70qRJZ13mySeftM7vBgAA3hUQF6Og5/+hgLgYp0sB4BB/f39VrFhRu3fvVkJCgtPlFBt5t5TKOyceF6Yo5VmiRAlVrlz5vK8l4fiF1AAAQNHhCgqUX3QpuYKcv1osAOeEh4crPj5e2dnZTpdSbOTdUqpMmTJc6M8GRSVPf3//Cz7aTtMNAAAsuYmHlf3h18q991b5lSvrdDkAHOTv7y9/f3+nyyg23G63AgMDFRISQtNtA1/Ks3hXDwAAbOVOP67clevkTj/udCkAAPgEmm4AAAAAALyEphsAAAAAAC/x+XO68+4vmJqa6nAlZ+Z2u5WWluYT5ywUBeRpL/K0F3naizztlZmWprTsTIWlpSm4iH92Fgfsn/YiT3uRp73I017FIc+8HvNs97R3GR+/6/3u3btVqVIlp8sAAAAAAPigXbt2qWLFiqed7/NNt9vt1t69e1WyZEnH7+92JqmpqapUqZJ27dqliIgIp8sp9sjTXuRpL/K0F3naizztRZ72Ik97kae9yNNexSFPY4zS0tIUFxd3xqPxPj+83M/P74zfOhQ1ERERRXanKo7I017kaS/ytBd52os87UWe9iJPe5GnvcjTXkU9z8jIyLMuUzQHxwMAAAAA4ANougEAAAAA8BKa7iIiODhYzz//vIKDg50uxSeQp73I017kaS/ytBd52os87UWe9iJPe5GnvXwpT5+/kBoAAAAAAE7hSDcAAAAAAF5C0w0AAAAAgJfQdAMAAAAA4CU03QAAAAAAeAlN90WQmZmp1atXS5K4bt2Fy8zM1OLFi50uw2dkZmZq/Pjx+vnnn50uxSe43W5lZWU5XYZPcrvdTpfgU8gTRRl/L9mLPO2Rk5OjQ4cOSSJTO1xKPRJNt5e9+OKLKl26tGbOnCljjFwul9MlFWuvvfaaKlSooHHjxmnHjh1Ol1PsvfTSS4qKitKjjz6qjIwMSb7/pudNr7/+uq6//nr16tVLn3zyiVJTU50uqVibMGGCBgwYoDfffFMHDhyQnx8fWRdiwoQJ6t+/vyZMmKCDBw+S5wWaM2eODhw44HQZPmPq1KkaOXKkpk+frqNHj/L30gV699131a9fPw0bNkx///03edrg22+/VeXKlTVp0iRlZ2eT6QW61HokPnG95Pvvv1flypX1zjvvaMqUKRo7dqzP70ze9tRTT+mtt97ShAkTNHXqVMXFxTldUrH1zTffqEqVKpowYYImTpyoFi1aaNGiRZLEfnoeEhIS1K5dO02YMEFdunRRbm6uRo0aZWWKc7N161ZdddVVev311+VyufTee++pY8eOmj17ttOlFUv79u1Tu3bt9Morryg5OVljx47V1Vdfre+//97p0oqlP/74Qy1bttQtt9yi8ePHO11OsffTTz+pXr16evHFF/XLL79o4MCB6t69u9NlFVs//PCD6tatq9dff12BgYGaNm2aunTposTERKdLK/b+85//aP/+/fr555/1+++/O11OsXWp9kg03V6wYMEC3Xrrrapdu7a2b9+unj175jvixdHEc7N3714tWrRIEydOVM+ePZWVlaXt27fr4MGDTpdW7AwZMkQ333yz+vfvr4SEBPXp00eBgYFKTU1Vbm6u0+UVS999952ysrK0atUqDRw4ULNnz9bhw4eVlpbmdGnF0qxZs1SyZEmtXbtW48eP119//aXAwECNHDlSK1ascLq8YueHH37QwYMHtXLlSk2fPl3btm1TVFSUxo0bR57naNeuXZowYYLi4+P19NNPa/z48Vq/fr3TZRVbq1at0uDBg3Xrrbfqt99+06xZs7R06VItWLDA+tKSv5cK79dff9XQoUPVrVs3/fnnn5owYYJWrlypDRs2aOvWrU6XV2zlnYpTsmRJvfbaa1q9erW+/vprpaSkSGIfPReXco9E0+0FDRs2VKdOnRQdHa2dO3dqxIgRuvnmm9WhQwc9+OCDSktLuyS+0bFDTk6OJOnQoUNKTEzUZZddphdeeEFNmjTRnXfeqaZNm2rKlCkOV1m8PP744zpw4ID+9a9/WR8kNWrU0G+//SZ/f3+ffbPzhuzsbGVlZenHH39UbGysNT0lJUWNGzdWfHy8MjMzHayweMnJydHx48c1Y8YMNWvWTMHBwdYXF9dee61Wr16t119/3dkiixG32y1jjNauXavIyEiFhIRIkgIDAzVq1CilpqZq8uTJDldZvJQqVUqtWrXSwIEDNWLECNWoUUPDhg3j/PjzVKJECZUsWVL/+Mc/FBISouDgYFWtWlWXX365dZ4nfy8VXnx8vB544AE98cQTCgoKkiRt375dnTp1Uo0aNRyurvjKOxVnzpw56tixowYMGKCZM2fq119/lcQ+ei4uu+yyS7ZHoum2wRtvvKH4+HjrKGFsbKy6deumdevWqUGDBlq0aJHuuOMONWnSRHPmzFHfvn21fft2h6suuk7OMyAgQJK0bds2xcbGatasWfr22281adIkTZ48WTfeeKPGjx+vd9991+Gqi65T98/y5csrOjra4/yZZs2a6cCBA9qzZ4/PvtnZ5eQ8AwMDFRQUpPj4eG3cuFHPPPOMXnvtNVWrVk3r1q1Tz549deutt2rmzJlOl11knfp6Dw0NVYUKFfTXX39JOnFkQZL279+vjh07KiEhQd99952TJRdpy5Yt07p163T8+HH5+fnJ5XIpJydHx44dkzHGag6vvvpqtW/fXn/99ZcWLlzocNVF18l5SlJ4eLjuvPNOXX755fLz89OLL76oWbNmacGCBQ5XWjycmme9evX0+eefq3LlypJONC9hYWHav3+/GjVq5GSpxcKpeZYuXVq33XabSpUqJUmaOHGirr76aq1evVpt27bVkCFDtHHjRidLLvJOzVQ68QV7amqqYmNjFRYWpkcffVQlSpTQ7NmzNWbMGE2cONHBiou2U/MsV66cunbtemn2SAbnbcmSJSY+Pt7ExcWZf//738YYY3Jzc40xxmRnZ5v/+7//M0OHDjUHDx60HvPTTz+ZqKgo89FHHzlSc1FWUJ5ut9sYY0x6erqJjIw04eHh5umnn7Yek5iYaPr162duvPFGk5aW5kjdRVVBeZ7O5MmTTdWqVc2OHTsuUnXFT0F55uTkGGOMyczMNO+9954ZMmSIiYmJMW+99ZY5cuSI+eWXX0zfvn1Nq1atzOHDh50sv8g50+t9+fLlJiAgwNx6663mxRdfNDVq1DCtW7c28+fPN5UqVTJTp051svQi6Y8//jANGjQwcXFxplKlSqZdu3bmP//5jzHGmC1bthh/f3/z9ddfG2NOfD4ZY8z69etN3bp1zfjx4x2ru6gqKM9vv/3Wmu92u639tUePHqZZs2Z8Bp3B2fLMey81xpjff//dVK1a1ezevdtjOv6noDy/++47j2XWr19vbr75ZvP222+btWvXms8++8xUq1bNDB482GRmZjpUedF1tkyPHTtmGjRoYHbv3m2MMWbo0KEmKCjIhIeHmylTpjhUddFVUJ7ffPONMebE30xDhgy55Hokmu7zkJ2dbZ5//nnjcrnMCy+8YP0Bc6rt27ebPXv2WL/nfUBfccUV5oEHHrgotRYHZ8szL7exY8cal8tlRo4c6TF/zJgxpnnz5iY9Pf2i1VyUFWb/zMs0799t27aZwMBAs3TpUmPM/748QuFf78ac+PKiTZs25vjx49a09957z9SpU8esW7fuYpRb5BU2zxkzZph7773XNGrUyIwYMcJarmnTpub555+/iBUXfcePHzc9e/Y0ffr0Mbt37zY///yzueGGG0zjxo2t13TPnj1N/fr18722r7nmGnPPPfcYY/73fnCpO1Oey5YtM8YYj/12y5YtJiQkxLz99tvWtKSkpIted1FVmDxzcnKsfXP8+PGmcePGHhnTfP9PYfI05sQ+empz3adPH3P11Vdf7JKLvMJk+ssvv5jOnTubxMRE06lTJxMcHGyqVq1qrrvuOrN161ZjDO+hec6U5+LFi40xJ943L7UeieHl5yEjI0O5ubkqWbKk/vWvfykgIEBvv/22xo8fr2nTplnD96pWrWpdYdv8dyjv3r17lZKSYg2lwtnzNP89x3jAgAGqUqWK5s+frw0bNliPz8nJUalSpayh6Je6wuyfeUPI8/7Nzc1V/fr19dtvv0kStxI6SWFf79KJYVS1atWyzp2VpPT0dJUoUYLX/H+dLc+80yBuv/12TZ48WX/88Yeee+45BQQEaMOGDdq/f7/q1avn8LMoWvbt26evvvpKt912mypUqKArr7xSL774omrUqKEnnnhCkjR8+HDt2rVLQ4cOVXZ2tiRZ/5YvX14S5yXmOV2eNWvW1OOPPy5JCggIsD6b8qa/8MILWrx4sbp3766hQ4dyIcX/Kkye/v7+1jVcFi1apDZt2iggIECHDx9W3759rVsKoXB5Sidez3nndbvdbmVmZio1NVUVKlTgGgSnOFOmjz32mKQTp47OnTtXsbGxys7O1saNGzVr1iytX79eM2bMUGZmJu+h/3WmPIcMGSLpxPvmJdcjOdryF2MbN240LVu2NA0bNjTNmzc3TZs2Ne3atTMul8v06NHD/Pzzz/kek5mZaYYPH24uv/xys3HjRgeqLrrOlGf37t3NDz/8YIwx5ttvvzVVq1Y1LVq0MFOmTDGjRo0y5cuX99mhKOersPvnyUcP4uPjzYgRI4wxfFt7qrPlmbd/fvDBB8bPz8+88sorZsWKFebll1825cqVM6+++qrJzc0l1/8q7P6Zl1dGRoY5duyYefrpp03btm3NgQMHnCy/yNmwYYNp1KiRmTlzpsf0uXPnmri4OPPOO+8YY4yZNGmSiYiIMPfcc4/57rvvzNixY0358uU9jo7hzHlWqFDBTJw40Rjj+f65detW43K5jMvlMs2bNzfbt2+/mCUXaYXN05gTr/VmzZqZ77//3rz55psmIiLCNGjQwOzcufNil11knUueeTIzM83YsWNN/fr1rSON+J+zvYe+//771t/wX3/9tceIod69e5shQ4YwZP8k57uP+nqPRNN9Dk7+gM3OzjaTJ0828fHxZtSoUSYlJcXk5OSYX375xbRu3drcd9991gtw7ty55pFHHjH16tUz1atXN0uWLHHqKRQp55pn3pDdpUuXmt69e5trrrnGNG7c2DpP8VJ3vvtn3hC+6667ztxxxx2O1F4UnWueGRkZxhhj7r//flOrVi1Tt25dU79+ffbP/zrf/XPdunXm5ZdfNtWrVzfVqlWzhktf6k7O89ChQ6ZevXrm+eefN8eOHbOmJyUlmYceesi0a9fOOv1m0qRJpmPHjqZRo0amVq1a1nnfl7rC5vnwww+bdu3aWa/33Nxc880335ioqCgTHx9vvv/++4tee1F0vnkuWLDAuFwuExoaamJjY81XX3110Wsvis43z2+++cYMGjTINGjQwFSvXt0sXLjwotdeVJ3Le+jVV1+dr6nOa7yzsrIuTsFF3Pnuo5dSj0TTXQgnH53KzMw0R48eNcYYk5CQYL777juPiwAYY8zzzz9vmjVrZl1sYcuWLebmm282b7755sUrugg73zxP/ab70KFD3i+2GLjQ/TPP+vXrvV9sMXA+eTZt2tS6CF1WVpY5dOiQ+e233y5e0UXYhe6fR48eNW+99ZZ57733Ll7RRdipeaamphpjjHnyySdNxYoVzerVqz2Wf/vtt03z5s3Ntm3bPKaf+vul6nzzzPs8yvsC6aWXXrp4RRdh55tnQkKCMebEebOhoaHmrbfeunhFF2Hnm2fe59G2bdvM7bff7nG9gUvd+WR6+eWXc6HZ07jQffRS6pFougswYcIEM3jwYPPmm296fEOzYsUKc9lll5kPP/ywwMflHTEcP368CQ0NNYmJida8S/kiIN7I81JGnvayO89LfQg5+6e9xo8fb5599lkza9YsjyMqv/76q7nsssvMBx98YE2LjY01Dz30kNm1a5c17fPPPzdBQUFm//79xhgukmh3npc6b+R5KQ/T9UaevOZ5zdvJG3leKj0SV0s6ybx581StWjVNnDhRe/fu1fDhw9WjRw9rfuPGjRUYGCi3221d7OdkAQEBOnbsmBYvXqz+/fsrOjramufv739RnkNR4s08L0XkaS9v5XmpXkiF/dNemzdvVqNGjfTWW29p5cqV+sc//qGbb75ZCQkJkqQmTZpYF/PKyMiQJL355puaN2+eXnnlFe3Zs0fHjx/XokWL1L17d5UuXVrSpXuRRG/leamyO8+8+0pLsi7+dSnxZp685nnN28Gb++gl0yM52fEXJbNnzzaNGzc2Y8eONTk5OSY7O9ssX77cuFwujwuinDoU0hhj0tLSzA8//GBmzpxpGjdubJo2bZpvOMWlhjztRZ72Ik97kaf9xo0bZ6688kqTlZVlMjMzzdatW0358uVNv379zJYtW4wxpsALyr399tumbt26pkaNGiY+Pt5UqFDBp8+RKyzytBd52os87Uem9iLPC3fJN915w2527txp3n//fet8Q2OM+eKLL8ydd9551qFOu3btMrfddpupWbOmefbZZ71ab1FHnvYiT3uRp73I035ut9tkZmaa7t27m7vuusu43W4r548++sjUr1/fvPbaa/kelzc8z+12m927d5tvvvmGuzoY8rQbedqLPO1HpvYiT/tcsk332rVrTUpKise0k88pGDdunClRooSpUqWKadKkiXn99dfN4cOHrfkLFy40kydPtv7I/PPPP62LB1yKyNNe5Gkv8rQXedrr559/Nnv37vWY1r17d9OxY0djjOc5rj179jQ33XSTxy1V8vLMu0L5pY487UWe9iJP+5GpvcjTOy65pnvhwoWmSZMmpl69eqZmzZrm0UcftS5bn+fbb7817du3N++//7754YcfzBtvvGFCQkLM5MmTrYsk3X///aZcuXJmxYoVTjyNIoM87UWe9iJPe5GnvX744QdTq1YtU6lSJVO5cmXTu3dvs3btWmPMiSH7/v7+1rC9vJyXLl1qSpcu7TE8Ly/PVatWXfwnUYSQp73I017kaT8ytRd5etcl03RnZmaasWPHmooVK5qRI0eaFStWmIkTJxqXy2VmzJhhjPnfkZqjR4/m+0OyVatW5t5777V+T0xMNHPnzr1o9Rc15Gkv8rQXedqLPO23f/9+065dOzN48GCzdetWM2fOHFOzZk3TuXNns2XLFpOWlmZatGhhHVk4+QrEefc3z0Oe5Gk38rQXedqPTO1Fnt53yTTdu3btMq1btzbTpk0zxvzvtj633XabueWWWzyWPfmWP7m5uSYpKcm0aNHCPPnkk/nmX6rI017kaS/ytBd52u/HH380ISEhZs2aNda0uXPnmquvvtrcd999xhhjZs2aZQIDA83HH39sLbNv3z5Tp04d677ll/rtgPKQp73I017kaT8ytRd5el+A01dPv1gqVqyofv36qXPnzh7TQ0NDFRUVJUkyxsjlcnnc8icrK0tvvvmmcnNz1bt3b0mX7i2BTkae9iJPe5GnvcjTfocOHVLt2rVljLGmderUSRs3btT777+vBQsWqFu3bnr88cf14IMPavPmzercubPmzJmj7OxstW7dWtKlezugU5GnvcjTXuRpPzK1F3leBA41+xdVQUdW8m7o3qJFCzNmzBiPeTk5OWbu3LnmqaeeMvHx8aZ27drmp59+uii1FgfkaS/ytBd52os87ZWX57Zt20xoaKiZPn26x/z169ebTp06mYceesha9umnnzZXXHGFqVWrlqlVq9Yle7uVgpCnvcjTXuRpPzK1F3lePJdE0306+/fvN3FxcWbDhg355i1ZssR06dLFvPvuuw5UVjyRp73I017kaS/yPH95w+9uv/12c/nll5sjR454zH/44YfNddddZ1351e12m6ysLLNu3bqLXWqxQJ72Ik97kaf9yNRe5Hlx+EzTnXfC/rmcLzh79mxTv359k52dbYwx5siRI2b58uXWpfAv5XMPydNe5Gkv8rQXedrrbHnmTd+8ebMJDg42r7zyijl+/Lg1/6WXXjJxcXHWiIJLOUtjyNNu5Gkv8rQfmdqLPIuGYj/wfsmSJapVq5Y6d+6suXPnyuVyye12n/Exubm5kqSFCxeqcePGCggI0Lhx41S6dGl98skn1vkMl+K5h+RpL/K0F3naizztVdg887KJj4/XsGHD9MILL+iDDz5Qamqqjh8/rh9//FG9e/dWYGCgx/KXGvK0F3naizztR6b2Is+ixWXMSWfMFzO//fabRowYoZiYGKWkpOjPP//Upk2bCv34du3aqXTp0tq2bZuSkpL05ptvqkePHl6suGgjT3uRp73I017kaa8LyXPQoEH64osvFB0drdTUVBljNHPmTDVp0sTLVRdd5Gkv8rQXedqPTO1FnkWQI8fXbbJz507z6quvmo0bN5r169ebUqVKmZdeeskYc/ZL1ickJBiXy2VKlixpRowYcTHKLfLI017kaS/ytBd52mvXrl3nnGfevc0zMzPNmjVrzOTJk82UKVMuVslFGnnaizztRZ72I1N7kWfRU6ya7qVLl5r169db5wwaYzzOLxg1apQJDw83hw4dsqYVJG/6xIkTTWpqqperLrrI017kaS/ytBd52uunn34ye/fu9Zh2PnniBPK0F3naizztR6b2Is+ir1g03XPnzjW1atUyderUMeXKlTO33Xab2bp1qzU/b8fZs2ePqVu3runTp4/H9FNd6jduJ097kae9yNNe5GmvhQsXmmrVqpkqVaqYihUrmn79+plNmzYZY05kdq55XurI017kaS/ytB+Z2os8i48i3XQfO3bM/Otf/zLly5c3r776qtm5c6dZsGCBCQsLM5999lmBj5k+fbpxuVxm9erVxpgT3/IcPXr0YpZdZJGnvcjTXuRpL/K0386dO82VV15pnnvuObN161Yzc+ZMU716ddOtWzeTkJBgjDHW1dyNIc+zIU97kae9yNN+ZGov8ixeinTTvWfPHjNs2DDz/fffG2P+961M06ZNzaxZswp8TGpqqrnxxhtNu3btzJo1a8yNN95o3nnnHes8hUsZedqLPO1FnvYiT/vNnz/fhIaGeowUmDVrlmnbtq35xz/+YU3Ly5o8z4w87UWe9iJP+5GpvcizeCnSTbcxxmzfvt1jZ3jppZdMhQoVzHPPPWfmzZtnnVN48jJffPGFcblcxuVymfbt25vDhw9f9LqLKvK0F3naizztRZ72mjFjhmnatKk1dM+YE9mNHj3a1KtXzyxZssSaloc8T4887UWe9iJP+5GpvcizeCnyTXeeY8eOmQ4dOpjSpUubwYMHm1tvvdXUq1fPPProo9YyWVlZ5sMPPzTBwcGmefPmZuXKlc4VXMSRp73I017kaS/ytMfatWtNSEiImT17tsf033//3XTs2NE89thj1jTyPDvytBd52os87Uem9iLP4qXYNN3GnLgy35EjR6zfn3nmGXPVVVeZbdu2GWOMOXLkiBkyZIiZOHGiQxUWL+RpL/K0F3naizztkTc0Ly0tzWP63Xffbbp27WpdaI48C4c87UWe9iJP+5Gpvciz+ChWTXeevEvgv/zyyyYiIsLs37/f4YqKN/K0F3naizztRZ4X5o8//jABAQFm4sSJHrdfe+aZZ0zNmjUdrKx4Ik97kae9yNN+ZGov8iw+AlQMBQYG6tChQ1q9erX69++v2NhYp0sq1sjTXuRpL/K0F3lemEaNGulf//qXRo4cqcDAQPXq1Utut1urVq3SXXfd5XR5xQ552os87UWe9iNTe5Fn8eEyxhiniyisgwcPatu2bdq2bZuGDh2qmJgYvf/++6pTp47TpRVL5Gkv8rQXedqLPO31yCOP6Msvv1TlypW1f/9+hYWFaebMmapXr57TpRVL5Gkv8rQXedqPTO1FnkVfsWq6165dq4EDB2rv3r36xz/+occff9zpkoo18rQXedqLPO1FnvbKyMjQhg0btHr1agUHB3NE4QKRp73I017kaT8ytRd5Fn3FqumWpF9++UVNmzZVUFCQ06X4BPK0F3naizztRZ4AAAAXX7FrugEAAAAAKC78nC4AAAAAAABfRdMNAAAAAICX0HQDAAAAAOAlNN0AAAAAAHgJTTcAAAAAAF5C0w0AAAAAgJfQdAMAAAAA4CU03QAAAAAAeAlNNwAAPuzqq6/WoEGD8k3/4IMPFBUVpapVq8rlcp32p0+fPpKkrVu36r777lPFihUVHBysatWq6Y477tCqVasu7hMCAKCYCXC6AAAA4JyVK1cqNzdXkvTTTz+pe/fu2rRpkyIiIiRJoaGhWrVqla699lo1aNBA7777rurUqaO0tDTNnj1bgwcP1tKlS518CgAAFGk03QAAXMKio6Ot/y5durQkKSYmRlFRUZIkY4z69Omj+Ph4LV++XH5+/xsk17hxYz366KMXtV4AAIobmm4AAHBaf/zxh9atW6fp06d7NNx58ppzAABQMM7pBgAAp7VlyxZJUp06dRyuBACA4ommGwAAnJYxxukSAAAo1mi6AQDwYREREUpJSck3PTk5WZGRkWd9fK1atSRJGzdutL02AAAuBTTdAAD4sNq1a2v16tX5pq9evdpqqM+kcePGqlevnl599VW53e5885OTk+0oEwAAn0XTDQCAD3v44Ye1efNmDRw4UGvWrNGmTZs0btw4ffLJJxo8ePBZH+9yuTRlyhRt3rxZbdq00TfffKNt27ZpzZo1Gj16tLp27XoRngUAAMUXTTcAAD6sevXqWrZsmTZu3KgOHTqoRYsW+uyzzzRz5kzdcMMNhVrHFVdcoVWrVqlmzZrq16+f6tatqy5dumjdunV6/fXXvfsEAAAo5lyGK6QAAAAAAOAVHOkGAAAAAMBLaLoBAAAAAPASmm4AAAAAALyEphsAAAAAAC+h6QYAAAAAwEtougEAAAAA8BKabgAAAAAAvISmGwAAAAAAL6HpBgAAAADAS2i6AQAAAADwEppuAAAAAAC8hKYbAAAAAAAv+X8hlpvDdBO0VAAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1000x400 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(10, 4))\n",
+    "ax.step(df[\"Sat.UTCGregorian\"], delta, where=\"post\", linewidth=1.5)\n",
+    "ax.axvline(\n",
+    "    pd.Timestamp(\"2017-01-01 00:00:00\"),\n",
+    "    color=\"crimson\",\n",
+    "    linestyle=\"--\",\n",
+    "    linewidth=1,\n",
+    "    alpha=0.7,\n",
+    "    label=\"2017-01-01 leap second\",\n",
+    ")\n",
+    "ax.set_xlabel(\"UTC\")\n",
+    "ax.set_ylabel(\"TAI - UTC (s)\")\n",
+    "ax.set_title(\"TAI - UTC across the 2017-01-01 leap second\")\n",
+    "ax.set_yticks([36, 37])\n",
+    "ax.grid(True, alpha=0.3)\n",
+    "ax.legend(loc=\"lower right\", fontsize=9)\n",
+    "fig.autofmt_xdate()\n",
+    "fig.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "388077da",
+   "metadata": {},
+   "source": [
+    "## Where to next\n",
+    "\n",
+    "- **Parser-level `convert_to`.** Every parser whose output carries `df.attrs[\"epoch_scales\"]` accepts `convert_to=` — including the three `EphemerisFile` parsers (`parsers.ephemeris.parse` for CCSDS-OEM, `parsers.stk_ephemeris.parse`, and `parsers.aem_ephemeris.parse` for CCSDS-AEM). Use it whenever you want every epoch column on a single time axis without writing the per-column dance yourself.\n",
+    "- **Outside the GMAT five.** CCSDS files can declare `TIME_SYSTEM` values (`UT1`, `GPS`, `TCG`, …) that fall outside the five GMAT scales. `convert_to=` raises rather than silently mis-converting; reach for [`gmat_run.time.convert`][gmat_run.time.convert] once you have a mapping you trust.\n",
+    "- **A1 in your own code.** `convert(series, \"A1\", *)` and `convert(series, *, \"A1\")` work series-by-series — handy if you need to interoperate with another tool that emits A1 modified Julian dates.\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -17,3 +17,8 @@ locally after `pip install gmat-run[examples]` and the matplotlib dependency.
   an STK ephemeris, convert it to a CCSDS-OEM file with
   [`Results.write_oem`][gmat_run.Results], re-parse the result, and visualise the
   trajectory in 3D.
+- [Time-scale conversion](05_time_scales.ipynb) — propagate across the 2017-01-01
+  leap-second boundary and convert the resulting ReportFile's epoch columns
+  between A1, TAI, UTC, TT, and TDB with
+  [`gmat_run.time.convert`][gmat_run.time.convert] and the parser-level
+  `convert_to=` keyword.

--- a/docs/examples/leap_second_demo.script
+++ b/docs/examples/leap_second_demo.script
@@ -1,0 +1,42 @@
+%  Inline mission used by docs/examples/05_time_scales.ipynb to demonstrate
+%  leap-second-correct time-scale conversion. Propagates a circular LEO
+%  across the 2017-01-01 00:00:00 UTC leap-second boundary and writes one
+%  ReportFile carrying epoch columns in four scales (UTC, TAI, TT, TDB) plus
+%  Sat.A1ModJulian, so the constant offsets and the leap-second jump are
+%  both visible in a single DataFrame. Avoids OpenFramesInterface / OrbitView
+%  so it parses headlessly through gmatpy.
+
+Create Spacecraft Sat
+Sat.DateFormat = UTCGregorian
+Sat.Epoch = '31 Dec 2016 23:55:00.000'
+Sat.CoordinateSystem = EarthMJ2000Eq
+Sat.DisplayStateType = Keplerian
+Sat.SMA = 7000
+Sat.ECC = 0.001
+Sat.INC = 28.5
+Sat.RAAN = 75
+Sat.AOP = 90
+Sat.TA = 0
+
+Create ForceModel FM
+FM.CentralBody = Earth
+FM.PointMasses = {Earth}
+FM.Drag = None
+FM.SRP = Off
+
+Create Propagator Prop
+Prop.FM = FM
+Prop.Type = PrinceDormand78
+Prop.InitialStepSize = 30
+Prop.Accuracy = 1e-9
+Prop.MinStep = 30
+Prop.MaxStep = 30
+
+Create ReportFile RF
+RF.Filename = 'leap_second_demo_report.txt'
+RF.Precision = 16
+RF.WriteHeaders = true
+RF.Add = {Sat.UTCGregorian, Sat.TAIGregorian, Sat.TTGregorian, Sat.TDBGregorian, Sat.A1ModJulian, Sat.X, Sat.Y, Sat.Z}
+
+BeginMissionSequence
+Propagate Prop(Sat) {Sat.ElapsedSecs = 600}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,7 @@ nav:
       - Parameter sweep: examples/02_parameter_sweep.ipynb
       - Ground track: examples/03_ground_track.ipynb
       - Export to CCSDS-OEM: examples/04_export_oem.ipynb
+      - Time-scale conversion: examples/05_time_scales.ipynb
   - API reference:
       - reference/index.md
       - Mission: reference/mission.md


### PR DESCRIPTION
## Summary

- New `docs/examples/05_time_scales.ipynb` walks through the v0.3 time-scale extra end-to-end on a propagation that crosses 2017-01-01: runs an inline mission whose `ReportFile` carries the same epoch in four scales side-by-side (`Sat.{UTC,TAI,TT,TDB}Gregorian`) plus `Sat.A1ModJulian`, inspects `df.attrs["epoch_scales"]`, demonstrates per-column conversion via `gmat_run.time.convert_column`, whole-frame conversion via `parsers.reportfile.parse(..., convert_to="UTC")`, the A1 path (GMAT-specific, routed through TAI by `gmat_run.time`), and plots `TAI - UTC` across the boundary so the 1-second leap-second jump is visible.
- New `docs/examples/leap_second_demo.script` is the inline LEO mission the notebook drives — a fixed 30 s step from `31 Dec 2016 23:55:00 UTC` for 600 s, modelled on `leo_keplerian.script` and following the same pattern as the inline fixture in `tests/integration/test_smoke.py`.
- Wires the new notebook into `mkdocs.yml` nav, the docs Examples index, the README runnable-examples list, and the CI smoke-execute job alongside notebooks 01 / 02 / 04. The dev group already includes `astropy>=6.0`, so the existing `--all-groups --extra examples` install in CI covers this notebook's deps without adding another `--extra`.
- Notebook cell outputs are committed so the docs site renders without re-execution (matches `mkdocs-jupyter`'s `execute: false` setting).

Two minor deviations from the issue body, matching the precedent set by #79:

- The relevant pyproject extra is `[astropy]`, not `[time]`. The notebook prose and README reference it correctly.
- The notebook lives at `docs/examples/05_time_scales.ipynb`, not `examples/05_time_scales.ipynb` — that's the actual layout the other example notebooks use and what `mkdocs-jupyter` is wired against.

The leap-second instant landing exactly on the propagation grid was originally going to be sidestepped with a 7 s epoch shift, but #80 (merged in #81) fixed the underlying conversion bug, so the original epoch works as-is and the demo runs cleanly.

## Test plan

- [x] `uv run ruff check`
- [x] `uv run ruff format --check`
- [x] `uv run mypy`
- [x] `uv run pytest` (622 passed)
- [x] `uv run mkdocs build --strict` — new notebook renders, no broken nav links
- [x] Manual end-to-end: `uv run jupyter execute --inplace docs/examples/05_time_scales.ipynb` against a local R2026a install with the `[astropy,examples]` extras
- [x] CI smoke-execute job picks up the new notebook on Ubuntu / py3.12 (verify on the PR's first CI run)

Closes #71.