### PR TITLE
Harden `Mission.run(working_dir=...)` for explicit-workspace re-runs

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -81,6 +81,10 @@ lifetime is tied to the returned [`Results`][gmat_run.Results] — the directory
 until you drop the result, so lazy DataFrame access still works after the run returns.
 Pass `working_dir=...` to write into a permanent location instead.
 
+See [Working directories](working-directories.md) for the full rules — pre-existing
+artefacts, absolute filenames in the script, permission errors, and the `overwrite=`
+opt-in for re-running into a populated workspace.
+
 ## Errors
 
 Every exception gmat-run raises inherits from [`GmatError`][gmat_run.GmatError]. Branch

--- a/docs/working-directories.md
+++ b/docs/working-directories.md
@@ -1,0 +1,133 @@
+# Working directories
+
+[`Mission.run`][gmat_run.Mission.run] writes every output file (and GMAT's own
+log) into a single directory — the *workspace*. By default that workspace is a
+fresh `tempfile.TemporaryDirectory` whose lifetime is tied to the returned
+[`Results`][gmat_run.Results]; pass `working_dir=...` to write into a permanent
+location instead.
+
+```python
+from gmat_run import Mission
+
+# Default: throwaway workspace, cleaned up when `result` is dropped.
+result = Mission.load("flyby.script").run()
+
+# Explicit: outputs land in ./out/ and stay there.
+result = Mission.load("flyby.script").run(working_dir="out")
+```
+
+## Filename rewrite (the rule that makes the workspace work)
+
+GMAT subscribers (`ReportFile`, `EphemerisFile`, `ContactLocator`) cache their
+output path internally at parse time, and `FileManager.OUTPUT_PATH` does not
+override it after the fact. [`Mission.run`][gmat_run.Mission.run] sidesteps
+the cache by rewriting each subscriber's `Filename` field to an absolute path
+inside the workspace before invoking `RunScript`.
+
+- A **relative** `Filename` (e.g. `RF.Filename = 'leo_state.txt'`) is rewritten
+  to `<working_dir>/leo_state.txt`. Any leading directory component is dropped
+  — output files always land at the top of the workspace, on every OS, and
+  forward-slash and back-slash relative paths are treated identically.
+- An **absolute** `Filename` (e.g. `RF.Filename = '/data/runs/leo.txt'`) is
+  honoured as-is. The user picked that destination; gmat-run does not relocate
+  it.
+
+Reading the field back from Python after the run yields the resolved absolute
+path:
+
+```python
+mission = Mission.load("flyby.script")
+result = mission.run(working_dir="out")
+mission["RF.Filename"]  # '/abs/.../out/leo_state.txt'
+```
+
+## Out-of-workspace notice
+
+Whenever an absolute `Filename` lands an output outside the workspace, a
+single line is prepended to [`Results.log`][gmat_run.Results] so the trail is
+visible without walking the path mappings:
+
+```
+[gmat-run] note: 1 output(s) landed outside working_dir: /data/runs/leo.txt
+<original GMAT log content>
+```
+
+The notice is informational. Pinned-absolute paths are a deliberate user
+choice and the run is not gated on them.
+
+## Pre-existing artefacts
+
+When `working_dir` already contains a file whose name matches a resolved
+output path (the `Filename` rewrite landed it inside the workspace), the
+default behaviour is to **refuse the run** rather than silently mix the prior
+run's artefacts with the new run's:
+
+```python
+Mission.load("flyby.script").run(working_dir="out")
+# raises GmatRunError: working_dir 'out' already contains output files: out/leo_state.txt;
+# pass overwrite=True to clear them and re-run
+```
+
+The gate fires before `RunScript` is invoked, so the existing files are
+untouched and the workspace is left in the same state the prior run left it
+in. The exception's `.path` attribute carries the offending workspace
+directory.
+
+Two ways forward:
+
+- Move the artefacts elsewhere (or run into a different `working_dir`) and
+  retry.
+- Re-run with `overwrite=True` to unlink the colliding files and proceed:
+  ```python
+  Mission.load("flyby.script").run(working_dir="out", overwrite=True)
+  ```
+  `overwrite=True` only removes files that match the run's resolved output
+  paths. Stale unrelated files in `working_dir` are left alone, and absolute
+  paths the script pinned outside `working_dir` are not touched either —
+  the gate is scoped to files inside the workspace.
+
+`overwrite` is ignored for the default-workspace case (`working_dir=None`)
+since a fresh temporary directory cannot contain colliding artefacts.
+
+## Permission errors
+
+If `working_dir` cannot be created or the writability probe fails (no write
+bit on the directory, full filesystem, ACL refusal on Windows, …)
+[`Mission.run`][gmat_run.Mission.run] raises
+[`GmatRunError`][gmat_run.GmatRunError] before invoking `RunScript`:
+
+```python
+Mission.load("flyby.script").run(working_dir="/proc/cannot-write-here")
+# raises GmatRunError: working_dir '/proc/cannot-write-here' is not writable: ...
+```
+
+The exception's `.path` attribute points at the offending directory and the
+underlying `OSError` is chained via `__cause__`, so callers can present a
+diagnostic without re-probing.
+
+## `working_dir` resolves to the script's own directory
+
+Pointing `working_dir` at the directory that contains the loaded `.script`
+emits a `UserWarning` — GMAT outputs there can clobber the script itself or
+sibling source files when filenames coincide:
+
+```python
+import warnings
+with warnings.catch_warnings():
+    warnings.simplefilter("error")
+    Mission.load("scripts/flyby.script").run(working_dir="scripts")
+    # UserWarning: working_dir 'scripts' is the script's own directory; ...
+```
+
+The warning is the only safety rail; the run still proceeds. Filter it
+explicitly with `warnings.simplefilter("ignore")` if you have audited the
+script's `Filename` declarations and know they cannot collide with sources.
+
+## `Results.persist`
+
+[`Results.persist`][gmat_run.Results.persist] is unaffected by the gates
+above. It still copies every artefact under [`Results.output_dir`][gmat_run.Results]
+into a destination directory and rewrites the path mappings to point at the
+copies. Calling `persist` after an explicit `working_dir` run leaves the
+original workspace intact; calling it after the default-workspace run releases
+the temporary directory as part of the move.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,6 +36,7 @@ nav:
   - Home: index.md
   - Getting started: getting-started.md
   - Install GMAT: install-gmat.md
+  - Working directories: working-directories.md
   - CLI usage: cli.md
   - Examples:
       - examples/index.md

--- a/src/gmat_run/errors.py
+++ b/src/gmat_run/errors.py
@@ -55,11 +55,15 @@ class GmatRunError(GmatError):
 
     The ``log`` attribute carries GMAT's own stderr / log content captured during
     the run, so callers can surface GMAT's diagnostic verbatim without re-reading
-    the log file.
+    the log file. The optional ``path`` attribute carries the offending directory
+    or file when the failure is wired to a specific filesystem location (e.g. a
+    non-writable ``working_dir`` or a colliding output file); ``None`` for engine
+    failures that are not path-scoped.
     """
 
-    def __init__(self, message: str, log: str) -> None:
+    def __init__(self, message: str, log: str, *, path: Path | None = None) -> None:
         self.log = log
+        self.path = path
         super().__init__(message)
 
 

--- a/src/gmat_run/mission.py
+++ b/src/gmat_run/mission.py
@@ -23,7 +23,8 @@ from __future__ import annotations
 import difflib
 import os
 import tempfile
-from collections.abc import Iterator, Mapping
+import warnings
+from collections.abc import Iterable, Iterator, Mapping
 from contextlib import suppress
 from pathlib import Path
 from types import MappingProxyType, ModuleType
@@ -261,6 +262,7 @@ class Mission:
         self,
         *,
         working_dir: str | os.PathLike[str] | None = None,
+        overwrite: bool = False,
     ) -> Results:
         """Execute the loaded mission sequence and return a :class:`Results`.
 
@@ -282,6 +284,28 @@ class Mission:
         After :meth:`run` returns, reading ``mission["RF.Filename"]`` yields
         the resolved absolute path, which points at the file on disk.
 
+        **Working directory** (when ``working_dir`` is set explicitly):
+
+        * The directory is created if missing; if creation or any write into
+          it fails, :class:`~gmat_run.errors.GmatRunError` is raised before
+          ``RunScript`` is invoked, with ``GmatRunError.path`` set to the
+          offending directory.
+        * If ``working_dir`` resolves to the same directory as
+          :attr:`script_path`'s parent, a :class:`UserWarning` is emitted —
+          GMAT outputs in that case may overwrite the user's source files.
+        * Pre-existing files inside ``working_dir`` whose names match the
+          run's resolved output paths are detected before ``RunScript``.
+          Default policy: raise :class:`~gmat_run.errors.GmatRunError` and
+          skip the run, so the prior run's artefacts are not silently mixed
+          with the new run's. Pass ``overwrite=True`` to unlink the colliding
+          files and proceed. The gate is scoped to files inside
+          ``working_dir`` only — absolute filenames pinned outside (see
+          below) are the user's destination and are never touched.
+        * After a successful run, any output that landed outside
+          ``working_dir`` (because the script declared an absolute
+          ``Filename``) is summarised as a one-line ``[gmat-run] note: …``
+          notice prepended to :attr:`Results.log`.
+
         Args:
             working_dir: Directory GMAT writes its outputs into. ``None``
                 creates a fresh :class:`tempfile.TemporaryDirectory` whose
@@ -290,14 +314,26 @@ class Mission:
                 report parsing keeps working without a context manager. Call
                 :meth:`Results.persist` before that to copy the artefacts to a
                 permanent location.
+            overwrite: When ``True``, unlink any pre-existing files in
+                ``working_dir`` that collide with the run's resolved output
+                paths before invoking ``RunScript``. When ``False`` (the
+                default), a collision raises
+                :class:`~gmat_run.errors.GmatRunError`. Ignored when
+                ``working_dir`` is ``None`` (a fresh temp directory cannot
+                contain colliding artefacts).
 
         Raises:
-            GmatRunError: ``RunScript`` returned a non-success status or
-                raised a GMAT engine exception. The captured log is attached
-                via ``GmatRunError.log``.
+            GmatRunError: ``RunScript`` returned a non-success status, raised
+                a GMAT engine exception, or a pre-run gate failed
+                (``working_dir`` not creatable, not writable, or contained
+                colliding output files with ``overwrite=False``). The
+                captured log is attached via ``GmatRunError.log`` (empty for
+                pre-run gate failures); the offending directory or file is
+                attached via ``GmatRunError.path``.
         """
         workspace_path, tempdir = _prepare_workspace(working_dir)
-        log_path = workspace_path / "GmatLog.txt"
+        if working_dir is not None:
+            self._warn_if_workspace_is_script_dir(workspace_path)
 
         # Walk every output subscriber once: bucket the paths and rewrite each
         # relative Filename to an absolute path inside the workspace so GMAT
@@ -308,6 +344,15 @@ class Mission:
         # subscriber, and overriding the Filename field is the only setting
         # the engine consults at write time.
         report_paths, ephemeris_paths, contact_paths = self._rewrite_output_paths(workspace_path)
+        all_paths = (*report_paths.values(), *ephemeris_paths.values(), *contact_paths.values())
+        # Pre-run gate: pre-existing artefacts inside working_dir. Bounded to
+        # *resolved* output paths that live under workspace_path — absolute
+        # filenames pinned by the script outside the workspace are the user's
+        # destination and we honour them. Default raises; overwrite=True
+        # unlinks the colliding files first.
+        _check_inside_workspace_collisions(workspace_path, all_paths, overwrite=overwrite)
+        log_path = workspace_path / "GmatLog.txt"
+
         self._gmat.UseLogFile(str(log_path))
 
         api_exception = _get_api_exception(self._gmat)
@@ -338,6 +383,14 @@ class Mission:
                 log=log,
             )
 
+        # Out-of-workspace notice: any output the script pinned at an absolute
+        # path outside workspace_path gets a one-line summary at the top of
+        # the captured log so callers see the trail without having to re-walk
+        # the path mappings themselves.
+        notice = _format_outside_workspace_notice(workspace_path, all_paths)
+        if notice:
+            log = notice + log
+
         results = Results(
             output_dir=workspace_path,
             log=log,
@@ -350,6 +403,31 @@ class Mission:
         # parsing on `result.reports[name]` still finds the file on disk.
         results._workspace = tempdir
         return results
+
+    def _warn_if_workspace_is_script_dir(self, workspace_path: Path) -> None:
+        """Emit a UserWarning if ``workspace_path`` resolves to the script's directory.
+
+        Running into the script's own directory risks GMAT overwriting the
+        ``.script`` itself (or sibling source files) when the script's
+        ``ReportFile.Filename`` happens to collide with a source name.
+        Resolution is required on both sides — relative ``working_dir`` and a
+        symlinked install both want to compare canonical paths. Failure to
+        resolve (e.g. permission denied on a parent symlink) silently skips
+        the warning; the writability gate would have already raised.
+        """
+        try:
+            workspace_resolved = workspace_path.resolve()
+            script_dir_resolved = self.script_path.parent.resolve()
+        except OSError:
+            return
+        if workspace_resolved != script_dir_resolved:
+            return
+        warnings.warn(
+            f"working_dir '{workspace_path}' is the script's own directory; "
+            "outputs may overwrite the script or other source files",
+            UserWarning,
+            stacklevel=3,
+        )
 
     # --- discovery helpers ----------------------------------------------------
 
@@ -672,15 +750,142 @@ def _prepare_workspace(
 
     When ``working_dir`` is None we mint a fresh :class:`TemporaryDirectory`
     and return its handle so the caller can park it on the resulting
-    :class:`Results` to extend its lifetime. A user-supplied path is created
-    on demand; no tempdir is allocated and ``None`` is returned in its slot.
+    :class:`Results` to extend its lifetime — writability is implicit and
+    the directory cannot collide with the script's own location, so neither
+    gate runs.
+
+    A user-supplied path is created on demand and probed for writability with
+    a unique :func:`tempfile.mkstemp` file inside it; either failure raises
+    :class:`~gmat_run.errors.GmatRunError` before ``RunScript`` is invoked,
+    with ``GmatRunError.path`` set to the offending directory.
     """
     if working_dir is None:
         tempdir = tempfile.TemporaryDirectory(prefix="gmat-run-")
         return Path(tempdir.name), tempdir
     path = Path(working_dir).expanduser()
-    path.mkdir(parents=True, exist_ok=True)
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise GmatRunError(
+            f"working_dir '{path}' could not be created: {exc}",
+            log="",
+            path=path,
+        ) from exc
+    _probe_writable(path)
     return path, None
+
+
+def _probe_writable(path: Path) -> None:
+    """Confirm ``path`` accepts writes by creating and unlinking a probe file.
+
+    ``os.access`` is unreliable on Windows ACLs and on filesystems where the
+    directory mode-bits don't capture the effective permission, so the only
+    portable answer is to actually try writing. ``tempfile.mkstemp`` is used
+    instead of a fixed probe-file name so the check is collision-free even if
+    the user happens to keep an unrelated dotfile of the same name.
+    """
+    try:
+        fd, probe = tempfile.mkstemp(prefix=".gmat-run-write-probe-", dir=str(path))
+    except OSError as exc:
+        raise GmatRunError(
+            f"working_dir '{path}' is not writable: {exc}",
+            log="",
+            path=path,
+        ) from exc
+    os.close(fd)
+    with suppress(OSError):
+        os.unlink(probe)
+
+
+def _check_inside_workspace_collisions(
+    workspace_path: Path,
+    paths: Iterable[Path],
+    *,
+    overwrite: bool,
+) -> None:
+    """Gate or clear pre-existing output files inside the workspace.
+
+    Walks every resolved output path; only those that live under
+    ``workspace_path`` (i.e. relative ``Filename`` rewrites, not user-pinned
+    absolute paths) participate in the gate. With ``overwrite=False`` (the
+    default), any pre-existing file raises
+    :class:`~gmat_run.errors.GmatRunError` listing the collisions; with
+    ``overwrite=True`` they are unlinked instead.
+
+    The check runs before ``RunScript`` so a refused run leaves the workspace
+    untouched (the error message tells the caller exactly what to clear, or
+    pass ``overwrite=True``). ``GmatLog.txt`` itself is not script-declared
+    and never participates in this gate.
+    """
+    try:
+        workspace_resolved = workspace_path.resolve()
+    except OSError:
+        # An unresolvable workspace means we cannot tell what is inside; skip
+        # the gate rather than raise a confusing collision error. Writability
+        # would have already failed if this path were genuinely broken.
+        return
+    collisions: list[Path] = []
+    for p in paths:
+        if not _is_inside(p, workspace_resolved):
+            continue
+        if p.exists():
+            collisions.append(p)
+    if not collisions:
+        return
+    if overwrite:
+        for p in collisions:
+            with suppress(OSError):
+                p.unlink()
+        return
+    listing = ", ".join(str(p) for p in collisions)
+    raise GmatRunError(
+        (
+            f"working_dir '{workspace_path}' already contains output files: "
+            f"{listing}; pass overwrite=True to clear them and re-run"
+        ),
+        log="",
+        path=workspace_path,
+    )
+
+
+def _format_outside_workspace_notice(workspace_path: Path, paths: Iterable[Path]) -> str:
+    """Build the one-line "out-of-workspace" notice for :attr:`Results.log`.
+
+    Returns ``""`` when every output landed inside ``workspace_path``;
+    otherwise a single line of the form ``[gmat-run] note: N output(s)
+    landed outside working_dir: <comma-separated paths>\\n`` so the notice
+    is visible at the top of the captured log without disturbing the GMAT
+    text below it.
+    """
+    try:
+        workspace_resolved = workspace_path.resolve()
+    except OSError:
+        return ""
+    outside = [p for p in paths if not _is_inside(p, workspace_resolved)]
+    if not outside:
+        return ""
+    listing = ", ".join(str(p) for p in outside)
+    return f"[gmat-run] note: {len(outside)} output(s) landed outside working_dir: {listing}\n"
+
+
+def _is_inside(path: Path, workspace_resolved: Path) -> bool:
+    """Return True if ``path`` resolves to a location under ``workspace_resolved``.
+
+    ``path`` may not exist yet (collision check fires before the run); that
+    is fine — :meth:`Path.resolve` returns the would-be absolute path against
+    the existing parents. ``OSError`` from a broken symlink along the way
+    falls through to ``False`` so the path is treated as outside (the
+    collision gate skips it; the out-of-workspace notice flags it).
+    """
+    try:
+        resolved = path.resolve()
+    except OSError:
+        return False
+    try:
+        resolved.relative_to(workspace_resolved)
+    except ValueError:
+        return False
+    return True
 
 
 def _safe_read(path: Path) -> str:

--- a/tests/integration/test_working_dir.py
+++ b/tests/integration/test_working_dir.py
@@ -1,0 +1,102 @@
+"""End-to-end regression for the ``Mission.run(working_dir=...)`` gates.
+
+Drives a real GMAT install through three back-to-back runs into the same
+explicit ``working_dir`` to pin the contract:
+
+1. The first run populates the workspace.
+2. The second run, with the default ``overwrite=False``, raises
+   :class:`~gmat_run.errors.GmatRunError` before invoking ``RunScript`` and
+   leaves the prior run's artefacts intact.
+3. The third run, with ``overwrite=True``, unlinks the colliding file and
+   succeeds — proving the gate is the only thing standing between explicit
+   re-runs and a silent mix of old and new artefacts.
+
+The script is written inline so the test does not depend on which stock
+samples ship with a given GMAT release.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gmat_run import Mission
+from gmat_run.errors import GmatRunError
+
+pytestmark = pytest.mark.integration
+
+
+_MINIMAL_SCRIPT = """\
+Create Spacecraft Sat
+Sat.DateFormat = UTCGregorian
+Sat.Epoch = '01 Jan 2026 12:00:00.000'
+Sat.CoordinateSystem = EarthMJ2000Eq
+Sat.DisplayStateType = Keplerian
+Sat.SMA = 7000
+Sat.ECC = 0.001
+Sat.INC = 28.5
+Sat.RAAN = 75
+Sat.AOP = 90
+Sat.TA = 0
+
+Create ForceModel FM
+FM.CentralBody = Earth
+FM.PrimaryBodies = {Earth}
+
+Create Propagator Prop
+Prop.FM = FM
+Prop.Type = PrinceDormand78
+Prop.InitialStepSize = 60
+Prop.Accuracy = 1e-9
+
+Create ReportFile RF
+RF.Filename = 'leo_state.txt'
+RF.Add = {Sat.UTCGregorian, Sat.X, Sat.Y, Sat.Z, Sat.SMA}
+RF.WriteHeaders = True
+
+BeginMissionSequence
+Propagate Prop(Sat) {Sat.ElapsedSecs = 600}
+"""
+
+
+@pytest.fixture
+def minimal_script(tmp_path: Path) -> Path:
+    """Write the minimal mission script into ``tmp_path`` and return its path."""
+    script_path = tmp_path / "minimal_leo.script"
+    script_path.write_text(_MINIMAL_SCRIPT, encoding="utf-8")
+    return script_path
+
+
+def test_collision_gate_requires_overwrite_for_explicit_working_dir(
+    gmat_available: None,
+    minimal_script: Path,
+    tmp_path: Path,
+) -> None:
+    custom = tmp_path / "out"
+    workspace_report = custom / "leo_state.txt"
+
+    # 1. First run populates the workspace.
+    first = Mission.load(minimal_script).run(working_dir=custom)
+    assert first.output_dir == custom
+    assert workspace_report.is_file()
+    first_size = workspace_report.stat().st_size
+
+    # 2. Second run refuses to clobber the prior artefacts. The captured byte
+    # count below pins both halves: the gate fires (GmatRunError) and the
+    # prior file is unchanged on disk.
+    with pytest.raises(GmatRunError) as excinfo:
+        Mission.load(minimal_script).run(working_dir=custom)
+    assert excinfo.value.path == custom
+    assert "leo_state.txt" in str(excinfo.value)
+    assert "overwrite=True" in str(excinfo.value)
+    assert workspace_report.stat().st_size == first_size
+
+    # 3. Third run with overwrite=True clears the collision and succeeds.
+    third = Mission.load(minimal_script).run(working_dir=custom, overwrite=True)
+    assert third.output_dir == custom
+    assert workspace_report.is_file()
+    # Re-running the same propagation produces the same report — but the
+    # file is freshly written, not appended. The size sanity check would
+    # surface an "old + new" concatenation regression instantly.
+    assert third.reports["RF"].equals(first.reports["RF"])

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import gc
 import os
+import warnings
 from collections.abc import Iterator
 from pathlib import Path
 from types import ModuleType
@@ -981,6 +982,215 @@ class TestMissionRun:
         # errors propagate.
         with pytest.raises(RuntimeError):
             mission.run()
+
+
+# --- Mission.run working-directory hardening ---------------------------------
+
+
+class TestMissionRunWorkingDir:
+    """Pre-run gates around explicit ``working_dir`` and the post-run notice."""
+
+    def test_collision_default_raises_before_runscript(self, tmp_path: Path) -> None:
+        # A pre-existing file matching a script-declared output's resolved
+        # name is a collision: gmat-run refuses the run rather than silently
+        # mixing old and new artefacts.
+        custom = tmp_path / "out"
+        custom.mkdir()
+        stale = custom / "r1.txt"
+        stale.write_text("stale\n", encoding="utf-8")
+        rf = _report_file("R1", "r1.txt")
+        mission, gmat = _run_mission(tmp_path, objects={"R1": rf})
+
+        with pytest.raises(GmatRunError) as excinfo:
+            mission.run(working_dir=custom)
+
+        assert "already contains output files" in str(excinfo.value)
+        assert str(stale) in str(excinfo.value)
+        assert excinfo.value.path == custom
+        assert excinfo.value.log == ""
+        # The pre-existing file is left intact: gmat-run did not touch it.
+        assert stale.read_text() == "stale\n"
+        # And RunScript / UseLogFile never ran — the gate fired earlier.
+        assert gmat._log_paths == []
+
+    def test_collision_with_overwrite_clears_and_succeeds(self, tmp_path: Path) -> None:
+        custom = tmp_path / "out"
+        custom.mkdir()
+        existing = custom / "r1.txt"
+        existing.write_text("stale\n", encoding="utf-8")
+        rf = _report_file("R1", "r1.txt")
+        mission, _ = _run_mission(tmp_path, objects={"R1": rf})
+
+        result = mission.run(working_dir=custom, overwrite=True)
+
+        # The colliding file was unlinked before RunScript ran. The fake gmat
+        # never re-creates it (only UseLogFile writes) — its absence post-run
+        # is direct evidence that overwrite=True did its job.
+        assert not existing.exists()
+        assert result.reports._paths == {"R1": existing}  # type: ignore[attr-defined]
+
+    def test_collision_lists_each_offender_in_message(self, tmp_path: Path) -> None:
+        custom = tmp_path / "out"
+        custom.mkdir()
+        (custom / "r1.txt").write_text("a\n", encoding="utf-8")
+        (custom / "e1.eph").write_text("b\n", encoding="utf-8")
+        mission, _ = _run_mission(
+            tmp_path,
+            objects={
+                "R1": _report_file("R1", "r1.txt"),
+                "E1": _ephemeris_file("E1", "e1.eph"),
+            },
+        )
+
+        with pytest.raises(GmatRunError) as excinfo:
+            mission.run(working_dir=custom)
+
+        msg = str(excinfo.value)
+        assert "r1.txt" in msg
+        assert "e1.eph" in msg
+        assert "overwrite=True" in msg
+
+    def test_collision_ignores_outputs_pinned_outside_workspace(self, tmp_path: Path) -> None:
+        # A user-pinned absolute Filename outside working_dir is the user's
+        # destination. Even when a file already exists at that absolute
+        # location, the collision gate is scoped to files *inside*
+        # working_dir and the run proceeds without touching the pinned file.
+        custom = tmp_path / "out"
+        custom.mkdir()
+        elsewhere = tmp_path / "elsewhere" / "report.txt"
+        elsewhere.parent.mkdir()
+        elsewhere.write_text("existing\n", encoding="utf-8")
+        rf = _report_file("R1", str(elsewhere))
+        mission, _ = _run_mission(tmp_path, objects={"R1": rf})
+
+        result = mission.run(working_dir=custom)
+
+        assert elsewhere.read_text() == "existing\n"
+        assert result.reports._paths == {"R1": elsewhere}  # type: ignore[attr-defined]
+
+    def test_default_workspace_skips_collision_gate(self, tmp_path: Path) -> None:
+        # working_dir=None mints a fresh tempdir, so the gate has no work to
+        # do — the test just guards against a regression that would refuse
+        # default-workspace runs.
+        rf = _report_file("R1", "r1.txt")
+        mission, _ = _run_mission(tmp_path, objects={"R1": rf})
+
+        result = mission.run()
+
+        assert (result.output_dir / "r1.txt").parent == result.output_dir
+
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="POSIX-only: chmod 0o400 does not enforce write protection on Windows",
+    )
+    @pytest.mark.skipif(
+        hasattr(os, "geteuid") and os.geteuid() == 0,
+        reason="root bypasses POSIX permission bits, so the writability probe still succeeds",
+    )
+    def test_unwritable_working_dir_raises_before_runscript(self, tmp_path: Path) -> None:
+        custom = tmp_path / "locked"
+        custom.mkdir()
+        custom.chmod(0o400)
+        try:
+            mission, gmat = _run_mission(tmp_path)
+
+            with pytest.raises(GmatRunError) as excinfo:
+                mission.run(working_dir=custom)
+
+            assert "not writable" in str(excinfo.value)
+            assert excinfo.value.path == custom
+            assert excinfo.value.log == ""
+            assert isinstance(excinfo.value.__cause__, OSError)
+            # RunScript / UseLogFile must not have run.
+            assert gmat._log_paths == []
+        finally:
+            # Restore write permission so pytest's tmp_path cleanup can
+            # remove the directory on teardown.
+            custom.chmod(0o700)
+
+    def test_warns_when_working_dir_is_script_dir(self, tmp_path: Path) -> None:
+        # The script lives at tmp_path/scripts/mission.script; pointing
+        # working_dir at tmp_path/scripts means GMAT outputs land alongside
+        # the source. The warning is the load-bearing safety rail — don't
+        # quietly let a user clobber their own script.
+        scripts = tmp_path / "scripts"
+        scripts.mkdir()
+        gmat = _make_fake_gmat()
+        install = _make_install(tmp_path / "gmat")
+        mission = Mission(gmat=gmat, install=install, script_path=scripts / "mission.script")
+
+        with pytest.warns(UserWarning, match="script's own directory"):
+            mission.run(working_dir=scripts)
+
+    def test_no_warning_for_unrelated_working_dir(self, tmp_path: Path) -> None:
+        scripts = tmp_path / "scripts"
+        scripts.mkdir()
+        out = tmp_path / "out"
+        out.mkdir()
+        gmat = _make_fake_gmat()
+        install = _make_install(tmp_path / "gmat")
+        mission = Mission(gmat=gmat, install=install, script_path=scripts / "mission.script")
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            mission.run(working_dir=out)
+
+    def test_outside_workspace_notice_prepended_to_log(self, tmp_path: Path) -> None:
+        # An absolute Filename pinned outside working_dir adds a one-line
+        # notice at the top of the captured log so callers see the trail
+        # without having to walk the path mappings themselves.
+        elsewhere = tmp_path / "elsewhere" / "report.txt"
+        elsewhere.parent.mkdir()
+        rf = _report_file("R1", str(elsewhere))
+        mission, _ = _run_mission(
+            tmp_path,
+            objects={"R1": rf},
+            log_text="GMAT execution complete\n",
+        )
+
+        result = mission.run()
+
+        assert result.log.startswith("[gmat-run] note:")
+        assert str(elsewhere) in result.log
+        # The original GMAT log content is preserved after the prefix line.
+        assert "GMAT execution complete" in result.log
+
+    def test_no_notice_when_every_output_is_inside(self, tmp_path: Path) -> None:
+        rf = _report_file("R1", "r1.txt")
+        mission, _ = _run_mission(
+            tmp_path,
+            objects={"R1": rf},
+            log_text="GMAT execution complete\n",
+        )
+
+        result = mission.run()
+
+        assert "[gmat-run] note:" not in result.log
+        assert result.log == "GMAT execution complete\n"
+
+    def test_forward_slash_relative_filename_resolves_under_workspace(self, tmp_path: Path) -> None:
+        # Regression for Windows-authored scripts that use forward slashes in
+        # a relative ``Filename``. ``Path.name`` strips any leading directory
+        # portion regardless of the platform, so the resolved path lives
+        # directly under the workspace on every OS.
+        rf = _report_file("R1", "outputs/r1.txt")
+        mission, _ = _run_mission(tmp_path, objects={"R1": rf})
+
+        result = mission.run()
+
+        assert result.reports._paths == {  # type: ignore[attr-defined]
+            "R1": result.output_dir / "r1.txt"
+        }
+
+    def test_overwrite_is_a_noop_for_default_workspace(self, tmp_path: Path) -> None:
+        # overwrite=True with a fresh tempdir has nothing to clear; the run
+        # completes normally. Guards against a regression that would gate
+        # the default path on the overwrite flag.
+        mission, _ = _run_mission(tmp_path)
+
+        result = mission.run(overwrite=True)
+
+        assert result.output_dir.is_dir()
 
 
 # --- Mission.attitude_inputs --------------------------------------------------


### PR DESCRIPTION
## Summary

- Add five pre-run gates around an explicit `working_dir=`: pre-existing artefacts (default raise, `overwrite=True` opt-in), writability probe, source-directory `UserWarning`, an out-of-workspace `[gmat-run] note: …` line on `Results.log`, and a regression test pinning forward-slash relative `Filename`s.
- Extend `GmatRunError` with a keyword-only `path: Path | None = None` so callers can branch on the offending location programmatically.
- New `docs/working-directories.md` subpage enumerating the rules; getting-started links to it; `mkdocs.yml` nav updated.

## Test plan

- [x] `uv run pytest` (634 unit tests, 12 new in `TestMissionRunWorkingDir`)
- [x] `uv run pytest -m integration` (15 integration tests, including the new three-run collision test)
- [x] `uv run ruff check && uv run ruff format --check && uv run mypy`
- [x] `uv run coverage report --fail-under=80` and `--include='src/gmat_run/parsers/*' --fail-under=95`
- [x] CI matrix (Ubuntu / Windows / macOS, Python 3.10–3.12)

Closes #69