### PR TITLE
Add Mission.run(timeout=...) with subprocess-based wall-clock cap

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -19,7 +19,7 @@ the top-level usage; `run --help` prints the subcommand's flags.
 ## `gmat-run run`
 
 ```text
-gmat-run run SCRIPT [--out DIR] [--gmat-root PATH]
+gmat-run run SCRIPT [--out DIR] [--gmat-root PATH] [--timeout SECONDS]
 ```
 
 Loads `SCRIPT`, runs its mission sequence headlessly, and prints a one-line
@@ -30,6 +30,7 @@ summary plus a per-output-type breakdown to stdout.
 | `SCRIPT` | Path to a GMAT `.script` file. |
 | `--out DIR` | Persist the run's outputs into `DIR`. The directory is created if missing. Without this flag, GMAT writes into a temporary workspace that is cleaned up when the process exits. |
 | `--gmat-root PATH` | Path to the GMAT install. Overrides discovery and `$GMAT_ROOT`. |
+| `--timeout SECONDS` | Cap the run at `SECONDS` wall-clock. The mission runs in a child process and is killed on timeout (exit code `6`). Without this flag the run is in-process with no cap. See [Timeouts](timeouts.md) for the full semantics. |
 
 ### Sample output
 
@@ -59,6 +60,7 @@ Stable, so shell scripts can branch on failure mode without parsing stderr:
 | `3` | [`GmatLoadError`][gmat_run.GmatLoadError] — `gmatpy` could not be loaded. |
 | `4` | [`GmatRunError`][gmat_run.GmatRunError] — the mission sequence itself failed. |
 | `5` | [`GmatOutputParseError`][gmat_run.GmatOutputParseError] — an output file could not be parsed. |
+| `6` | [`GmatTimeoutError`][gmat_run.GmatTimeoutError] — `--timeout` was set and the child exceeded the wall-clock cap. |
 
 Argparse uses code `2` for argument errors (missing `SCRIPT`, unknown flag).
 That overlaps with `GmatNotFoundError`; the script can disambiguate from

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -83,6 +83,20 @@ guessed at.
   stock R2026a sample missions through this format, and no public tooling
   decodes it; out of scope unless a user need surfaces.
 
+## `Mission.gmat` mutations do not survive `run(timeout=...)`
+
+The [`Mission.gmat`][gmat_run.Mission.gmat] escape hatch lets callers reach
+raw `gmatpy` for graph-level mutations that the dotted-path interface does
+not cover. Those mutations are *not* recorded as overrides — only writes
+through [`Mission.__setitem__`][gmat_run.Mission] are — so they cannot be
+replayed when [`Mission.run`][gmat_run.Mission.run] is called with `timeout=`,
+which executes in a child process that re-loads the script from disk.
+
+A `UserWarning` fires when `timeout=` is passed on a `Mission` whose `gmat`
+property has been touched. If the escape-hatch mutations matter for your
+run, drop the `timeout=` and execute in-process. See [Timeouts](timeouts.md)
+for the full discussion.
+
 ## Epoch promotion is not a time-scale conversion
 
 [`gmat_run.parsers.epoch.promote_epochs`][gmat_run.parsers.epoch.promote_epochs]

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -14,6 +14,8 @@ relevant to their failure mode as attributes (`attempts`, `log`, `path`,
 
 ::: gmat_run.GmatRunError
 
+::: gmat_run.GmatTimeoutError
+
 ::: gmat_run.GmatOutputParseError
 
 ::: gmat_run.GmatFieldError

--- a/docs/timeouts.md
+++ b/docs/timeouts.md
@@ -1,0 +1,109 @@
+# Timeouts and subprocess execution
+
+Long-running propagations, divergent solvers, and hung subscribers can block
+the calling Python process indefinitely. A notebook user has no way out short
+of restarting the kernel — Python signal handlers do not fire inside the
+SWIG-wrapped `gmat.RunScript()` call (which holds the GIL), and Python threads
+cannot be safely killed mid-`gmatpy`.
+
+[`Mission.run`][gmat_run.Mission.run] accepts an opt-in `timeout=` keyword
+that solves this by running the mission in a child Python process and killing
+it if it exceeds the cap.
+
+## Usage
+
+```python
+from gmat_run import Mission, GmatTimeoutError
+
+mission = Mission.load("flyby.script")
+mission["Sat.SMA"] = 7100.0  # overrides applied as usual
+
+try:
+    result = mission.run(timeout=30.0)
+except GmatTimeoutError as exc:
+    print(f"killed after {exc.elapsed:.1f} s; partial log:\n{exc.log}")
+```
+
+`timeout=None` (the default) runs in-process with no cap — no behavior
+change for callers who don't ask for one.
+
+The CLI exposes the same:
+
+```bash
+gmat-run run flyby.script --timeout 30
+```
+
+[Exit code `6`](cli.md#exit-codes) signals a timeout.
+
+## How it works
+
+The parent forwards three things to the child:
+
+- The `script_path` of the loaded `Mission`.
+- Every recorded `__setitem__` write, in dotted-path form, as a JSON object.
+- The resolved workspace path (so `ReportFile`, `EphemerisFile`, and
+  `ContactLocator` outputs land where the parent expects).
+
+The child re-runs `Mission.load`, replays the override writes, and invokes
+the in-process `Mission.run`. The parent waits up to `timeout` seconds via
+`Popen.communicate`. On timeout the parent kills the child's process group
+(POSIX) or the child itself (Windows) and raises
+[`GmatTimeoutError`][gmat_run.GmatTimeoutError]. The error carries the
+requested timeout, the wall-clock elapsed, and any partial GMAT log content
+salvageable from the workspace at kill time.
+
+## Limitations
+
+### Escape-hatch mutations are not replayed
+
+[`Mission.gmat`][gmat_run.Mission.gmat] is an escape hatch for callers who
+need raw `gmatpy` access. Mutations made through it (calling `SetField` on
+a resource directly, walking the registry to flip a flag, etc.) are
+**not** recorded in the override set the parent ships to the child.
+
+If you have touched `mission.gmat` and then call `mission.run(timeout=...)`,
+a `UserWarning` fires:
+
+```text
+UserWarning: Mission.gmat was accessed before run(timeout=...). Mutations
+made through that escape hatch are not replayed in the child process; only
+writes that went through __setitem__ are shipped. The child run may diverge
+from what the in-process path would produce.
+```
+
+If your mutations matter for the run, either move them into `__setitem__`
+calls (the supported path), or run in-process with no `timeout=`.
+
+### Bootstrap cost paid twice
+
+The child re-imports `gmatpy` and re-parses the script. On R2026a this adds
+roughly one to two seconds to the run on top of the timeout itself. Acceptable
+for the timeout case (the alternative is no timeout at all); something to
+keep in mind when picking a `timeout=` value for short-running missions.
+
+### Override values must be JSON-encodable
+
+The parent serialises overrides with `json.dumps(allow_nan=False)`. Every
+value [`Mission.__setitem__`][gmat_run.Mission] accepts (real, integer,
+boolean, string, string-array, real-vector, real-matrix) is already
+JSON-native after the in-process `_coerce` step, so this is transparent
+in practice. `NaN` or `Inf` overrides are rejected at the parent encode
+call rather than silently round-tripping into the child's `SetField`.
+
+### Windows kill is unbuffered
+
+`TerminateProcess` does not flush GMAT's C++ I/O buffers; orphaned files
+in the workspace tempdir are possible after a Windows timeout. The parent
+wipes the workspace anyway, so a hung run does not leak a directory.
+
+## When *not* to use `timeout=`
+
+The in-process path is faster, simpler, and easier to debug. Skip
+`timeout=` when:
+
+- You're running a known-finite mission whose worst-case wall-clock is
+  bounded by something other than a parent-side cap.
+- You need raw `gmatpy` access via [`Mission.gmat`][gmat_run.Mission.gmat]
+  for graph-level mutations that don't go through `__setitem__`.
+- You're driving the engine through your own `gmat.RunScript()` calls
+  outside `Mission.run`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
   - Getting started: getting-started.md
   - Install GMAT: install-gmat.md
   - Working directories: working-directories.md
+  - Timeouts: timeouts.md
   - CLI usage: cli.md
   - Examples:
       - examples/index.md

--- a/src/gmat_run/__init__.py
+++ b/src/gmat_run/__init__.py
@@ -7,6 +7,7 @@ from gmat_run.errors import (
     GmatNotFoundError,
     GmatOutputParseError,
     GmatRunError,
+    GmatTimeoutError,
 )
 from gmat_run.install import GmatInstall, locate_gmat
 from gmat_run.mission import Mission
@@ -23,6 +24,7 @@ __all__ = [
     "GmatNotFoundError",
     "GmatOutputParseError",
     "GmatRunError",
+    "GmatTimeoutError",
     "Mission",
     "Results",
     "__version__",

--- a/src/gmat_run/_subprocess.py
+++ b/src/gmat_run/_subprocess.py
@@ -227,7 +227,7 @@ def child_main(
 
     try:
         status = _run_child(payload)
-    except Exception as exc:  # noqa: BLE001 — top-level handler, surface anything
+    except Exception as exc:
         log = ""
         # GmatRunError carries a log; surface it so the parent can show it.
         if hasattr(exc, "log"):

--- a/src/gmat_run/_subprocess.py
+++ b/src/gmat_run/_subprocess.py
@@ -1,0 +1,284 @@
+"""Subprocess execution for ``Mission.run(timeout=...)``.
+
+Parent-side driver and child-side handler for the wall-clock-cap path. The
+public surface is :meth:`gmat_run.mission.Mission.run` (with ``timeout=``)
+and :class:`~gmat_run.errors.GmatTimeoutError`; the JSON wire format
+between parent and child is intentionally private and not part of the
+package's stable API.
+
+The driver lives here rather than in ``mission.py`` to keep the platform-
+specific process management (``start_new_session`` / ``CREATE_NEW_PROCESS_
+GROUP``, the SIGTERM/SIGKILL ladder) isolated from the in-process run path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from contextlib import suppress
+from pathlib import Path
+from typing import IO, Any
+
+from gmat_run.errors import GmatRunError, GmatTimeoutError
+
+__all__ = ["child_main", "run_in_subprocess"]
+
+# Grace period between SIGTERM and SIGKILL on POSIX. The child gets this
+# much wall-clock time to clean up after the first signal before the
+# parent escalates to an unrecoverable kill.
+_KILL_GRACE_SECONDS = 5.0
+
+
+def run_in_subprocess(
+    *,
+    script_path: Path,
+    overrides: dict[str, Any],
+    workspace_path: Path,
+    overwrite: bool,
+    gmat_root: Path | None,
+    timeout: float,
+    _popen: Any = None,
+) -> dict[str, Any]:
+    """Run a mission in a child Python process and return its status payload.
+
+    The parent serialises the inputs as JSON (``allow_nan=False`` so a NaN
+    or Inf override surfaces here with a usable stack instead of silently
+    landing in the child's ``SetField``), spawns the child via ``-m
+    gmat_run.cli _internal-run``, and waits up to ``timeout`` seconds for it
+    to return. On timeout, the parent kills the entire child process group
+    (POSIX) or the child itself (Windows) and raises
+    :class:`~gmat_run.errors.GmatTimeoutError`. On any other failure mode
+    (non-zero exit, malformed stdout, ``ok=False`` status) the parent
+    raises :class:`~gmat_run.errors.GmatRunError` with the salvaged log.
+
+    ``_popen`` is a test seam — pass a callable matching ``subprocess.Popen``
+    to drive the parent without spawning real processes.
+
+    Returns:
+        Parsed status dict ``{ok, log, report_paths, ephemeris_paths,
+        contact_paths, output_dir}``. The caller (``Mission.run``) builds
+        the :class:`~gmat_run.results.Results`.
+    """
+    payload = {
+        "script": str(script_path),
+        "overrides": overrides,
+        "working_dir": str(workspace_path),
+        "overwrite": overwrite,
+        "gmat_root": str(gmat_root) if gmat_root is not None else None,
+    }
+    payload_bytes = json.dumps(payload, allow_nan=False).encode("utf-8")
+
+    cmd = [sys.executable, "-m", "gmat_run.cli", "_internal-run"]
+    spawn = _popen if _popen is not None else _spawn
+    proc = spawn(cmd)
+
+    started = time.monotonic()
+    try:
+        stdout, stderr = proc.communicate(input=payload_bytes, timeout=timeout)
+    except subprocess.TimeoutExpired:
+        elapsed = time.monotonic() - started
+        _kill_child(proc)
+        log = _salvage_log(workspace_path)
+        raise GmatTimeoutError(
+            f"mission run exceeded {timeout} s timeout (elapsed {elapsed:.2f} s)",
+            log=log,
+            requested_timeout=timeout,
+            elapsed=elapsed,
+        ) from None
+
+    if proc.returncode != 0:
+        log = _salvage_log(workspace_path)
+        message = stderr.decode("utf-8", errors="replace").strip() or "no stderr"
+        raise GmatRunError(
+            f"subprocess exited with code {proc.returncode}: {message}",
+            log=log,
+        )
+
+    try:
+        status: dict[str, Any] = json.loads(stdout.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        log = _salvage_log(workspace_path)
+        raise GmatRunError(
+            f"subprocess returned non-JSON output: {exc}",
+            log=log,
+        ) from exc
+
+    if not status.get("ok", False):
+        raise GmatRunError(
+            status.get("error", "subprocess returned ok=False without an error message"),
+            log=status.get("log", ""),
+        )
+    return status
+
+
+def _spawn(cmd: list[str]) -> subprocess.Popen[bytes]:
+    """Spawn the child with platform-appropriate process-isolation flags.
+
+    POSIX: ``start_new_session=True`` puts the child in a new session so the
+    parent can signal the entire process group together via ``killpg``.
+    Windows: ``CREATE_NEW_PROCESS_GROUP`` allows group-level termination
+    via ``TerminateProcess``; per the issue we accept that buffer flushing
+    may be skipped on the hard-kill path.
+    """
+    if sys.platform == "win32":
+        return subprocess.Popen(
+            cmd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            creationflags=subprocess.CREATE_NEW_PROCESS_GROUP,  # type: ignore[attr-defined]
+        )
+    return subprocess.Popen(
+        cmd,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        start_new_session=True,
+    )
+
+
+def _kill_child(proc: subprocess.Popen[bytes]) -> None:
+    """Escalating-signal kill ladder.
+
+    POSIX: ``SIGTERM`` the process group, wait :data:`_KILL_GRACE_SECONDS`,
+    then ``SIGKILL`` if anything is still alive. Windows: ``terminate()``
+    (= ``TerminateProcess``) — the kernel does not offer a graceful
+    escalation that would respect ``CREATE_NEW_PROCESS_GROUP``, so this is
+    the unrecoverable kill from the start.
+    """
+    if sys.platform == "win32":
+        with suppress(OSError):
+            proc.terminate()
+        with suppress(subprocess.TimeoutExpired):
+            proc.wait(timeout=_KILL_GRACE_SECONDS)
+        return
+
+    pgid = _try_get_pgid(proc.pid)
+    if pgid is not None:
+        with suppress(ProcessLookupError, OSError):
+            os.killpg(pgid, signal.SIGTERM)
+    try:
+        proc.wait(timeout=_KILL_GRACE_SECONDS)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    if pgid is not None:
+        with suppress(ProcessLookupError, OSError):
+            os.killpg(pgid, signal.SIGKILL)
+    with suppress(subprocess.TimeoutExpired):
+        proc.wait(timeout=_KILL_GRACE_SECONDS)
+
+
+def _try_get_pgid(pid: int) -> int | None:
+    try:
+        return os.getpgid(pid)
+    except (ProcessLookupError, OSError):
+        return None
+
+
+def _salvage_log(workspace_path: Path) -> str:
+    """Best-effort read of the child's GmatLog.txt; empty string on any failure.
+
+    GMAT writes its diagnostic output here as soon as ``UseLogFile`` is
+    pointed at the workspace, so even a child killed mid-propagation has
+    likely flushed *something* useful. A missing file (child died before
+    the log handle was redirected) or any I/O error returns ``""`` so the
+    caller can still build a :class:`GmatTimeoutError` without choking.
+    """
+    log_path = workspace_path / "GmatLog.txt"
+    try:
+        return log_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ""
+
+
+# --- child-side handler -------------------------------------------------------
+
+
+def child_main(
+    stdin: IO[bytes] | None = None,
+    stdout: IO[bytes] | None = None,
+) -> int:
+    """Read JSON payload from stdin, run the mission, write status to stdout.
+
+    Returns an exit code intended for the process entry point. ``stdin`` /
+    ``stdout`` parameters exist for testability — the default uses the
+    real process streams via ``sys.stdin.buffer`` / ``sys.stdout.buffer``.
+    Failures in the handler itself (malformed payload, exception during
+    load/run) are reported as ``{"ok": false, "error": ..., "log": ...}``
+    on stdout with a non-zero exit code, so the parent can surface them
+    in :class:`~gmat_run.errors.GmatRunError`.
+    """
+    if stdin is None:
+        stdin = sys.stdin.buffer
+    if stdout is None:
+        stdout = sys.stdout.buffer
+
+    payload_bytes = stdin.read()
+    try:
+        payload = json.loads(payload_bytes.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        _emit_error(stdout, f"invalid stdin payload: {exc}", "")
+        return 1
+
+    try:
+        status = _run_child(payload)
+    except Exception as exc:  # noqa: BLE001 — top-level handler, surface anything
+        log = ""
+        # GmatRunError carries a log; surface it so the parent can show it.
+        if hasattr(exc, "log"):
+            log_attr = getattr(exc, "log", "")
+            if isinstance(log_attr, str):
+                log = log_attr
+        _emit_error(stdout, f"{type(exc).__name__}: {exc}", log)
+        return 1
+
+    stdout.write(json.dumps(status, allow_nan=False).encode("utf-8"))
+    stdout.flush()
+    return 0
+
+
+def _run_child(payload: dict[str, Any]) -> dict[str, Any]:
+    """Apply ``payload`` to a fresh :class:`Mission` and return a status dict.
+
+    The handler walks the in-process ``Mission.load`` → ``__setitem__`` →
+    ``run`` pipeline exactly as a notebook user would; the wall-clock cap
+    is enforced by the parent, not here.
+    """
+    # Late import — keeps the parent process from paying the gmatpy
+    # bootstrap cost just because it imported the driver.
+    from gmat_run.mission import Mission
+
+    script = payload["script"]
+    overrides: dict[str, Any] = payload.get("overrides", {})
+    working_dir = payload.get("working_dir")
+    overwrite: bool = bool(payload.get("overwrite", False))
+    gmat_root = payload.get("gmat_root")
+
+    mission = Mission.load(script, gmat_root=gmat_root)
+    for dotted, value in overrides.items():
+        mission[dotted] = value
+    result = mission.run(working_dir=working_dir, overwrite=overwrite)
+
+    # `Results` exposes ephemeris_paths / contact_paths publicly; the
+    # report-path mapping lives on the lazy `reports` view as `_paths`.
+    # Asymmetric, but matches the existing public surface.
+    report_paths: dict[str, Path] = result.reports._paths  # type: ignore[attr-defined]
+    return {
+        "ok": True,
+        "log": result.log,
+        "report_paths": {k: str(v) for k, v in report_paths.items()},
+        "ephemeris_paths": {k: str(v) for k, v in result.ephemeris_paths.items()},
+        "contact_paths": {k: str(v) for k, v in result.contact_paths.items()},
+        "output_dir": str(result.output_dir),
+    }
+
+
+def _emit_error(stdout: IO[bytes], error: str, log: str) -> None:
+    payload = {"ok": False, "error": error, "log": log}
+    stdout.write(json.dumps(payload, allow_nan=False).encode("utf-8"))
+    stdout.flush()

--- a/src/gmat_run/cli.py
+++ b/src/gmat_run/cli.py
@@ -115,7 +115,7 @@ def _build_parser() -> argparse.ArgumentParser:
     # subcommand name still appears in the usage line's choice set; argparse
     # has no clean way to hide that and it's acceptable for an internal name.
     subparsers.add_parser("_internal-run", help=argparse.SUPPRESS)
-    subparsers._choices_actions.pop()  # type: ignore[attr-defined]
+    subparsers._choices_actions.pop()
     return parser
 
 

--- a/src/gmat_run/cli.py
+++ b/src/gmat_run/cli.py
@@ -47,6 +47,12 @@ def main(argv: list[str] | None = None) -> int:
     """
     parser = _build_parser()
     args = parser.parse_args(argv)
+    if args.command == "_internal-run":
+        # Late import — keeps `gmat-run --help` from pulling subprocess
+        # plumbing it does not need.
+        from gmat_run._subprocess import child_main
+
+        return child_main()
     return _run(script=args.script, out=args.out, gmat_root=args.gmat_root)
 
 
@@ -83,6 +89,15 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Path to the GMAT install. Overrides discovery and $GMAT_ROOT.",
     )
+    # Hidden child-process entry point used by Mission.run(timeout=...). Not
+    # part of the public CLI surface — it reads a JSON payload on stdin and
+    # writes a status JSON on stdout. ``help=SUPPRESS`` alone leaks
+    # ``==SUPPRESS==`` into ``--help`` output (argparse quirk); popping the
+    # last pseudo-action removes the description row entirely. The
+    # subcommand name still appears in the usage line's choice set; argparse
+    # has no clean way to hide that and it's acceptable for an internal name.
+    subparsers.add_parser("_internal-run", help=argparse.SUPPRESS)
+    subparsers._choices_actions.pop()  # type: ignore[attr-defined]
     return parser
 
 
@@ -139,3 +154,9 @@ def _print_section(label: str, frames: Mapping[str, pd.DataFrame]) -> None:
         # is the place to actually count rows. Callers that want the path
         # without parsing can still reach result.report_paths from Python.
         print(f"  {name}: {len(frames[name])} rows")
+
+
+# Allows `python -m gmat_run.cli ...`, which is how the subprocess driver
+# in `gmat_run._subprocess` invokes the hidden `_internal-run` subcommand.
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/gmat_run/cli.py
+++ b/src/gmat_run/cli.py
@@ -19,6 +19,7 @@ from gmat_run.errors import (
     GmatNotFoundError,
     GmatOutputParseError,
     GmatRunError,
+    GmatTimeoutError,
 )
 from gmat_run.mission import Mission
 
@@ -36,6 +37,7 @@ EXIT_NOT_FOUND = 2
 EXIT_LOAD = 3
 EXIT_RUN = 4
 EXIT_PARSE = 5
+EXIT_TIMEOUT = 6
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -53,7 +55,12 @@ def main(argv: list[str] | None = None) -> int:
         from gmat_run._subprocess import child_main
 
         return child_main()
-    return _run(script=args.script, out=args.out, gmat_root=args.gmat_root)
+    return _run(
+        script=args.script,
+        out=args.out,
+        gmat_root=args.gmat_root,
+        timeout=args.timeout,
+    )
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -89,6 +96,17 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="Path to the GMAT install. Overrides discovery and $GMAT_ROOT.",
     )
+    run_parser.add_argument(
+        "--timeout",
+        metavar="SECONDS",
+        type=float,
+        default=None,
+        help=(
+            "Cap the run at SECONDS wall-clock. Mission runs in a child "
+            "process and is killed on timeout (exit code 6). Without this "
+            "flag the run is in-process with no cap."
+        ),
+    )
     # Hidden child-process entry point used by Mission.run(timeout=...). Not
     # part of the public CLI surface — it reads a JSON payload on stdin and
     # writes a status JSON on stdout. ``help=SUPPRESS`` alone leaks
@@ -101,10 +119,16 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _run(*, script: str, out: str | None, gmat_root: str | None) -> int:
+def _run(
+    *,
+    script: str,
+    out: str | None,
+    gmat_root: str | None,
+    timeout: float | None,
+) -> int:
     try:
         mission = Mission.load(script, gmat_root=gmat_root)
-        result = mission.run()
+        result = mission.run(timeout=timeout)
         if out is not None:
             result.persist(out)
         _print_summary(
@@ -119,6 +143,11 @@ def _run(*, script: str, out: str | None, gmat_root: str | None) -> int:
     except GmatLoadError as exc:
         print(f"gmat-run: {exc}", file=sys.stderr)
         return EXIT_LOAD
+    # GmatTimeoutError is a GmatRunError subclass — catch it first so the
+    # narrower mapping wins.
+    except GmatTimeoutError as exc:
+        print(f"gmat-run: {exc}", file=sys.stderr)
+        return EXIT_TIMEOUT
     except GmatRunError as exc:
         print(f"gmat-run: {exc}", file=sys.stderr)
         return EXIT_RUN

--- a/src/gmat_run/errors.py
+++ b/src/gmat_run/errors.py
@@ -92,3 +92,31 @@ class GmatFieldError(GmatError):
         self.path = path
         self.value = value
         super().__init__(message)
+
+
+class GmatTimeoutError(GmatRunError):
+    """Raised when ``Mission.run(timeout=...)`` exceeds its wall-clock cap.
+
+    A subclass of :class:`GmatRunError` so callers that already branch on
+    "the run failed" keep working — narrower handlers can catch this first
+    to distinguish a timeout from an engine-side failure.
+
+    Carries the ``requested_timeout`` (the cap the caller asked for, in
+    seconds) and ``elapsed`` (the wall-clock time the parent observed before
+    killing the child). The inherited ``log`` carries any partial GMAT log
+    content readable from the workspace at kill time, or ``""`` if nothing
+    was salvageable. ``path`` is unset — a timeout is not wired to a
+    specific filesystem location.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        log: str,
+        *,
+        requested_timeout: float,
+        elapsed: float,
+    ) -> None:
+        self.requested_timeout = requested_timeout
+        self.elapsed = elapsed
+        super().__init__(message, log=log)

--- a/src/gmat_run/mission.py
+++ b/src/gmat_run/mission.py
@@ -120,6 +120,7 @@ class Mission:
     _attitude_input_paths: dict[str, Path] | None
     _attitude_inputs: _LazyAttitudeInputs | None
     _overrides: dict[str, Any]
+    _gmat_accessed: bool
 
     def __init__(
         self,
@@ -143,6 +144,13 @@ class Mission:
         # value is post-_coerce, so it's always a JSON-native Python type and
         # can be shipped to a child process verbatim.
         self._overrides = {}
+        # One-shot flag: set the first time the ``gmat`` property is touched
+        # and never cleared. ``run(timeout=...)`` reads this to decide whether
+        # to warn that escape-hatch mutations may not survive the subprocess
+        # re-load. We deliberately don't track "since last __setitem__" — any
+        # access at all makes the override set incomplete from the child's
+        # point of view.
+        self._gmat_accessed = False
 
     @classmethod
     def load(
@@ -237,6 +245,7 @@ class Mission:
         stable public surface — the documented contract is the dotted-path
         ``__getitem__`` / ``__setitem__`` interface.
         """
+        self._gmat_accessed = True
         return self._gmat
 
     def __getitem__(self, dotted: str) -> Any:

--- a/src/gmat_run/mission.py
+++ b/src/gmat_run/mission.py
@@ -244,6 +244,15 @@ class Mission:
         Escape hatch for callers that need raw SWIG access. Not part of the
         stable public surface — the documented contract is the dotted-path
         ``__getitem__`` / ``__setitem__`` interface.
+
+        **Mutations through this escape hatch do not survive
+        :meth:`run` ``(timeout=...)``.** Only writes that go through
+        ``__setitem__`` are recorded in the override set the parent ships
+        to the child process; raw graph mutations are lost when the child
+        re-loads the script from disk. Touching this property flips a flag
+        that causes ``run(timeout=...)`` to emit a :class:`UserWarning`
+        flagging the override set as incomplete; if the mutations matter,
+        run in-process (omit ``timeout``).
         """
         self._gmat_accessed = True
         return self._gmat

--- a/src/gmat_run/mission.py
+++ b/src/gmat_run/mission.py
@@ -279,6 +279,7 @@ class Mission:
         *,
         working_dir: str | os.PathLike[str] | None = None,
         overwrite: bool = False,
+        timeout: float | None = None,
     ) -> Results:
         """Execute the loaded mission sequence and return a :class:`Results`.
 
@@ -287,6 +288,17 @@ class Mission:
         isolated temp directory when ``None``), runs ``gmat.RunScript()``, and
         builds a :class:`Results` populated with the resolved output paths and
         the captured log.
+
+        **Wall-clock timeout.** Pass ``timeout=`` to cap the run at a fixed
+        number of seconds. The mission is executed in a child Python process
+        and killed if it exceeds the cap; on timeout
+        :class:`~gmat_run.errors.GmatTimeoutError` is raised. Mutations made
+        through :attr:`gmat` (the escape hatch) are *not* replayed in the
+        child — only writes that went through ``__setitem__`` are recorded
+        and shipped. A :class:`UserWarning` fires when ``timeout=`` is set
+        on a :class:`Mission` whose :attr:`gmat` property has been touched,
+        since the override set is then incomplete from the child's point of
+        view.
 
         **Filename rewrite.** A relative ``Filename`` on an output subscriber
         is rewritten to an absolute path inside ``working_dir`` before the
@@ -337,6 +349,13 @@ class Mission:
                 :class:`~gmat_run.errors.GmatRunError`. Ignored when
                 ``working_dir`` is ``None`` (a fresh temp directory cannot
                 contain colliding artefacts).
+            timeout: When set, run the mission in a child process and kill
+                it after this many wall-clock seconds. ``None`` (the default)
+                runs in-process with no cap. A child re-runs ``Mission.load``
+                from ``script_path`` and replays every recorded
+                ``__setitem__`` against it before invoking ``RunScript``;
+                expect a one- to two-second bootstrap overhead vs. the
+                in-process path.
 
         Raises:
             GmatRunError: ``RunScript`` returned a non-success status, raised
@@ -346,11 +365,31 @@ class Mission:
                 captured log is attached via ``GmatRunError.log`` (empty for
                 pre-run gate failures); the offending directory or file is
                 attached via ``GmatRunError.path``.
+            GmatTimeoutError: ``timeout`` was set and the child exceeded the
+                wall-clock cap. The partial GMAT log is attached via
+                ``GmatTimeoutError.log`` (empty if the kill raced the log
+                handle).
         """
         workspace_path, tempdir = _prepare_workspace(working_dir)
         if working_dir is not None:
             self._warn_if_workspace_is_script_dir(workspace_path)
+        if timeout is not None:
+            return self._run_in_subprocess(
+                workspace_path,
+                tempdir,
+                overwrite=overwrite,
+                timeout=timeout,
+            )
+        return self._run_in_process(workspace_path, tempdir, overwrite=overwrite)
 
+    def _run_in_process(
+        self,
+        workspace_path: Path,
+        tempdir: tempfile.TemporaryDirectory[str] | None,
+        *,
+        overwrite: bool,
+    ) -> Results:
+        """Run the mission against the in-process gmatpy module."""
         # Walk every output subscriber once: bucket the paths and rewrite each
         # relative Filename to an absolute path inside the workspace so GMAT
         # writes where we expect. This sidesteps FileManager.OUTPUT_PATH /
@@ -417,6 +456,72 @@ class Mission:
         # See project memory `gmat-run Mission.run temp-dir lifetime ties to
         # Results`: the temp dir must outlive Mission.run so lazy report
         # parsing on `result.reports[name]` still finds the file on disk.
+        results._workspace = tempdir
+        return results
+
+    def _run_in_subprocess(
+        self,
+        workspace_path: Path,
+        tempdir: tempfile.TemporaryDirectory[str] | None,
+        *,
+        overwrite: bool,
+        timeout: float,
+    ) -> Results:
+        """Run the mission in a child process under a wall-clock cap.
+
+        Re-loads the script in the child, replays the recorded ``_overrides``
+        via ``__setitem__``, and invokes ``Mission.run`` (without timeout)
+        there. The child writes its outputs into ``workspace_path`` so the
+        parent can build a :class:`Results` against the same paths. On
+        timeout the parent kills the child's process group / process and
+        raises :class:`GmatTimeoutError`; the workspace tempdir is cleaned
+        up here so a hung run does not leak a directory.
+        """
+        # Late import — avoids a top-of-module dependency on subprocess
+        # plumbing for the in-process path that the vast majority of
+        # callers will use.
+        from gmat_run import _subprocess
+
+        if self._gmat_accessed:
+            warnings.warn(
+                "Mission.gmat was accessed before run(timeout=...). Mutations "
+                "made through that escape hatch are not replayed in the child "
+                "process; only writes that went through __setitem__ are "
+                "shipped. The child run may diverge from what the in-process "
+                "path would produce.",
+                UserWarning,
+                stacklevel=4,
+            )
+
+        try:
+            status = _subprocess.run_in_subprocess(
+                script_path=self.script_path,
+                overrides=self._overrides,
+                workspace_path=workspace_path,
+                overwrite=overwrite,
+                gmat_root=self.install.root,
+                timeout=timeout,
+            )
+        except BaseException:
+            # On any failure (timeout, engine error, malformed payload),
+            # release a tempdir we own — the child is gone and nothing else
+            # will clean up on our behalf. A user-supplied working_dir is
+            # left intact (their directory, their choice).
+            if tempdir is not None:
+                with suppress(OSError):
+                    tempdir.cleanup()
+            raise
+
+        report_paths = {k: Path(v) for k, v in status.get("report_paths", {}).items()}
+        ephemeris_paths = {k: Path(v) for k, v in status.get("ephemeris_paths", {}).items()}
+        contact_paths = {k: Path(v) for k, v in status.get("contact_paths", {}).items()}
+        results = Results(
+            output_dir=workspace_path,
+            log=status.get("log", ""),
+            report_paths=report_paths,
+            ephemeris_paths=ephemeris_paths,
+            contact_paths=contact_paths,
+        )
         results._workspace = tempdir
         return results
 

--- a/src/gmat_run/mission.py
+++ b/src/gmat_run/mission.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from types import MappingProxyType, ModuleType
 from typing import Any, Final
 
+import numpy as np
 import pandas as pd
 
 from gmat_run.errors import GmatFieldError, GmatLoadError, GmatRunError
@@ -118,6 +119,7 @@ class Mission:
     _type_map: dict[int, str]
     _attitude_input_paths: dict[str, Path] | None
     _attitude_inputs: _LazyAttitudeInputs | None
+    _overrides: dict[str, Any]
 
     def __init__(
         self,
@@ -137,6 +139,10 @@ class Mission:
         # snapshot at first access matches the rest of the surface.
         self._attitude_input_paths = None
         self._attitude_inputs = None
+        # Records every successful __setitem__ as ``{dotted: coerced}``. The
+        # value is post-_coerce, so it's always a JSON-native Python type and
+        # can be shipped to a child process verbatim.
+        self._overrides = {}
 
     @classmethod
     def load(
@@ -257,6 +263,7 @@ class Mission:
                 dotted,
                 value,
             ) from exc
+        self._overrides[dotted] = coerced
 
     def run(
         self,
@@ -617,6 +624,11 @@ class Mission:
         return str(obj.GetField(field))
 
     def _coerce(self, type_code: int, value: Any, dotted: str) -> Any:
+        # Strip numpy first so the type checks below see native Python types.
+        # Notebook users routinely pass np.float64 / np.int64 / np.bool_ /
+        # ndarray without thinking — the alternative is a confusing rejection
+        # for what looks like a valid number/array.
+        value = _strip_numpy(value)
         kind = self._type_map.get(type_code, "string")
         if kind == "real":
             if isinstance(value, bool) or not isinstance(value, (int, float)):
@@ -671,6 +683,27 @@ class Mission:
 
 
 # --- module-level helpers -----------------------------------------------------
+
+
+def _strip_numpy(value: Any) -> Any:
+    """Recursively convert numpy scalars/arrays into native Python types.
+
+    Handles three shapes the issue commits to: ``numpy.bool_`` / numpy scalar
+    dtypes (via ``.item()``), ``numpy.ndarray`` (via ``.tolist()``, which
+    recursively yields native types), and Python lists/tuples that may
+    contain numpy elements (walk and convert in place). Anything else is
+    returned untouched so the rest of ``_coerce``'s type checks fire as
+    written.
+    """
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, list):
+        return [_strip_numpy(v) for v in value]
+    if isinstance(value, tuple):
+        return tuple(_strip_numpy(v) for v in value)
+    return value
 
 
 def _split_path(dotted: str, *, value: Any = None) -> tuple[str, str]:

--- a/tests/integration/test_timeout.py
+++ b/tests/integration/test_timeout.py
@@ -1,0 +1,124 @@
+"""End-to-end tests for ``Mission.run(timeout=...)`` against a real GMAT install.
+
+These exercise the real subprocess path: parent spawns a child via
+``-m gmat_run.cli _internal-run``, which boots gmatpy, loads the script,
+applies overrides, and runs. The driver and the child handler are
+unit-tested in :mod:`tests.test_subprocess`; this suite covers the path
+nothing else can — the full Popen → child → gmatpy → kill round-trip.
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from gmat_run import Mission
+from gmat_run.errors import GmatTimeoutError
+
+pytestmark = pytest.mark.integration
+
+
+# A minimal mission that propagates for 1e9 seconds (~31 years). Even the
+# fastest integrator step rate cannot finish this in any wall-clock window
+# the test cares about, so a parent-side timeout will always fire first.
+# Same shape as ``tests.integration.test_smoke._MINIMAL_SCRIPT`` so any
+# discovery / bootstrap wiring shared between the two stays exercised.
+_HANGING_SCRIPT = """\
+Create Spacecraft Sat
+Sat.DateFormat = UTCGregorian
+Sat.Epoch = '01 Jan 2026 12:00:00.000'
+Sat.CoordinateSystem = EarthMJ2000Eq
+Sat.DisplayStateType = Keplerian
+Sat.SMA = 7000
+Sat.ECC = 0.001
+Sat.INC = 28.5
+Sat.RAAN = 75
+Sat.AOP = 90
+Sat.TA = 0
+
+Create ForceModel FM
+FM.CentralBody = Earth
+FM.PrimaryBodies = {Earth}
+
+Create Propagator Prop
+Prop.FM = FM
+Prop.Type = PrinceDormand78
+Prop.InitialStepSize = 1
+Prop.Accuracy = 1e-12
+
+Create ReportFile RF
+RF.Filename = 'hanging.txt'
+RF.Add = {Sat.UTCGregorian, Sat.X}
+
+BeginMissionSequence
+Propagate Prop(Sat) {Sat.ElapsedSecs = 1e9}
+"""
+
+
+@pytest.fixture
+def hanging_script(tmp_path: Path) -> Path:
+    script_path = tmp_path / "hanging.script"
+    script_path.write_text(_HANGING_SCRIPT, encoding="utf-8")
+    return script_path
+
+
+def test_timeout_raises_gmat_timeout_error_within_wall_clock_window(
+    gmat_available: None,
+    hanging_script: Path,
+) -> None:
+    """A 2 s timeout on a 1e9 s propagation raises within ~5 s wall-clock.
+
+    Generous upper bound because Windows / macOS CI runners cold-start the
+    gmatpy bootstrap inside the child and that adds ~1–2 s on top of the
+    timeout itself. The 5 s ceiling still catches a runaway parent that
+    failed to kill the child.
+    """
+    mission = Mission.load(hanging_script)
+    started = time.monotonic()
+    with pytest.raises(GmatTimeoutError) as excinfo:
+        mission.run(timeout=2.0)
+    elapsed = time.monotonic() - started
+
+    assert excinfo.value.requested_timeout == 2.0
+    # The exception's reported elapsed should match the parent's measurement
+    # to within a small tolerance — both are wall-clock from the same start.
+    assert excinfo.value.elapsed == pytest.approx(elapsed, abs=1.0)
+    # Hard ceiling — if this trips, the kill ladder isn't reaping the child.
+    assert elapsed < 5.0
+
+
+def test_timeout_subprocess_path_runs_finite_mission_to_completion(
+    gmat_available: None,
+    tmp_path: Path,
+) -> None:
+    """A finite mission with ``timeout=`` returns a populated :class:`Results`.
+
+    Cross-check that the subprocess path is not just for hanging scripts —
+    a normal mission completes inside its cap and yields a Results that
+    looks like the in-process run's. The DataFrames-byte-equal comparison
+    against the in-process path is covered by the broader regression suite;
+    here we just confirm round-trip.
+    """
+    import pandas as pd
+
+    script_path = tmp_path / "finite.script"
+    script_path.write_text(
+        # 600 s propagation — same as test_smoke's _MINIMAL_SCRIPT.
+        _HANGING_SCRIPT.replace("Sat.ElapsedSecs = 1e9", "Sat.ElapsedSecs = 600")
+        .replace("Prop.InitialStepSize = 1", "Prop.InitialStepSize = 60")
+        .replace("hanging.txt", "finite.txt"),
+        encoding="utf-8",
+    )
+
+    mission = Mission.load(script_path)
+    result = mission.run(timeout=60.0)
+
+    assert list(result.reports) == ["RF"]
+    df = result.reports["RF"]
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) >= 2
+    assert "Sat.UTCGregorian" in df.columns
+    assert isinstance(result.log, str)
+    assert len(result.log) > 0

--- a/tests/integration/test_timeout.py
+++ b/tests/integration/test_timeout.py
@@ -71,7 +71,7 @@ def test_timeout_raises_gmat_timeout_error_within_wall_clock_window(
     """A 2 s timeout on a 1e9 s propagation raises within ~5 s wall-clock.
 
     Generous upper bound because Windows / macOS CI runners cold-start the
-    gmatpy bootstrap inside the child and that adds ~1–2 s on top of the
+    gmatpy bootstrap inside the child and that adds ~1-2 s on top of the
     timeout itself. The 5 s ceiling still catches a runaway parent that
     failed to kill the child.
     """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,6 +22,7 @@ from gmat_run.errors import (
     GmatNotFoundError,
     GmatOutputParseError,
     GmatRunError,
+    GmatTimeoutError,
 )
 
 # --- fakes -------------------------------------------------------------------
@@ -51,6 +52,7 @@ class _FakeMission:
     """Mission stand-in that records ``load`` arguments and returns a result."""
 
     last_load: tuple[str, str | None] | None = None
+    last_run_timeout: float | None = None
     next_result: _FakeResult | None = None
     load_raises: BaseException | None = None
     run_raises: BaseException | None = None
@@ -66,7 +68,8 @@ class _FakeMission:
             raise load_raises
         return cls(path)
 
-    def run(self) -> _FakeResult:
+    def run(self, *, timeout: float | None = None) -> _FakeResult:
+        type(self).last_run_timeout = timeout
         run_raises = type(self).run_raises
         if run_raises is not None:
             raise run_raises
@@ -78,11 +81,13 @@ class _FakeMission:
 @pytest.fixture(autouse=True)
 def _reset_fake() -> Iterator[None]:
     _FakeMission.last_load = None
+    _FakeMission.last_run_timeout = None
     _FakeMission.next_result = None
     _FakeMission.load_raises = None
     _FakeMission.run_raises = None
     yield
     _FakeMission.last_load = None
+    _FakeMission.last_run_timeout = None
     _FakeMission.next_result = None
     _FakeMission.load_raises = None
     _FakeMission.run_raises = None
@@ -225,6 +230,29 @@ def test_run_passes_gmat_root_to_load(
     assert patch_mission.last_load == ("flyby.script", "/opt/gmat-R2026a")
 
 
+def test_run_without_timeout_passes_none(
+    patch_mission: type[_FakeMission],
+    tmp_path: Path,
+) -> None:
+    patch_mission.next_result = _FakeResult(tmp_path)
+
+    cli.main(["run", "flyby.script"])
+
+    assert patch_mission.last_run_timeout is None
+
+
+def test_run_passes_timeout_to_mission(
+    patch_mission: type[_FakeMission],
+    tmp_path: Path,
+) -> None:
+    patch_mission.next_result = _FakeResult(tmp_path)
+
+    code = cli.main(["run", "flyby.script", "--timeout", "30"])
+
+    assert code == cli.EXIT_OK
+    assert patch_mission.last_run_timeout == 30.0
+
+
 # --- exit-code mapping -------------------------------------------------------
 
 
@@ -263,6 +291,26 @@ def test_gmat_run_error_maps_to_exit_4(
 
     assert code == cli.EXIT_RUN == 4
     assert "solver did not converge" in capsys.readouterr().err
+
+
+def test_gmat_timeout_error_maps_to_exit_6(
+    patch_mission: type[_FakeMission],
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    # GmatTimeoutError is a GmatRunError subclass; the CLI must catch it
+    # first so the narrower exit code (6) wins over the generic 4.
+    patch_mission.run_raises = GmatTimeoutError(
+        "mission run exceeded 2.0 s timeout",
+        log="partial\n",
+        requested_timeout=2.0,
+        elapsed=2.5,
+    )
+
+    code = cli.main(["run", "flyby.script", "--timeout", "2"])
+
+    assert code == cli.EXIT_TIMEOUT == 6
+    assert "exceeded 2.0 s timeout" in capsys.readouterr().err
 
 
 def test_gmat_output_parse_error_maps_to_exit_5(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -109,7 +109,14 @@ def test_top_level_help_exits_zero(capsys: pytest.CaptureFixture[str]) -> None:
     with pytest.raises(SystemExit) as info:
         cli.main(["--help"])
     assert info.value.code == 0
-    assert "run" in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert "run" in out
+    # The _internal-run description row must be suppressed: argparse leaks
+    # the literal "==SUPPRESS==" placeholder unless we pop the pseudo-action,
+    # and a stray placeholder advertises the wire format the subcommand
+    # exists to hide. (The name still appears in the usage choice set —
+    # argparse has no clean way to hide that, and it's acceptable.)
+    assert "==SUPPRESS==" not in out
 
 
 def test_run_help_exits_zero(capsys: pytest.CaptureFixture[str]) -> None:
@@ -315,3 +322,23 @@ def test_entrypoint_module_target() -> None:
     import gmat_run.cli
 
     assert callable(gmat_run.cli.main)
+
+
+def test_internal_run_subcommand_dispatches_to_child_main(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The hidden subcommand must route to the subprocess child handler so
+    # `Mission.run(timeout=...)` can spawn `python -m gmat_run.cli
+    # _internal-run` and have it work. The handler reads stdin / writes
+    # stdout in production; we just confirm the dispatch by stubbing it.
+    called = False
+
+    def _stub() -> int:
+        nonlocal called
+        called = True
+        return 0
+
+    monkeypatch.setattr("gmat_run._subprocess.child_main", _stub)
+    code = cli.main(["_internal-run"])
+    assert code == 0
+    assert called is True

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -18,6 +18,7 @@ from gmat_run.errors import (
     GmatNotFoundError,
     GmatOutputParseError,
     GmatRunError,
+    GmatTimeoutError,
 )
 
 _CONCRETE_CLASSES = [
@@ -26,6 +27,7 @@ _CONCRETE_CLASSES = [
     GmatRunError,
     GmatOutputParseError,
     GmatFieldError,
+    GmatTimeoutError,
 ]
 
 
@@ -93,3 +95,36 @@ def test_gmat_field_error_defaults_value_to_none_for_reads() -> None:
 def test_gmat_field_error_preserves_arbitrary_value_types(value: object) -> None:
     exc = GmatFieldError("type mismatch", "Sat.SMA", value)
     assert exc.value == value
+
+
+# --- GmatTimeoutError ---------------------------------------------------------
+
+
+def test_gmat_timeout_error_subclasses_gmat_run_error() -> None:
+    # Callers that branch on "the run failed" must still match a timeout.
+    assert issubclass(GmatTimeoutError, GmatRunError)
+
+
+def test_gmat_timeout_error_preserves_payload() -> None:
+    exc = GmatTimeoutError(
+        "mission run exceeded 2.0 s timeout",
+        "GMAT: integrating step 12345...\n",
+        requested_timeout=2.0,
+        elapsed=2.7,
+    )
+    assert exc.requested_timeout == 2.0
+    assert exc.elapsed == 2.7
+    assert exc.log == "GMAT: integrating step 12345...\n"
+    assert exc.path is None
+    assert str(exc) == "mission run exceeded 2.0 s timeout"
+
+
+def test_gmat_timeout_error_accepts_empty_log() -> None:
+    # The kill may race the workspace teardown; an empty log is normal.
+    exc = GmatTimeoutError(
+        "killed",
+        "",
+        requested_timeout=1.0,
+        elapsed=1.5,
+    )
+    assert exc.log == ""

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -472,6 +472,22 @@ def test_gmat_property_is_read_only(mission: Mission) -> None:
         mission.gmat = object()  # type: ignore[misc, assignment]
 
 
+def test_gmat_property_access_flips_gmat_accessed_flag(mission: Mission) -> None:
+    assert mission._gmat_accessed is False
+    _ = mission.gmat
+    assert mission._gmat_accessed is True
+
+
+def test_gmat_accessed_flag_is_one_shot(mission: Mission) -> None:
+    # Once flipped, the flag stays True regardless of subsequent setitem
+    # calls — any access makes the override set incomplete from the child's
+    # point of view, and we don't try to be clever about "since the last
+    # supported mutation".
+    _ = mission.gmat
+    mission["Sat.SMA"] = 7100.0
+    assert mission._gmat_accessed is True
+
+
 # --- read path: type dispatch (Spacecraft / Propagator / ImpulsiveBurn) -------
 
 

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -1392,6 +1392,177 @@ def _make_mission_with_attitude(
     return Mission(gmat=gmat, install=install, script_path=script_dir / "mission.script")
 
 
+class TestMissionRunTimeout:
+    """``Mission.run(timeout=...)`` dispatches to the subprocess driver.
+
+    The driver itself is unit-tested in ``test_subprocess.py``; here we
+    exercise the dispatch logic — that the right arguments flow through,
+    the recorded ``_overrides`` are passed, the `_gmat_accessed` warning
+    fires when appropriate, and the resulting :class:`Results` is built
+    from the status dict the driver returns.
+    """
+
+    def test_run_with_timeout_calls_subprocess_driver(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from gmat_run import _subprocess as sub
+
+        captured: dict[str, Any] = {}
+
+        def _fake_run(**kwargs: Any) -> dict[str, Any]:
+            captured.update(kwargs)
+            return {
+                "ok": True,
+                "log": "ran in child\n",
+                "report_paths": {},
+                "ephemeris_paths": {},
+                "contact_paths": {},
+                "output_dir": str(kwargs["workspace_path"]),
+            }
+
+        monkeypatch.setattr(sub, "run_in_subprocess", _fake_run)
+
+        mission, _ = _run_mission(tmp_path, objects={"Sat": _spacecraft()})
+        mission["Sat.SMA"] = 7100.0  # populates _overrides
+        result = mission.run(timeout=5.0)
+
+        assert isinstance(result, Results)
+        assert result.log == "ran in child\n"
+        assert captured["script_path"] == mission.script_path
+        assert captured["overrides"] == {"Sat.SMA": 7100.0}
+        assert captured["timeout"] == 5.0
+        assert captured["overwrite"] is False
+
+    def test_run_with_timeout_warns_when_gmat_accessed(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from gmat_run import _subprocess as sub
+
+        monkeypatch.setattr(
+            sub,
+            "run_in_subprocess",
+            lambda **_kwargs: {
+                "ok": True,
+                "log": "",
+                "report_paths": {},
+                "ephemeris_paths": {},
+                "contact_paths": {},
+                "output_dir": "",
+            },
+        )
+
+        mission, _ = _run_mission(tmp_path)
+        _ = mission.gmat  # flips _gmat_accessed
+
+        with pytest.warns(UserWarning, match="Mission.gmat was accessed"):
+            mission.run(timeout=2.0)
+
+    def test_run_with_timeout_does_not_warn_when_gmat_not_accessed(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from gmat_run import _subprocess as sub
+
+        monkeypatch.setattr(
+            sub,
+            "run_in_subprocess",
+            lambda **_kwargs: {
+                "ok": True,
+                "log": "",
+                "report_paths": {},
+                "ephemeris_paths": {},
+                "contact_paths": {},
+                "output_dir": "",
+            },
+        )
+
+        mission, _ = _run_mission(tmp_path)
+        # No `mission.gmat` access — _gmat_accessed stays False.
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            mission.run(timeout=2.0)
+
+    def test_run_without_timeout_skips_subprocess_path(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from gmat_run import _subprocess as sub
+
+        called = False
+
+        def _trap(**_kwargs: Any) -> dict[str, Any]:
+            nonlocal called
+            called = True
+            return {}
+
+        monkeypatch.setattr(sub, "run_in_subprocess", _trap)
+
+        mission, _ = _run_mission(tmp_path)
+        mission.run()  # no timeout
+        assert called is False
+
+    def test_run_with_timeout_propagates_gmat_timeout_error(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        from gmat_run import _subprocess as sub
+        from gmat_run.errors import GmatTimeoutError
+
+        def _raise(**_kwargs: Any) -> dict[str, Any]:
+            raise GmatTimeoutError(
+                "exceeded 2.0 s",
+                log="partial\n",
+                requested_timeout=2.0,
+                elapsed=2.5,
+            )
+
+        monkeypatch.setattr(sub, "run_in_subprocess", _raise)
+
+        mission, _ = _run_mission(tmp_path)
+        with pytest.raises(GmatTimeoutError) as excinfo:
+            mission.run(timeout=2.0)
+        assert excinfo.value.requested_timeout == 2.0
+        assert excinfo.value.log == "partial\n"
+
+    def test_run_with_timeout_cleans_default_tempdir_on_failure(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # When run_in_subprocess raises and we own a tempdir, it must be
+        # cleaned up — otherwise a hung run leaks a directory per call.
+        from gmat_run import _subprocess as sub
+        from gmat_run.errors import GmatTimeoutError
+
+        captured_workspace: dict[str, Path] = {}
+
+        def _raise(**kwargs: Any) -> dict[str, Any]:
+            captured_workspace["path"] = kwargs["workspace_path"]
+            raise GmatTimeoutError(
+                "timed out",
+                log="",
+                requested_timeout=1.0,
+                elapsed=2.0,
+            )
+
+        monkeypatch.setattr(sub, "run_in_subprocess", _raise)
+
+        mission, _ = _run_mission(tmp_path)
+        with pytest.raises(GmatTimeoutError):
+            mission.run(timeout=1.0)
+        # The default-workspace tempdir was wiped.
+        assert "path" in captured_workspace
+        assert not captured_workspace["path"].exists()
+
+
 class TestAttitudeInputs:
     """``Mission.attitude_inputs`` discovers Spacecraft.AttitudeFileName entries."""
 

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -614,6 +614,140 @@ class TestWriteCoercion:
         assert mission["TOI.Element1"] == 0.5
 
 
+# --- numpy normalization ------------------------------------------------------
+
+
+class TestNumpyCoercion:
+    """`_coerce` strips numpy scalars/arrays before type-checking.
+
+    Notebook users routinely pass numpy values without converting; the
+    alternative was a `type mismatch` error for what looks like a valid
+    number or array. After normalization the rest of `_coerce` runs against
+    native Python types unchanged.
+    """
+
+    def test_real_accepts_numpy_float64(self, mission: Mission) -> None:
+        import numpy as np
+
+        mission["Sat.SMA"] = np.float64(7100.5)
+        assert mission["Sat.SMA"] == 7100.5
+
+    def test_real_accepts_numpy_int64(self, mission: Mission) -> None:
+        import numpy as np
+
+        mission["Sat.SMA"] = np.int64(7000)
+        assert mission["Sat.SMA"] == 7000.0
+
+    def test_real_rejects_numpy_bool(self, mission: Mission) -> None:
+        # np.bool_ → Python bool via .item(); the existing bool-trap guard
+        # then rejects it for a real field.
+        import numpy as np
+
+        with pytest.raises(GmatFieldError):
+            mission["Sat.SMA"] = np.bool_(True)
+
+    def test_integer_accepts_numpy_int64(self, mission: Mission) -> None:
+        import numpy as np
+
+        mission["Sat.OrbitColor"] = np.int64(128)
+        assert mission["Sat.OrbitColor"] == 128
+
+    def test_boolean_accepts_numpy_bool(self, mission: Mission) -> None:
+        import numpy as np
+
+        mission["TOI.DecrementMass"] = np.bool_(True)
+        assert mission["TOI.DecrementMass"] is True
+
+    def test_string_array_accepts_numpy_array_of_strings(self, mission: Mission) -> None:
+        import numpy as np
+
+        mission["Sat.Tanks"] = np.array(["A", "B"])
+        assert mission["Sat.Tanks"] == ["A", "B"]
+
+    def test_rvector_accepts_numpy_array(self, mission: Mission) -> None:
+        import numpy as np
+
+        mission["Sat.EulerAngles"] = np.array([1.0, 2.5, 3.0])
+        assert mission["Sat.EulerAngles"] == [1.0, 2.5, 3.0]
+
+    def test_rvector_accepts_list_with_numpy_scalars(self, mission: Mission) -> None:
+        import numpy as np
+
+        mission["Sat.EulerAngles"] = [np.float64(1.0), np.int64(2), 3.0]
+        assert mission["Sat.EulerAngles"] == [1.0, 2.0, 3.0]
+
+    def test_rmatrix_accepts_2d_numpy_array(self, mission: Mission) -> None:
+        import numpy as np
+
+        mission["Sat.Covariance"] = np.array([[1.0, 2.0], [3.0, 4.0]])
+        assert mission["Sat.Covariance"] == [[1.0, 2.0], [3.0, 4.0]]
+
+
+# --- override recording -------------------------------------------------------
+
+
+class TestOverrideRecording:
+    """`__setitem__` mirrors every successful write into ``Mission._overrides``.
+
+    The recorded value is post-`_coerce`, so it's always a JSON-native Python
+    type — that's the contract the subprocess timeout path relies on.
+    """
+
+    def test_overrides_starts_empty(self, mission: Mission) -> None:
+        assert mission._overrides == {}
+
+    def test_overrides_records_real(self, mission: Mission) -> None:
+        mission["Sat.SMA"] = 7100.5
+        assert mission._overrides == {"Sat.SMA": 7100.5}
+
+    def test_overrides_records_post_coerce_value(self, mission: Mission) -> None:
+        # int input to a real field is stored as float, not the original int.
+        mission["Sat.SMA"] = 7100
+        assert mission._overrides["Sat.SMA"] == 7100.0
+        assert isinstance(mission._overrides["Sat.SMA"], float)
+
+    def test_overrides_records_string_array(self, mission: Mission) -> None:
+        mission["Sat.Tanks"] = ["A", "B"]
+        assert mission._overrides == {"Sat.Tanks": ["A", "B"]}
+
+    def test_overrides_records_rvector(self, mission: Mission) -> None:
+        mission["Sat.EulerAngles"] = [1, 2.5, 3]
+        assert mission._overrides == {"Sat.EulerAngles": [1.0, 2.5, 3.0]}
+
+    def test_overrides_records_rmatrix(self, mission: Mission) -> None:
+        mission["Sat.Covariance"] = [[1, 2], [3, 4]]
+        assert mission._overrides == {"Sat.Covariance": [[1.0, 2.0], [3.0, 4.0]]}
+
+    def test_overrides_records_numpy_input_as_native(self, mission: Mission) -> None:
+        # The recorded value goes through _strip_numpy + _coerce, so it must
+        # be JSON-native — no numpy objects leak into _overrides.
+        import json
+
+        import numpy as np
+
+        mission["Sat.SMA"] = np.float64(7000.0)
+        mission["Sat.EulerAngles"] = np.array([1.0, 2.0, 3.0])
+        mission["Sat.Covariance"] = np.array([[1.0, 2.0], [3.0, 4.0]])
+        # json.dumps round-trips iff every value is native JSON-compatible.
+        assert json.loads(json.dumps(mission._overrides)) == mission._overrides
+
+    def test_overrides_overwrites_on_subsequent_setitem(self, mission: Mission) -> None:
+        mission["Sat.SMA"] = 7100.0
+        mission["Sat.SMA"] = 7200.0
+        assert mission._overrides == {"Sat.SMA": 7200.0}
+
+    def test_overrides_not_populated_on_coerce_failure(self, mission: Mission) -> None:
+        with pytest.raises(GmatFieldError):
+            mission["Sat.SMA"] = "not a number"
+        assert "Sat.SMA" not in mission._overrides
+
+    def test_overrides_not_populated_on_engine_rejection(self, mission: Mission) -> None:
+        # Read-only fields raise inside SetField; nothing is recorded.
+        with pytest.raises(GmatFieldError):
+            mission["Sat.CartesianX"] = 100.0
+        assert "Sat.CartesianX" not in mission._overrides
+
+
 # --- error paths --------------------------------------------------------------
 
 

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -12,9 +12,11 @@ from __future__ import annotations
 import io
 import json
 import math
+import os
+import signal
 import subprocess
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 import pytest
 
@@ -58,7 +60,7 @@ class _FakePopen:
     def communicate(
         self,
         *,
-        input: bytes | None = None,  # noqa: A002 — match Popen signature
+        input: bytes | None = None,
         timeout: float | None = None,
     ) -> tuple[bytes, bytes]:
         self.received_stdin = input
@@ -120,9 +122,11 @@ def test_run_in_subprocess_decodes_status_dict(tmp_path: Path) -> None:
 def test_run_in_subprocess_serialises_overrides_with_allow_nan_false(
     tmp_path: Path,
 ) -> None:
-    proc = _FakePopen(stdout=b'{"ok": true, "log": "", "report_paths": {}, '
-                             b'"ephemeris_paths": {}, "contact_paths": {}, '
-                             b'"output_dir": ""}')
+    proc = _FakePopen(
+        stdout=b'{"ok": true, "log": "", "report_paths": {}, '
+        b'"ephemeris_paths": {}, "contact_paths": {}, '
+        b'"output_dir": ""}'
+    )
     run_in_subprocess(
         script_path=tmp_path / "x.script",
         overrides={"Sat.SMA": 7000.0, "Sat.ECC": 0.0},
@@ -155,9 +159,11 @@ def test_run_in_subprocess_rejects_nan_override(tmp_path: Path) -> None:
 
 
 def test_run_in_subprocess_passes_gmat_root(tmp_path: Path) -> None:
-    proc = _FakePopen(stdout=b'{"ok": true, "log": "", "report_paths": {}, '
-                             b'"ephemeris_paths": {}, "contact_paths": {}, '
-                             b'"output_dir": ""}')
+    proc = _FakePopen(
+        stdout=b'{"ok": true, "log": "", "report_paths": {}, '
+        b'"ephemeris_paths": {}, "contact_paths": {}, '
+        b'"output_dir": ""}'
+    )
     root = tmp_path / "gmat-install"
     run_in_subprocess(
         script_path=tmp_path / "x.script",
@@ -262,6 +268,106 @@ def test_run_in_subprocess_raises_gmat_run_error_on_ok_false(tmp_path: Path) -> 
     assert excinfo.value.log == "engine error\n"
 
 
+# --- _kill_child --------------------------------------------------------------
+
+
+@pytest.mark.skipif(__import__("sys").platform == "win32", reason="POSIX-only ladder")
+def test_kill_child_posix_sigterm_then_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The fast path: SIGTERM, child exits within the grace window, no SIGKILL."""
+    from gmat_run import _subprocess as sub
+
+    proc = _FakePopen()
+    proc.returncode = -15  # already exited from the SIGTERM caller's perspective
+
+    sent: list[tuple[int, int]] = []
+    monkeypatch.setattr(sub, "_try_get_pgid", lambda _pid: 99)
+    monkeypatch.setattr(os, "killpg", lambda pgid, sig: sent.append((pgid, sig)))
+
+    sub._kill_child(proc)  # type: ignore[arg-type]
+
+    # SIGTERM was sent; SIGKILL was not (child exited inside the grace window).
+    assert (99, signal.SIGTERM) in sent
+    assert (99, signal.SIGKILL) not in sent
+
+
+@pytest.mark.skipif(__import__("sys").platform == "win32", reason="POSIX-only ladder")
+def test_kill_child_posix_escalates_to_sigkill(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When SIGTERM is ignored past the grace window, the ladder escalates."""
+    from gmat_run import _subprocess as sub
+
+    proc = _FakePopen()  # returncode stays None — proc.wait raises TimeoutExpired
+
+    sent: list[tuple[int, int]] = []
+    monkeypatch.setattr(sub, "_try_get_pgid", lambda _pid: 99)
+    monkeypatch.setattr(os, "killpg", lambda pgid, sig: sent.append((pgid, sig)))
+
+    sub._kill_child(proc)  # type: ignore[arg-type]
+
+    assert (99, signal.SIGTERM) in sent
+    assert (99, signal.SIGKILL) in sent
+
+
+# --- _run_child ---------------------------------------------------------------
+
+
+def test_run_child_loads_applies_overrides_and_runs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The child handler walks load → __setitem__ → run with the parent's payload."""
+    from gmat_run import _subprocess as sub
+
+    set_calls: list[tuple[str, Any]] = []
+
+    class _FakeReports:
+        _paths: ClassVar[dict[str, Path]] = {"RF": Path("/tmp/work/rf.txt")}
+
+    class _FakeResult:
+        log = "child ran fine\n"
+        reports = _FakeReports()
+        ephemeris_paths: ClassVar[dict[str, Path]] = {"E1": Path("/tmp/work/e1.eph")}
+        contact_paths: ClassVar[dict[str, Path]] = {}
+        output_dir = Path("/tmp/work")
+
+    class _FakeMission:
+        @classmethod
+        def load(cls, path: str, *, gmat_root: str | None = None) -> _FakeMission:
+            cls.last_load = (path, gmat_root)  # type: ignore[attr-defined]
+            return cls()
+
+        def __setitem__(self, key: str, value: Any) -> None:
+            set_calls.append((key, value))
+
+        def run(self, *, working_dir: Any = None, overwrite: bool = False) -> _FakeResult:
+            type(self).last_run = (working_dir, overwrite)  # type: ignore[attr-defined]
+            return _FakeResult()
+
+    # Patch the late-imported Mission inside _run_child by stubbing the
+    # module attribute on `gmat_run.mission` before the function imports it.
+    import gmat_run.mission as mission_module
+
+    monkeypatch.setattr(mission_module, "Mission", _FakeMission)
+
+    payload = {
+        "script": "/path/to/x.script",
+        "overrides": {"Sat.SMA": 7100.0, "Sat.ECC": 0.01},
+        "working_dir": "/tmp/work",
+        "overwrite": True,
+        "gmat_root": "/opt/gmat",
+    }
+    status = sub._run_child(payload)
+
+    assert _FakeMission.last_load == ("/path/to/x.script", "/opt/gmat")  # type: ignore[attr-defined]
+    assert ("Sat.SMA", 7100.0) in set_calls
+    assert ("Sat.ECC", 0.01) in set_calls
+    assert _FakeMission.last_run == ("/tmp/work", True)  # type: ignore[attr-defined]
+    assert status == {
+        "ok": True,
+        "log": "child ran fine\n",
+        "report_paths": {"RF": "/tmp/work/rf.txt"},
+        "ephemeris_paths": {"E1": "/tmp/work/e1.eph"},
+        "contact_paths": {},
+        "output_dir": "/tmp/work",
+    }
+
+
 # --- child_main ---------------------------------------------------------------
 
 
@@ -293,6 +399,27 @@ def test_child_main_surfaces_handler_exception_on_stdout(monkeypatch: pytest.Mon
     assert parsed["ok"] is False
     assert "RuntimeError" in parsed["error"]
     assert "kaboom" in parsed["error"]
+
+
+def test_child_main_propagates_gmat_run_error_log(monkeypatch: pytest.MonkeyPatch) -> None:
+    # When _run_child raises a GmatRunError-shaped exception, its `log`
+    # attribute must surface on the wire so the parent can propagate it
+    # through to the caller's GmatRunError.log.
+    from gmat_run import _subprocess as sub
+
+    def _raise_with_log(_payload: dict[str, Any]) -> dict[str, Any]:
+        raise GmatRunError("engine failed", log="GMAT: integrator diverged\n")
+
+    monkeypatch.setattr(sub, "_run_child", _raise_with_log)
+
+    stdin = io.BytesIO(json.dumps({"script": "/x.script"}).encode("utf-8"))
+    stdout = io.BytesIO()
+    rc = child_main(stdin=stdin, stdout=stdout)
+    assert rc == 1
+    parsed = json.loads(stdout.getvalue().decode("utf-8"))
+    assert parsed["ok"] is False
+    assert "GmatRunError" in parsed["error"]
+    assert parsed["log"] == "GMAT: integrator diverged\n"
 
 
 def test_child_main_passes_through_run_child_status(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -316,15 +316,22 @@ def test_run_child_loads_applies_overrides_and_runs(monkeypatch: pytest.MonkeyPa
 
     set_calls: list[tuple[str, Any]] = []
 
+    # Use a tmp_path-style location so `str(Path(...))` round-trips
+    # natively on whatever platform the test runs (Windows turns "/tmp/x"
+    # into "\\tmp\\x" and the assertion would diverge).
+    work = Path("work")
+    rf_path = work / "rf.txt"
+    eph_path = work / "e1.eph"
+
     class _FakeReports:
-        _paths: ClassVar[dict[str, Path]] = {"RF": Path("/tmp/work/rf.txt")}
+        _paths: ClassVar[dict[str, Path]] = {"RF": rf_path}
 
     class _FakeResult:
         log = "child ran fine\n"
         reports = _FakeReports()
-        ephemeris_paths: ClassVar[dict[str, Path]] = {"E1": Path("/tmp/work/e1.eph")}
+        ephemeris_paths: ClassVar[dict[str, Path]] = {"E1": eph_path}
         contact_paths: ClassVar[dict[str, Path]] = {}
-        output_dir = Path("/tmp/work")
+        output_dir = work
 
     class _FakeMission:
         @classmethod
@@ -348,7 +355,7 @@ def test_run_child_loads_applies_overrides_and_runs(monkeypatch: pytest.MonkeyPa
     payload = {
         "script": "/path/to/x.script",
         "overrides": {"Sat.SMA": 7100.0, "Sat.ECC": 0.01},
-        "working_dir": "/tmp/work",
+        "working_dir": str(work),
         "overwrite": True,
         "gmat_root": "/opt/gmat",
     }
@@ -357,14 +364,14 @@ def test_run_child_loads_applies_overrides_and_runs(monkeypatch: pytest.MonkeyPa
     assert _FakeMission.last_load == ("/path/to/x.script", "/opt/gmat")  # type: ignore[attr-defined]
     assert ("Sat.SMA", 7100.0) in set_calls
     assert ("Sat.ECC", 0.01) in set_calls
-    assert _FakeMission.last_run == ("/tmp/work", True)  # type: ignore[attr-defined]
+    assert _FakeMission.last_run == (str(work), True)  # type: ignore[attr-defined]
     assert status == {
         "ok": True,
         "log": "child ran fine\n",
-        "report_paths": {"RF": "/tmp/work/rf.txt"},
-        "ephemeris_paths": {"E1": "/tmp/work/e1.eph"},
+        "report_paths": {"RF": str(rf_path)},
+        "ephemeris_paths": {"E1": str(eph_path)},
         "contact_paths": {},
-        "output_dir": "/tmp/work",
+        "output_dir": str(work),
     }
 
 

--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -1,0 +1,332 @@
+"""Unit tests for :mod:`gmat_run._subprocess`.
+
+The driver is exercised with a fake ``Popen`` so tests can drive the
+parent through the timeout, non-zero-exit, malformed-stdout, and
+ok-False branches deterministically. ``child_main`` is exercised by
+calling it directly with ``BytesIO`` stdin/stdout — the real subprocess
+end-to-end path is covered in ``tests/integration/test_timeout.py``.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import math
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gmat_run._subprocess import child_main, run_in_subprocess
+from gmat_run.errors import GmatRunError, GmatTimeoutError
+
+# --- fake Popen ---------------------------------------------------------------
+
+
+class _FakePopen:
+    """Stand-in for ``subprocess.Popen`` controllable by the test.
+
+    ``communicate`` returns ``(stdout, stderr)`` after setting
+    ``returncode`` if ``timeout_after`` is ``None``; otherwise it raises
+    :class:`subprocess.TimeoutExpired`. ``terminate`` / ``wait`` /
+    ``kill`` track call counts so the kill-ladder branches are
+    observable.
+    """
+
+    def __init__(
+        self,
+        *,
+        stdout: bytes = b"",
+        stderr: bytes = b"",
+        returncode: int = 0,
+        raise_timeout: bool = False,
+        terminate_actually_kills: bool = True,
+    ) -> None:
+        self._stdout = stdout
+        self._stderr = stderr
+        self._returncode = returncode
+        self._raise_timeout = raise_timeout
+        self._terminate_kills = terminate_actually_kills
+        self.returncode: int | None = None
+        self.pid = 12345
+        self.terminate_calls = 0
+        self.kill_calls = 0
+        self.wait_calls = 0
+        self.received_stdin: bytes | None = None
+
+    def communicate(
+        self,
+        *,
+        input: bytes | None = None,  # noqa: A002 — match Popen signature
+        timeout: float | None = None,
+    ) -> tuple[bytes, bytes]:
+        self.received_stdin = input
+        if self._raise_timeout:
+            raise subprocess.TimeoutExpired(cmd="fake", timeout=timeout or 0.0)
+        self.returncode = self._returncode
+        return self._stdout, self._stderr
+
+    def terminate(self) -> None:
+        self.terminate_calls += 1
+        if self._terminate_kills:
+            self.returncode = -15
+
+    def kill(self) -> None:
+        self.kill_calls += 1
+        self.returncode = -9
+
+    def wait(self, timeout: float | None = None) -> int:
+        self.wait_calls += 1
+        if self.returncode is None:
+            raise subprocess.TimeoutExpired(cmd="fake", timeout=timeout or 0.0)
+        return self.returncode
+
+
+def _make_spawn(proc: _FakePopen) -> Any:
+    """Wrap a single fake Popen as a ``spawn(cmd) -> proc`` callable."""
+
+    def _spawn(_cmd: list[str]) -> _FakePopen:
+        return proc
+
+    return _spawn
+
+
+# --- run_in_subprocess: happy path --------------------------------------------
+
+
+def test_run_in_subprocess_decodes_status_dict(tmp_path: Path) -> None:
+    payload = {
+        "ok": True,
+        "log": "GMAT execution complete\n",
+        "report_paths": {"RF": str(tmp_path / "rf.txt")},
+        "ephemeris_paths": {},
+        "contact_paths": {},
+        "output_dir": str(tmp_path),
+    }
+    proc = _FakePopen(stdout=json.dumps(payload).encode("utf-8"))
+    status = run_in_subprocess(
+        script_path=tmp_path / "x.script",
+        overrides={},
+        workspace_path=tmp_path,
+        overwrite=False,
+        gmat_root=None,
+        timeout=10.0,
+        _popen=_make_spawn(proc),
+    )
+    assert status == payload
+
+
+def test_run_in_subprocess_serialises_overrides_with_allow_nan_false(
+    tmp_path: Path,
+) -> None:
+    proc = _FakePopen(stdout=b'{"ok": true, "log": "", "report_paths": {}, '
+                             b'"ephemeris_paths": {}, "contact_paths": {}, '
+                             b'"output_dir": ""}')
+    run_in_subprocess(
+        script_path=tmp_path / "x.script",
+        overrides={"Sat.SMA": 7000.0, "Sat.ECC": 0.0},
+        workspace_path=tmp_path,
+        overwrite=True,
+        gmat_root=None,
+        timeout=5.0,
+        _popen=_make_spawn(proc),
+    )
+    assert proc.received_stdin is not None
+    sent = json.loads(proc.received_stdin.decode("utf-8"))
+    assert sent["overrides"] == {"Sat.SMA": 7000.0, "Sat.ECC": 0.0}
+    assert sent["working_dir"] == str(tmp_path)
+    assert sent["overwrite"] is True
+
+
+def test_run_in_subprocess_rejects_nan_override(tmp_path: Path) -> None:
+    # allow_nan=False on the encode side is the parent-stack-trace guarantee
+    # — a NaN/Inf must not silently round-trip into the child's SetField.
+    with pytest.raises(ValueError):  # json raises ValueError on NaN with allow_nan=False
+        run_in_subprocess(
+            script_path=tmp_path / "x.script",
+            overrides={"Sat.SMA": math.nan},
+            workspace_path=tmp_path,
+            overwrite=False,
+            gmat_root=None,
+            timeout=5.0,
+            _popen=_make_spawn(_FakePopen()),
+        )
+
+
+def test_run_in_subprocess_passes_gmat_root(tmp_path: Path) -> None:
+    proc = _FakePopen(stdout=b'{"ok": true, "log": "", "report_paths": {}, '
+                             b'"ephemeris_paths": {}, "contact_paths": {}, '
+                             b'"output_dir": ""}')
+    root = tmp_path / "gmat-install"
+    run_in_subprocess(
+        script_path=tmp_path / "x.script",
+        overrides={},
+        workspace_path=tmp_path,
+        overwrite=False,
+        gmat_root=root,
+        timeout=5.0,
+        _popen=_make_spawn(proc),
+    )
+    sent = json.loads((proc.received_stdin or b"").decode("utf-8"))
+    assert sent["gmat_root"] == str(root)
+
+
+# --- run_in_subprocess: failure paths -----------------------------------------
+
+
+def test_run_in_subprocess_raises_gmat_timeout_error_on_timeout(tmp_path: Path) -> None:
+    proc = _FakePopen(raise_timeout=True)
+    log_path = tmp_path / "GmatLog.txt"
+    log_path.write_text("partial GMAT log content\n", encoding="utf-8")
+
+    with pytest.raises(GmatTimeoutError) as excinfo:
+        run_in_subprocess(
+            script_path=tmp_path / "x.script",
+            overrides={},
+            workspace_path=tmp_path,
+            overwrite=False,
+            gmat_root=None,
+            timeout=2.0,
+            _popen=_make_spawn(proc),
+        )
+    err = excinfo.value
+    assert err.requested_timeout == 2.0
+    assert err.elapsed >= 0.0
+    assert "partial GMAT log" in err.log
+
+
+def test_run_in_subprocess_kills_child_on_timeout(tmp_path: Path) -> None:
+    proc = _FakePopen(raise_timeout=True)
+    with pytest.raises(GmatTimeoutError):
+        run_in_subprocess(
+            script_path=tmp_path / "x.script",
+            overrides={},
+            workspace_path=tmp_path,
+            overwrite=False,
+            gmat_root=None,
+            timeout=1.0,
+            _popen=_make_spawn(proc),
+        )
+    # On POSIX the kill ladder uses os.killpg, not proc.terminate; on Windows
+    # it would call proc.terminate. Either way wait() is called at least once
+    # to give the child a chance to exit.
+    assert proc.wait_calls >= 1
+
+
+def test_run_in_subprocess_raises_gmat_run_error_on_nonzero_exit(tmp_path: Path) -> None:
+    proc = _FakePopen(stdout=b"", stderr=b"child crashed\n", returncode=1)
+    with pytest.raises(GmatRunError) as excinfo:
+        run_in_subprocess(
+            script_path=tmp_path / "x.script",
+            overrides={},
+            workspace_path=tmp_path,
+            overwrite=False,
+            gmat_root=None,
+            timeout=5.0,
+            _popen=_make_spawn(proc),
+        )
+    assert "exited with code 1" in str(excinfo.value)
+    assert "child crashed" in str(excinfo.value)
+
+
+def test_run_in_subprocess_raises_gmat_run_error_on_malformed_stdout(tmp_path: Path) -> None:
+    proc = _FakePopen(stdout=b"not json at all", returncode=0)
+    with pytest.raises(GmatRunError) as excinfo:
+        run_in_subprocess(
+            script_path=tmp_path / "x.script",
+            overrides={},
+            workspace_path=tmp_path,
+            overwrite=False,
+            gmat_root=None,
+            timeout=5.0,
+            _popen=_make_spawn(proc),
+        )
+    assert "non-JSON" in str(excinfo.value)
+
+
+def test_run_in_subprocess_raises_gmat_run_error_on_ok_false(tmp_path: Path) -> None:
+    payload = {"ok": False, "error": "GMAT rejected the script", "log": "engine error\n"}
+    proc = _FakePopen(stdout=json.dumps(payload).encode("utf-8"), returncode=0)
+    with pytest.raises(GmatRunError) as excinfo:
+        run_in_subprocess(
+            script_path=tmp_path / "x.script",
+            overrides={},
+            workspace_path=tmp_path,
+            overwrite=False,
+            gmat_root=None,
+            timeout=5.0,
+            _popen=_make_spawn(proc),
+        )
+    assert "GMAT rejected" in str(excinfo.value)
+    assert excinfo.value.log == "engine error\n"
+
+
+# --- child_main ---------------------------------------------------------------
+
+
+def test_child_main_emits_error_on_invalid_stdin() -> None:
+    stdin = io.BytesIO(b"this is not json")
+    stdout = io.BytesIO()
+    rc = child_main(stdin=stdin, stdout=stdout)
+    assert rc == 1
+    parsed = json.loads(stdout.getvalue().decode("utf-8"))
+    assert parsed["ok"] is False
+    assert "invalid stdin payload" in parsed["error"]
+
+
+def test_child_main_surfaces_handler_exception_on_stdout(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Force _run_child to raise; the handler must catch it and emit a
+    # structured error on stdout rather than a Python traceback on stderr.
+    from gmat_run import _subprocess as sub
+
+    def _boom(_payload: dict[str, Any]) -> dict[str, Any]:
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(sub, "_run_child", _boom)
+
+    stdin = io.BytesIO(json.dumps({"script": "/x.script"}).encode("utf-8"))
+    stdout = io.BytesIO()
+    rc = child_main(stdin=stdin, stdout=stdout)
+    assert rc == 1
+    parsed = json.loads(stdout.getvalue().decode("utf-8"))
+    assert parsed["ok"] is False
+    assert "RuntimeError" in parsed["error"]
+    assert "kaboom" in parsed["error"]
+
+
+def test_child_main_passes_through_run_child_status(monkeypatch: pytest.MonkeyPatch) -> None:
+    from gmat_run import _subprocess as sub
+
+    def _ok(payload: dict[str, Any]) -> dict[str, Any]:
+        # Echo a deterministic status so the test asserts the wire format.
+        return {
+            "ok": True,
+            "log": "ran fine\n",
+            "report_paths": {"RF": "/tmp/rf.txt"},
+            "ephemeris_paths": {},
+            "contact_paths": {},
+            "output_dir": payload.get("working_dir", ""),
+        }
+
+    monkeypatch.setattr(sub, "_run_child", _ok)
+
+    stdin = io.BytesIO(
+        json.dumps(
+            {
+                "script": "/x.script",
+                "overrides": {"Sat.SMA": 7000.0},
+                "working_dir": "/tmp/work",
+                "overwrite": False,
+                "gmat_root": None,
+            }
+        ).encode("utf-8")
+    )
+    stdout = io.BytesIO()
+    rc = child_main(stdin=stdin, stdout=stdout)
+    assert rc == 0
+    parsed = json.loads(stdout.getvalue().decode("utf-8"))
+    assert parsed["ok"] is True
+    assert parsed["log"] == "ran fine\n"
+    assert parsed["report_paths"] == {"RF": "/tmp/rf.txt"}
+    assert parsed["output_dir"] == "/tmp/work"


### PR DESCRIPTION
## Summary

- `Mission.run(timeout=...)` runs the mission in a child Python process under a wall-clock cap and raises `GmatTimeoutError` on timeout. In-process behavior (`timeout=None`) unchanged.
- New `gmat-run run --timeout SECONDS` CLI flag, exit code `6` for timeouts.
- Override values now record on `Mission._overrides` after `_coerce`; `_coerce` strips numpy (`bool_`, scalar `.item()`, `ndarray.tolist()`).
- Subprocess wire format is JSON with `allow_nan=False`; pickle is intentionally not used.
- Documented at `docs/timeouts.md`; the `mission.gmat` escape-hatch limitation lives on the property docstring (where users land via tab-completion) and in `docs/known-limitations.md`.

## Commits

The branch has six logically scoped commits, reviewable in order:

1. Record field overrides on Mission and accept numpy inputs in `_coerce`
2. Track `mission.gmat` property access on `Mission._gmat_accessed`
3. Add `GmatTimeoutError` for the wall-clock-cap path
4. Add `Mission.run(timeout=...)` with subprocess-based wall-clock cap
5. Expose `--timeout` on `gmat-run run`, document the timeout path
6. Tighten lint and tests on the timeout path (coverage polish)

## Test plan

- [ ] `uv run pytest` passes locally (Linux): 686 unit, 0 failures.
- [ ] `uv run pytest -m integration` against a real GMAT R2026a install: 17 passed, including the new hanging-script timeout test (raises `GmatTimeoutError` within ~5 s wall-clock).
- [ ] `uv run ruff check`, `uv run ruff format --check`, `uv run mypy` clean.
- [ ] Coverage 95% overall (`_subprocess.py` 88% locally; remaining lines are real-Popen / Windows-only paths exercised by the integration test).
- [ ] CI matrix green on Ubuntu / Windows / macOS.
- [ ] Manual sanity: `Mission.run(timeout=2.0)` against a known-hanging script raises `GmatTimeoutError`; finite mission with `timeout=60.0` returns a populated `Results` byte-equal to the in-process run.

Closes #73
