### PR TITLE
Accept numpy scalars and arrays in Mission.__setitem__

### DIFF
--- a/src/gmat_run/mission.py
+++ b/src/gmat_run/mission.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from types import MappingProxyType, ModuleType
 from typing import Any, Final
 
+import numpy as np
 import pandas as pd
 
 from gmat_run.errors import GmatFieldError, GmatLoadError, GmatRunError
@@ -617,6 +618,11 @@ class Mission:
         return str(obj.GetField(field))
 
     def _coerce(self, type_code: int, value: Any, dotted: str) -> Any:
+        # Strip numpy first so the type checks below see native Python types.
+        # Notebook users routinely pass np.float64 / np.int64 / np.bool_ /
+        # ndarray without thinking — the alternative is a confusing rejection
+        # for what looks like a valid number/array.
+        value = _strip_numpy(value)
         kind = self._type_map.get(type_code, "string")
         if kind == "real":
             if isinstance(value, bool) or not isinstance(value, (int, float)):
@@ -671,6 +677,26 @@ class Mission:
 
 
 # --- module-level helpers -----------------------------------------------------
+
+
+def _strip_numpy(value: Any) -> Any:
+    """Recursively convert numpy scalars/arrays into native Python types.
+
+    Handles three shapes: ``numpy.bool_`` and other numpy scalar dtypes (via
+    ``.item()``), ``numpy.ndarray`` (via ``.tolist()``, which recursively
+    yields native types), and Python lists/tuples that may contain numpy
+    elements (walk and convert in place). Anything else is returned
+    untouched so the rest of ``_coerce``'s type checks fire as written.
+    """
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    if isinstance(value, np.generic):
+        return value.item()
+    if isinstance(value, list):
+        return [_strip_numpy(v) for v in value]
+    if isinstance(value, tuple):
+        return tuple(_strip_numpy(v) for v in value)
+    return value
 
 
 def _split_path(dotted: str, *, value: Any = None) -> tuple[str, str]:

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -614,6 +614,75 @@ class TestWriteCoercion:
         assert mission["TOI.Element1"] == 0.5
 
 
+# --- numpy normalization ------------------------------------------------------
+
+
+class TestNumpyCoercion:
+    """`_coerce` strips numpy scalars/arrays before type-checking.
+
+    Notebook users routinely pass numpy values without converting; the
+    alternative was a `type mismatch` error for what looks like a valid
+    number or array. After normalization the rest of `_coerce` runs against
+    native Python types unchanged.
+    """
+
+    def test_real_accepts_numpy_float64(self, mission: Mission) -> None:
+        import numpy as np
+
+        mission["Sat.SMA"] = np.float64(7100.5)
+        assert mission["Sat.SMA"] == 7100.5
+
+    def test_real_accepts_numpy_int64(self, mission: Mission) -> None:
+        import numpy as np
+
+        mission["Sat.SMA"] = np.int64(7000)
+        assert mission["Sat.SMA"] == 7000.0
+
+    def test_real_rejects_numpy_bool(self, mission: Mission) -> None:
+        # np.bool_ → Python bool via .item(); the existing bool-trap guard
+        # then rejects it for a real field.
+        import numpy as np
+
+        with pytest.raises(GmatFieldError):
+            mission["Sat.SMA"] = np.bool_(True)
+
+    def test_integer_accepts_numpy_int64(self, mission: Mission) -> None:
+        import numpy as np
+
+        mission["Sat.OrbitColor"] = np.int64(128)
+        assert mission["Sat.OrbitColor"] == 128
+
+    def test_boolean_accepts_numpy_bool(self, mission: Mission) -> None:
+        import numpy as np
+
+        mission["TOI.DecrementMass"] = np.bool_(True)
+        assert mission["TOI.DecrementMass"] is True
+
+    def test_string_array_accepts_numpy_array_of_strings(self, mission: Mission) -> None:
+        import numpy as np
+
+        mission["Sat.Tanks"] = np.array(["A", "B"])
+        assert mission["Sat.Tanks"] == ["A", "B"]
+
+    def test_rvector_accepts_numpy_array(self, mission: Mission) -> None:
+        import numpy as np
+
+        mission["Sat.EulerAngles"] = np.array([1.0, 2.5, 3.0])
+        assert mission["Sat.EulerAngles"] == [1.0, 2.5, 3.0]
+
+    def test_rvector_accepts_list_with_numpy_scalars(self, mission: Mission) -> None:
+        import numpy as np
+
+        mission["Sat.EulerAngles"] = [np.float64(1.0), np.int64(2), 3.0]
+        assert mission["Sat.EulerAngles"] == [1.0, 2.0, 3.0]
+
+    def test_rmatrix_accepts_2d_numpy_array(self, mission: Mission) -> None:
+        import numpy as np
+
+        mission["Sat.Covariance"] = np.array([[1.0, 2.0], [3.0, 4.0]])
+        assert mission["Sat.Covariance"] == [[1.0, 2.0], [3.0, 4.0]]
+
+
 # --- error paths --------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

- `Mission["Sat.SMA"] = np.float64(7000)` and `Mission["Sat.OrbitState"] = np.array([...])` now work without a manual `float(...)` / `.tolist()` at the call site.
- New `_strip_numpy` helper at the top of `_coerce`: numpy scalars via `.item()`, `np.ndarray` via `.tolist()`, lists/tuples walked element-wise.
- The rest of `_coerce`'s rules fire unchanged on the resulting native types — the bool-trap for real fields still catches `np.bool_` correctly.

## Background

Surfaced during the design review of #73 (`Mission.run(timeout=...)`). That feature was scoped down out of YAGNI concerns, but the numpy-normalization slice stands on its own as a notebook-ergonomics fix and is unrelated to subprocess execution.

## Test plan

- [x] `uv run pytest` passes locally: 643 unit, 0 failures (9 new in `TestNumpyCoercion`).
- [x] `uv run ruff check`, `uv run ruff format --check`, `uv run mypy` clean.
- [x] CI matrix green on Ubuntu / Windows / macOS × Python 3.10/3.11/3.12.
- [x] Manual: `mission["Sat.SMA"] = np.float64(7000.5)` round-trips to `7000.5` against a real GMAT install.
