### PR TITLE
Cut v0.3.0: bump version, add CHANGELOG, ship timeout cookbook page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,48 @@ All notable changes to gmat-run are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] — 2026-04-28
+
+### Added
+
+- CCSDS-OEM export — `Results.write_oem(name, path)` writes any ephemeris
+  DataFrame in `Results.ephemerides` as a CCSDS-OEM file, gated behind the
+  new `[ccsds-ndm]` extra (#67). A CI-enforced golden round-trip pins the
+  writer against GMAT's own OEM output (#68).
+- Time-scale conversion — `gmat_run.time` routes A1 / TAI / UTC / TT / TDB
+  epochs through `astropy.time.Time` (leap-second-correct), gated behind
+  the new `[astropy]` extra (#65). `promote_epochs(..., convert_to=...)`
+  and the matching keyword on the four file-format parsers compose the
+  conversion into a single DataFrame access (#66).
+- Hardened explicit workspaces — `Mission.run(working_dir=...)` now handles
+  pre-existing artefacts (with `overwrite=True` for re-runs into a populated
+  workspace), absolute `Filename` fields in the script, and permission
+  errors, surfacing each as a typed `GmatRunError` (#69).
+- New optional extras `[ccsds-ndm]` and `[astropy]`, documented in the
+  README install table (#64).
+- Example notebooks, runnable end-to-end and rendered into the docs site:
+  export an ephemeris to CCSDS-OEM (#70), and time-scale conversion across
+  a leap-second boundary (#71).
+- Wall-clock timeout cookbook page (`docs/timeouts.md`) — a subprocess
+  recipe for capping `Mission.run` from caller code, with a cross-link
+  from "Known limitations".
+
+### Changed
+
+- `Mission.__setitem__` accepts numpy scalars (`np.float64`, `np.int_`,
+  `np.bool_`) and `np.ndarray` directly. Previously the call site had to
+  do `float(...)` / `.tolist()` first (#85).
+
+### Fixed
+
+- `gmat_run.time.convert(..., to_scale="UTC")` (and transitively
+  `convert_column`, `promote_epochs(..., convert_to=)`, and the parser-level
+  `convert_to=` keyword) raised `ValueError` from astropy's
+  `Time.utc.datetime64` accessor on epochs landing exactly on a leap-second
+  instant. Non-leap rows keep nanosecond precision; leap-second rows fall
+  back to microsecond precision and are pinned to the post-jump second to
+  match GMAT's labelling convention (#80, #81).
+
 ## [0.2.0] — 2026-04-26
 
 ### Added
@@ -65,6 +107,7 @@ Initial public release.
 - Release workflow: build, PyPI trusted publishing, and
   `gh release create --generate-notes` on `v*` tags (#31).
 
+[0.3.0]: https://github.com/astro-tools/gmat-run/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/astro-tools/gmat-run/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/astro-tools/gmat-run/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/astro-tools/gmat-run/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ the dependency it pulls in:
 | Extra | Pulls in | Unlocks |
 |---|---|---|
 | `[spiceypy]` | `spiceypy` | SPK (NASA SPICE binary) ephemeris parsing. |
-| `[ccsds-ndm]` | `ccsds-ndm` | CCSDS-OEM export (lands in v0.3 — see [#67](https://github.com/astro-tools/gmat-run/issues/67)). |
-| `[astropy]` | `astropy` | Leap-second-correct time-scale conversion (lands in v0.3 — see [#65](https://github.com/astro-tools/gmat-run/issues/65)). |
+| `[ccsds-ndm]` | `ccsds-ndm` | CCSDS-OEM export via `Results.write_oem`. |
+| `[astropy]` | `astropy` | Leap-second-correct time-scale conversion via `gmat_run.time`. |
 
 Install one or more at once:
 
@@ -111,7 +111,8 @@ and sample output.
   to `datetime64[ns]`.
 - **`EphemerisFile`** → DataFrame, dispatching on file format: **CCSDS-OEM** and
   **STK-TimePosVel** are read out of the box; **SPK** (NASA SPICE binary) is read with the
-  `[spiceypy]` extra installed. **Code-500** (GSFC binary) is tracked for v0.3 (#50).
+  `[spiceypy]` extra installed. **Code-500** (GSFC binary) is not implemented —
+  see [Known limitations](https://astro-tools.github.io/gmat-run/known-limitations/).
 - **`ContactLocator`** → DataFrame, supporting Legacy and the five tabular `ReportFormat`
   variants. `df.attrs["report_format"]` carries the variant name so downstream code can
   branch on it without inspecting the column set.

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -5,6 +5,14 @@ a heads-up. Most items are intentional — they fall out of the underlying
 `gmatpy` runtime or the GMAT script semantics — and gmat-run does not try to
 paper over them.
 
+## No built-in wall-clock timeout
+
+[`Mission.run`][gmat_run.Mission.run] does not take a `timeout=` keyword. A
+divergent solver or hung subscriber blocks the calling Python process until
+the kernel is restarted. The library deliberately stops at that line — see
+[Wall-clock timeouts](timeouts.md) for a 25-line subprocess recipe that gives
+you the cap on the caller's side.
+
 ## gmatpy single-init constraint
 
 `gmatpy` cannot be cleanly reinitialised once it has been loaded into a Python

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -7,11 +7,10 @@ paper over them.
 
 ## No built-in wall-clock timeout
 
-[`Mission.run`][gmat_run.Mission.run] does not take a `timeout=` keyword. A
-divergent solver or hung subscriber blocks the calling Python process until
-the kernel is restarted. The library deliberately stops at that line — see
-[Wall-clock timeouts](timeouts.md) for a 25-line subprocess recipe that gives
-you the cap on the caller's side.
+[`Mission.run`][gmat_run.Mission.run] does not take a `timeout=` keyword. If
+you need a wall-clock cap on a mission run — for example to bound a divergent
+solver or a hung subscriber — see [Wall-clock timeouts](timeouts.md) for a
+subprocess recipe.
 
 ## gmatpy single-init constraint
 

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -1,9 +1,8 @@
 # Known limitations
 
 The list below captures behaviour that surprises users often enough to warrant
-a heads-up. Most items are intentional — they fall out of the underlying
-`gmatpy` runtime or the GMAT script semantics — and gmat-run does not try to
-paper over them.
+a heads-up. Most items fall out of the underlying `gmatpy` runtime or the GMAT
+script semantics.
 
 ## No built-in wall-clock timeout
 
@@ -21,13 +20,9 @@ interpreter. [`gmat_run.bootstrap`][gmat_run.bootstrap] (and therefore
 a *different* install raises [`GmatLoadError`][gmat_run.GmatLoadError]. Calling
 again with the *same* install is a no-op and returns the cached module.
 
-Practical implications:
-
-- A single Python process is bound to one GMAT install for its lifetime. If
-  you need to compare missions across GMAT releases, run them in separate
-  processes (subprocess, pytest workers, multiprocessing).
-- `gmat-run` integration tests that touch the runtime cannot fork
-  `xdist` workers within the same process; spawn them.
+Practical implication: a single Python process is bound to one GMAT install
+for its lifetime. If you need to compare missions across GMAT releases, run
+them in separate processes (subprocess, pytest workers, multiprocessing).
 
 ## Supported Python versions
 
@@ -68,9 +63,8 @@ but you cannot ask GMAT to *emit* an AEM trace of a propagated spacecraft.
 ## Parser format restrictions
 
 The parsers in [`gmat_run.parsers`](reference/parsers.md) cover the formats
-GMAT actually emits in v0.3; uncommon variants are rejected with
-[`GmatOutputParseError`][gmat_run.GmatOutputParseError] rather than silently
-guessed at.
+GMAT actually emits in v0.3; uncommon variants raise
+[`GmatOutputParseError`][gmat_run.GmatOutputParseError].
 
 - **CCSDS-OEM ephemeris**: covariance blocks (`COVARIANCE_START` …
   `COVARIANCE_STOP`) are skipped; acceleration columns past the mandatory six
@@ -86,9 +80,8 @@ guessed at.
   concatenable).
 - **SPK ephemeris**: the parser assumes one spacecraft per file (which
   matches GMAT's writer behaviour). Multi-target SPKs are rejected.
-- **Code-500 binary ephemeris**: not implemented. GMAT does not run any of its
-  stock R2026a sample missions through this format, and no public tooling
-  decodes it; out of scope unless a user need surfaces.
+- **Code-500 binary ephemeris**: not implemented. No public tooling decodes
+  the format, and GMAT does not exercise it in its stock R2026a samples.
 
 ## Epoch promotion is not a time-scale conversion
 

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -69,7 +69,7 @@ but you cannot ask GMAT to *emit* an AEM trace of a propagated spacecraft.
 ## Parser format restrictions
 
 The parsers in [`gmat_run.parsers`](reference/parsers.md) cover the formats
-GMAT actually emits in v0.2; uncommon variants are rejected with
+GMAT actually emits in v0.3; uncommon variants are rejected with
 [`GmatOutputParseError`][gmat_run.GmatOutputParseError] rather than silently
 guessed at.
 

--- a/docs/timeouts.md
+++ b/docs/timeouts.md
@@ -1,101 +1,53 @@
 # Wall-clock timeouts
 
-[`Mission.run`][gmat_run.Mission.run] does not take a `timeout=` keyword. A
-divergent solver or a hung subscriber will block the calling Python process
-until the interpreter is restarted.
+[`Mission.run`][gmat_run.Mission.run] does not take a `timeout=` keyword. If
+you need a wall-clock cap on a mission run — for example to bound a divergent
+solver or a hung subscriber — run the mission in a child process and let
+`subprocess.run(timeout=...)` enforce the cap.
 
-The library doesn't ship a built-in cap because the use case is narrow — real
-GMAT runs are slow, not hung — and a short subprocess recipe covers it
-cleanly without dragging cross-platform process management into the library.
-If you need a wall-clock cap on a mission run, lift the snippet below into
-your own code.
+## Worked example
 
-## Recipe
+Put the mission in its own file:
 
 ```python
-import json
-import subprocess
-import sys
-import tempfile
-from contextlib import contextmanager
-from pathlib import Path
-
-DRIVER = """
-import json
-import sys
-
+# run_flyby.py
 from gmat_run import Mission
 
-payload = json.loads(sys.stdin.read())
-mission = Mission.load(payload["script"])
-for k, v in payload["overrides"].items():
-    mission[k] = v
-mission.run(working_dir=payload["workspace"])
-"""
-
-
-@contextmanager
-def run_with_timeout(script, overrides, timeout):
-    """Run a GMAT mission in a child process under a wall-clock cap.
-
-    Yields the workspace path. The temp dir is cleaned up on context exit,
-    so read every output you need before leaving the ``with`` block.
-    """
-    with tempfile.TemporaryDirectory() as workspace:
-        payload = json.dumps(
-            {
-                "script": str(script),
-                "overrides": overrides,
-                "workspace": workspace,
-            }
-        )
-        try:
-            subprocess.run(
-                [sys.executable, "-c", DRIVER],
-                input=payload,
-                text=True,
-                timeout=timeout,
-                check=True,
-            )
-        except subprocess.TimeoutExpired as exc:
-            raise RuntimeError(f"mission exceeded {timeout} s") from exc
-        yield Path(workspace)
+mission = Mission.load("flyby.script")
+mission["Sat.SMA"] = 7000
+mission.run(working_dir="out/")
 ```
 
-## Using it
+Run it from the parent process under a timeout:
 
 ```python
-import pandas as pd
+import subprocess
 
-with run_with_timeout("flyby.script", {"Sat.SMA": 7000}, timeout=60) as ws:
-    df = pd.read_csv(ws / "ReportFile1.txt", sep=r"\s+")
-    # ...do whatever you need with df before leaving the block
+try:
+    subprocess.run(
+        ["python", "run_flyby.py"],
+        timeout=60,
+        check=True,
+    )
+except subprocess.TimeoutExpired:
+    raise RuntimeError("mission exceeded 60 s") from None
+
+# outputs are now in out/ — read them however you like
 ```
 
-## How it works
+`subprocess.run(timeout=...)` does the kill cross-platform: `SIGTERM` on
+POSIX, `TerminateProcess` on Windows.
 
-- `subprocess.run(timeout=...)` does the cross-platform kill: `SIGTERM` on
-  POSIX, `TerminateProcess` on Windows. There is nothing for the library to
-  add on top.
-- `tempfile.TemporaryDirectory` owns the workspace lifetime; the `with`
-  block on the caller side keeps it alive until you've finished reading.
-- The driver uses `json` rather than `pickle` for the override payload — only
-  JSON-encodable values cross the process boundary. If you need to pass numpy
-  arrays, convert with `.tolist()` first.
-- The child process pays the full `gmat_run.bootstrap()` cost on every call.
-  That's the right price for the use case (wall-clock-bounded, occasionally
-  killed); for tight inner loops, run in-process without the timeout.
+To parameterise the child — different scripts, different overrides — pass
+arguments via `argv` or read a small config file from inside `run_flyby.py`.
 
-## Limitations
+## Caveats
 
-- **No partial results on timeout.** When the cap fires, the child process is
-  killed mid-run — output files in the workspace may be empty, truncated, or
-  missing. The recipe surfaces only the timeout itself; recovering whatever
-  GMAT had flushed to disk is on you.
-- **One timeout per call.** Wrapping `Mission.run` from inside an in-process
-  thread does not work — `gmat.RunScript` holds the GIL through a blocking
-  C++ call, so Python signals never fire. The subprocess split is what makes
-  the cap real.
-- **JSON-only overrides.** `Mission["Sat.OrbitState"] = np.array([...])`
-  works in-process, but the array has to be pre-converted to a list before
-  crossing the subprocess boundary here.
+- **No partial results on timeout.** When the cap fires, the child is killed
+  mid-run; output files in the workspace may be empty, truncated, or missing.
+- **Bootstrap cost on every call.** The child pays the full
+  `gmat_run.bootstrap()` import on every run, which adds noticeable startup
+  time. For tight inner loops, run in-process without a timeout.
+- **Threads can't substitute for a child process.** Wrapping `Mission.run` in
+  an in-process thread does not give you a real cap — `gmat.RunScript` holds
+  the GIL through a blocking C++ call, so Python signals never fire.

--- a/docs/timeouts.md
+++ b/docs/timeouts.md
@@ -1,19 +1,14 @@
 # Wall-clock timeouts
 
 [`Mission.run`][gmat_run.Mission.run] does not take a `timeout=` keyword. A
-divergent solver, a bad fixture, or a hung subscriber can therefore block the
-calling Python process indefinitely — short of restarting the kernel, there is
-no way out from inside the same interpreter.
+divergent solver or a hung subscriber will block the calling Python process
+until the interpreter is restarted.
 
-The library deliberately stops at that line: a built-in subprocess driver was
-prototyped in [#84](https://github.com/astro-tools/gmat-run/pull/84) and rejected
-in [#73](https://github.com/astro-tools/gmat-run/issues/73) on cost/benefit
-grounds. The use case is narrow (real GMAT runs are slow, not hung), and the
-~25-line subprocess recipe below covers it without dragging cross-platform
-process management into the library.
-
-If you actually need a wall-clock cap, lift the snippet below into your own
-code.
+The library doesn't ship a built-in cap because the use case is narrow — real
+GMAT runs are slow, not hung — and a short subprocess recipe covers it
+cleanly without dragging cross-platform process management into the library.
+If you need a wall-clock cap on a mission run, lift the snippet below into
+your own code.
 
 ## Recipe
 
@@ -106,5 +101,5 @@ subprocess.
   C++ call, so Python signals never fire. The subprocess split is what makes
   the cap real.
 - **JSON-only overrides.** `Mission["Sat.OrbitState"] = np.array([...])`
-  works in-process (PR #85) but the array has to be pre-converted to a list
-  before crossing the subprocess boundary here.
+  works in-process, but the array has to be pre-converted to a list before
+  crossing the subprocess boundary here.

--- a/docs/timeouts.md
+++ b/docs/timeouts.md
@@ -72,10 +72,6 @@ with run_with_timeout("flyby.script", {"Sat.SMA": 7000}, timeout=60) as ws:
     # ...do whatever you need with df before leaving the block
 ```
 
-The caller already knows the script's output filenames, so they read directly
-out of the workspace — no need to round-trip a file mapping through the
-subprocess.
-
 ## How it works
 
 - `subprocess.run(timeout=...)` does the cross-platform kill: `SIGTERM` on

--- a/docs/timeouts.md
+++ b/docs/timeouts.md
@@ -1,0 +1,110 @@
+# Wall-clock timeouts
+
+[`Mission.run`][gmat_run.Mission.run] does not take a `timeout=` keyword. A
+divergent solver, a bad fixture, or a hung subscriber can therefore block the
+calling Python process indefinitely — short of restarting the kernel, there is
+no way out from inside the same interpreter.
+
+The library deliberately stops at that line: a built-in subprocess driver was
+prototyped in [#84](https://github.com/astro-tools/gmat-run/pull/84) and rejected
+in [#73](https://github.com/astro-tools/gmat-run/issues/73) on cost/benefit
+grounds. The use case is narrow (real GMAT runs are slow, not hung), and the
+~25-line subprocess recipe below covers it without dragging cross-platform
+process management into the library.
+
+If you actually need a wall-clock cap, lift the snippet below into your own
+code.
+
+## Recipe
+
+```python
+import json
+import subprocess
+import sys
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+
+DRIVER = """
+import json
+import sys
+
+from gmat_run import Mission
+
+payload = json.loads(sys.stdin.read())
+mission = Mission.load(payload["script"])
+for k, v in payload["overrides"].items():
+    mission[k] = v
+mission.run(working_dir=payload["workspace"])
+"""
+
+
+@contextmanager
+def run_with_timeout(script, overrides, timeout):
+    """Run a GMAT mission in a child process under a wall-clock cap.
+
+    Yields the workspace path. The temp dir is cleaned up on context exit,
+    so read every output you need before leaving the ``with`` block.
+    """
+    with tempfile.TemporaryDirectory() as workspace:
+        payload = json.dumps(
+            {
+                "script": str(script),
+                "overrides": overrides,
+                "workspace": workspace,
+            }
+        )
+        try:
+            subprocess.run(
+                [sys.executable, "-c", DRIVER],
+                input=payload,
+                text=True,
+                timeout=timeout,
+                check=True,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(f"mission exceeded {timeout} s") from exc
+        yield Path(workspace)
+```
+
+## Using it
+
+```python
+import pandas as pd
+
+with run_with_timeout("flyby.script", {"Sat.SMA": 7000}, timeout=60) as ws:
+    df = pd.read_csv(ws / "ReportFile1.txt", sep=r"\s+")
+    # ...do whatever you need with df before leaving the block
+```
+
+The caller already knows the script's output filenames, so they read directly
+out of the workspace — no need to round-trip a file mapping through the
+subprocess.
+
+## How it works
+
+- `subprocess.run(timeout=...)` does the cross-platform kill: `SIGTERM` on
+  POSIX, `TerminateProcess` on Windows. There is nothing for the library to
+  add on top.
+- `tempfile.TemporaryDirectory` owns the workspace lifetime; the `with`
+  block on the caller side keeps it alive until you've finished reading.
+- The driver uses `json` rather than `pickle` for the override payload — only
+  JSON-encodable values cross the process boundary. If you need to pass numpy
+  arrays, convert with `.tolist()` first.
+- The child process pays the full `gmat_run.bootstrap()` cost on every call.
+  That's the right price for the use case (wall-clock-bounded, occasionally
+  killed); for tight inner loops, run in-process without the timeout.
+
+## Limitations
+
+- **No partial results on timeout.** When the cap fires, the child process is
+  killed mid-run — output files in the workspace may be empty, truncated, or
+  missing. The recipe surfaces only the timeout itself; recovering whatever
+  GMAT had flushed to disk is on you.
+- **One timeout per call.** Wrapping `Mission.run` from inside an in-process
+  thread does not work — `gmat.RunScript` holds the GIL through a blocking
+  C++ call, so Python signals never fire. The subprocess split is what makes
+  the cap real.
+- **JSON-only overrides.** `Mission["Sat.OrbitState"] = np.array([...])`
+  works in-process (PR #85) but the array has to be pre-converted to a list
+  before crossing the subprocess boundary here.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -37,6 +37,7 @@ nav:
   - Getting started: getting-started.md
   - Install GMAT: install-gmat.md
   - Working directories: working-directories.md
+  - Wall-clock timeouts: timeouts.md
   - CLI usage: cli.md
   - Examples:
       - examples/index.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gmat-run"
-version = "0.2.0"
+version = "0.3.0"
 description = "Run GMAT mission scripts from Python and get results as pandas DataFrames."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/gmat_run/__init__.py
+++ b/src/gmat_run/__init__.py
@@ -13,7 +13,7 @@ from gmat_run.mission import Mission
 from gmat_run.results import Results
 from gmat_run.runtime import bootstrap
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 __all__ = [
     "GmatError",

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -4,4 +4,4 @@ import gmat_run
 
 
 def test_import() -> None:
-    assert gmat_run.__version__ == "0.2.0"
+    assert gmat_run.__version__ == "0.3.0"

--- a/uv.lock
+++ b/uv.lock
@@ -861,7 +861,7 @@ wheels = [
 
 [[package]]
 name = "gmat-run"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

- Bumps `__version__` to `0.3.0` in `pyproject.toml`, `gmat_run/__init__.py`, the smoke test, and `uv.lock`.
- New `[0.3.0]` `CHANGELOG.md` section, grouped Added / Changed / Fixed, covering every PR that landed since v0.2 — OEM export (#67, #68), time-scale conversion (#64, #65, #66), hardened explicit workspaces (#69), v0.3 example notebooks (#70, #71), the new timeouts cookbook page below, the numpy-coercion ergonomics fix (#85), and the leap-second-instant fix (#80, #81).
- New `docs/timeouts.md` cookbook page — the subprocess `Mission.run` timeout recipe from #73's wontfix close, lifted into the docs site. Recipe is rewritten as a `@contextmanager` so the temp workspace stays alive while the caller reads outputs (the verbatim snippet in #73 returned the path from inside `with`, which would have cleaned the dir up too early). Cross-linked from "Known limitations".
- README cleanup: drop "lands in v0.3" qualifiers from the `[ccsds-ndm]` and `[astropy]` extras (both shipped this release); replace the Code-500 "tracked for v0.3 (#50)" line with a pointer to Known limitations (#50 closed wontfix).
- `docs/known-limitations.md`: bump the parser-format-coverage caveat from "v0.2" to "v0.3".

## Milestone hygiene applied

- Added issue #80 to milestone v0.3 (the leap-second bug fixed by #81).
- Removed milestone tag from PR #81 (the bug is the trackable artifact, per repo convention).
- Added PR #85 to milestone v0.3 (no associated issue; the PR is the only artifact).
- Moved issue #49 from v0.3 → v0.2 (PR #60 shipped it before #63 cut v0.2; v0.2 CHANGELOG already lists it).

The v0.3 milestone now reads 11 closed + 1 open (this PR closing the open one).

## Test plan

- [x] `uv run pytest -m "not integration"` — 643 passed, 15 deselected.
- [x] `uv run ruff check`
- [x] `uv run ruff format --check` — 58 files already formatted.
- [x] `uv run mypy` — 53 source files, no issues.
- [x] CI green on Ubuntu / Windows / macOS.
- [x] Integration tests pass on the runner that has GMAT R2026a installed.

## After merge

- Tag `v0.3.0` from `main`; the existing release workflow handles PyPI trusted publishing.
- Docs site auto-deploys via the existing tag trigger.
- Verify on PyPI: `pip install gmat-run==0.3.0` smoke test, `pip install gmat-run[ccsds-ndm,astropy]==0.3.0` runs the v0.3 example notebooks end-to-end.

Closes #72.