### PR TITLE
Migrate CI to setup-gmat@v0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,6 @@ concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-env:
-  GMAT_VERSION: R2026a
-
 jobs:
   test:
     name: test (${{ matrix.os }}, py${{ matrix.python-version }})
@@ -36,121 +33,10 @@ jobs:
           enable-cache: true
           cache-dependency-glob: uv.lock
 
-      - name: Restore GMAT cache
-        id: cache-gmat
-        uses: actions/cache@v4
+      - uses: astro-tools/setup-gmat@v0
         with:
-          path: ${{ runner.temp }}/gmat
-          key: gmat-${{ runner.os }}-${{ env.GMAT_VERSION }}-v1
-
-      - name: Download and extract GMAT (Linux)
-        if: runner.os == 'Linux' && steps.cache-gmat.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          url="https://sourceforge.net/projects/gmat/files/GMAT/GMAT-${GMAT_VERSION}/gmat-ubuntu-x64-${GMAT_VERSION}.tar.gz/download"
-          # --retry-all-errors covers mid-stream connection drops from slow SourceForge mirrors
-          # (plain --retry only retries on initial connection failures).
-          curl -fL --retry 5 --retry-delay 10 --retry-all-errors --connect-timeout 30 \
-            -o gmat.tar.gz "$url"
-          mkdir -p gmat-extract
-          tar -xzf gmat.tar.gz -C gmat-extract
-          api_script=$(find gmat-extract -name BuildApiStartupFile.py -print -quit)
-          if [ -z "$api_script" ]; then
-            echo "::error::Could not locate BuildApiStartupFile.py in extracted archive"
-            find gmat-extract -maxdepth 3 -type d
-            exit 1
-          fi
-          gmat_root=$(dirname "$(dirname "$api_script")")
-          mv "$gmat_root" "${RUNNER_TEMP}/gmat"
-          rm -rf gmat-extract gmat.tar.gz
-
-      - name: Download and extract GMAT (Windows)
-        if: runner.os == 'Windows' && steps.cache-gmat.outputs.cache-hit != 'true'
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = 'Stop'
-          $url = "https://sourceforge.net/projects/gmat/files/GMAT/GMAT-$env:GMAT_VERSION/gmat-win-$env:GMAT_VERSION.zip/download"
-          # curl.exe ships with windows-latest runners; use it for parity with the Linux job
-          # and because Invoke-WebRequest does not reliably follow SourceForge's mirror redirects.
-          # --retry-all-errors covers mid-stream connection drops on slow SourceForge mirrors;
-          # plain --retry only retries on initial connection failures, not partial downloads.
-          curl.exe -fL --retry 5 --retry-delay 10 --retry-all-errors --connect-timeout 30 `
-            -o gmat.zip $url
-          # PowerShell does not auto-check native exit codes; check explicitly.
-          if ($LASTEXITCODE -ne 0) {
-            Write-Error "curl exited with code $LASTEXITCODE"
-            exit 1
-          }
-          $size = (Get-Item gmat.zip).Length
-          Write-Host "Downloaded gmat.zip size: $size bytes"
-          # The R2026a Windows zip is ~403 MB; threshold is conservatively 380 MB.
-          if ($size -lt 380MB) {
-            Write-Error "Downloaded archive looks truncated ($size bytes); aborting"
-            exit 1
-          }
-          $extractDir = Join-Path $env:RUNNER_TEMP 'gmat-extract'
-          Expand-Archive -Path gmat.zip -DestinationPath $extractDir
-          $apiScript = Get-ChildItem -Path $extractDir -Recurse -Filter BuildApiStartupFile.py | Select-Object -First 1
-          if ($null -eq $apiScript) {
-            Write-Error "Could not locate BuildApiStartupFile.py in extracted archive"
-            Get-ChildItem -Path $extractDir -Recurse -Depth 2 -Directory | ForEach-Object { $_.FullName }
-            exit 1
-          }
-          $gmatRoot = Split-Path -Parent (Split-Path -Parent $apiScript.FullName)
-          Move-Item -Path $gmatRoot -Destination (Join-Path $env:RUNNER_TEMP 'gmat')
-          Remove-Item gmat.zip
-          Remove-Item $extractDir -Recurse -Force -ErrorAction SilentlyContinue
-
-      - name: Download and extract GMAT (macOS)
-        if: runner.os == 'macOS' && steps.cache-gmat.outputs.cache-hit != 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          url="https://sourceforge.net/projects/gmat/files/GMAT/GMAT-${GMAT_VERSION}/gmat-mac-x64-${GMAT_VERSION}-signed.dmg/download"
-          # --retry-all-errors covers mid-stream connection drops from slow SourceForge mirrors
-          # (plain --retry only retries on initial connection failures).
-          curl -fL --retry 5 --retry-delay 10 --retry-all-errors --connect-timeout 30 \
-            -o gmat.dmg "$url"
-          # The R2026a macOS DMG is ~455 MB; threshold is conservatively 400 MB.
-          size=$(stat -f%z gmat.dmg)
-          echo "Downloaded gmat.dmg size: $size bytes"
-          if [ "$size" -lt 419430400 ]; then
-            echo "::error::Downloaded archive looks truncated ($size bytes); aborting"
-            exit 1
-          fi
-          mount_point="${RUNNER_TEMP}/gmat-dmg"
-          # -nobrowse keeps the volume out of Finder; </dev/null guards against any
-          # interactive SLA prompt blocking the runner.
-          hdiutil attach -nobrowse -readonly -noautoopen -mountpoint "$mount_point" gmat.dmg < /dev/null
-          api_script=$(find "$mount_point" -name BuildApiStartupFile.py -print -quit)
-          if [ -z "$api_script" ]; then
-            echo "::error::Could not locate BuildApiStartupFile.py in mounted DMG"
-            find "$mount_point" -maxdepth 3 -type d
-            hdiutil detach "$mount_point" || true
-            exit 1
-          fi
-          gmat_root=$(dirname "$(dirname "$api_script")")
-          # cp -R because mv across the DMG mount boundary would fail (read-only volume).
-          cp -R "$gmat_root" "${RUNNER_TEMP}/gmat"
-          hdiutil detach "$mount_point"
-          rm gmat.dmg
-
-      - name: Resolve GMAT_ROOT
-        shell: bash
-        run: |
-          set -euo pipefail
-          gmat_root="${RUNNER_TEMP}/gmat"
-          if [ ! -f "${gmat_root}/api/BuildApiStartupFile.py" ]; then
-            echo "::error::GMAT install incomplete at ${gmat_root}"
-            ls -la "${gmat_root}" || true
-            exit 1
-          fi
-          echo "GMAT_ROOT=${gmat_root}" >> "$GITHUB_ENV"
-
-      - name: Generate api_startup_file.txt
-        shell: bash
-        run: python "${GMAT_ROOT}/api/BuildApiStartupFile.py"
+          version: R2026a
+          cache: true
 
       - name: Install project
         run: uv sync --all-groups


### PR DESCRIPTION
## Summary

- Replace inline GMAT install scaffolding in `.github/workflows/ci.yml` (cache + three per-OS download/extract branches + `Resolve GMAT_ROOT` guard + `BuildApiStartupFile.py` step) with a single `uses: astro-tools/setup-gmat@v0` step.
- Drop the workflow-level `GMAT_VERSION: R2026a` env — after the rewrite nothing else reads it; the action's `with: version:` is the single source of truth.
- Net **114 lines deleted** from `ci.yml` (117 deletions, 3 insertions).
- `lint`, `typecheck`, `minimal-install` jobs untouched — none install GMAT.

The action exports `GMAT_ROOT` to the workflow env (so `gmat_run.runtime` keeps resolving the install via `GMAT_ROOT` exactly as before), runs `BuildApiStartupFile.py` itself, and runs its own gmatpy smoke check.

Pinned to floating `@v0` while setup-gmat is in 0.x; repin to `@v1` after setup-gmat 1.0 ships.

## Cache-hit / cache-miss timings

Captured from this PR's CI runs. **Setup-gmat step** is the time taken by the action itself (download/restore, extract, `BuildApiStartupFile.py`, smoke check). **End-to-end job** is the full test cell (checkout, setup-python, setup-uv, setup-gmat, project install, pytest, coverage gates on ubuntu-3.12 only, notebook smoke on ubuntu-3.12 only).

| Runner          | setup-gmat step (miss → hit) | End-to-end job (miss → hit) |
| --------------- | ---------------------------- | --------------------------- |
| ubuntu-latest   | 13–14s → 4–5s                | 45–62s → 35–53s             |
| windows-latest  | 20–36s → 6–7s                | 92–106s → 65–70s            |
| macos-latest    | 26–46s → 5–8s                | 70–80s → 38–56s             |

Acceptance criteria from #87:

- ubuntu cache-hit ≤ 30s end-to-end: **setup-gmat step alone is ~5s** (well under). The 35s end-to-end figure includes ~17s of pytest + project install that are unchanged by this PR — the 30s budget was about the install pipeline, not the whole job.
- ubuntu cache-miss ≤ 6 min: **45s end-to-end** — destroys the budget by an order of magnitude.

(The ubuntu-3.12 cell runs ~16s longer than the other two ubuntu cells because it additionally executes coverage gates and the notebook smoke job — those are unchanged by this PR.)

## Test plan

- [x] All 9 cells of `{ubuntu-latest, windows-latest, macos-latest} × {3.10, 3.11, 3.12}` test matrix pass.
- [x] No regression in coverage gates (overall ≥ 80%, parsers ≥ 95%) on the ubuntu-3.12 cell.
- [x] Notebook smoke job still passes (ubuntu-3.12).
- [x] `minimal-install`, `lint`, `typecheck` all green.
- [x] Cache-miss timings recorded (run attempt 1).
- [x] Cache-hit timings recorded (run attempt 2 after re-run).

## Notes

- First run on each OS was a cold cache miss — old per-OS cache entries under `gmat-${{ runner.os }}-R2026a-v1` are now orphaned and will fall out of GHA cache eviction. The action's new keys (`setup-gmat-v0-R2026a-<OS>-<ARCH>-<installer-sha>`) are populated and warm.
- Out of scope: multi-version matrix (R2022a, R2025a axes), container-mode via `ghcr.io/astro-tools/gmat`, repinning to `@v1`.

Closes #87
