### PR TITLE
Add cookbook page: Run gmat-run in your CI with setup-gmat

### DIFF
--- a/docs/ci-with-setup-gmat.md
+++ b/docs/ci-with-setup-gmat.md
@@ -1,0 +1,110 @@
+# Run gmat-run in your CI
+
+[`astro-tools/setup-gmat`](https://github.com/astro-tools/setup-gmat) installs
+GMAT on the runner, caches it across runs, and exports `GMAT_ROOT` to the
+workflow environment. With it, a complete CI workflow for a project that uses
+gmat-run is four steps.
+
+## Minimal workflow
+
+Drop this into `.github/workflows/test.yml`:
+
+```yaml
+name: test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - uses: astro-tools/setup-gmat@v0
+        with:
+          version: R2026a
+          cache: true
+
+      - run: pip install gmat-run
+
+      - run: pytest
+```
+
+`setup-gmat` runs `BuildApiStartupFile.py` and a one-line gmatpy smoke check
+before returning, then exports `GMAT_ROOT` for downstream steps. gmat-run picks
+up `GMAT_ROOT` automatically — no `--gmat-root` flag and no `Mission.load(...,
+gmat_root=...)` argument needed in the test code.
+
+If your project does not have a `pytest` suite yet, swap the last step for a
+one-line discovery smoke that proves the install is wired up:
+
+```yaml
+      - run: python -c "from gmat_run import locate_gmat; print(locate_gmat().version)"
+```
+
+## Optional extras
+
+Some gmat-run features are gated behind extras. Install the ones you need in
+the same step as gmat-run itself:
+
+```yaml
+      - run: pip install 'gmat-run[spiceypy,ccsds-ndm,astropy]'
+```
+
+| Extra          | Pulls in                                                                    |
+| -------------- | --------------------------------------------------------------------------- |
+| `[spiceypy]`   | SPK ephemeris parsing in [`Results.ephemerides`][gmat_run.Results].         |
+| `[ccsds-ndm]`  | CCSDS-NDM (OEM/OPM) parsing on the same lazy mapping.                       |
+| `[astropy]`    | [`gmat_run.time`](reference/time.md) leap-second-correct time-scale conversion. |
+
+The extras compose; pass several in one bracketed list as above.
+
+## Caching
+
+`cache: true` is the default and caches the resolved GMAT install across runs,
+keyed on `(action major version, GMAT version, runner OS, runner arch,
+installer SHA-256)`. First run on each `(OS, version)` pair is a cold download
++ extract (a few minutes); subsequent runs restore from cache in seconds. The
+key includes the installer hash, so an upstream installer rebuild invalidates
+the cache automatically.
+
+## Multi-version testing
+
+Add a `version:` axis to your matrix to exercise multiple GMAT releases:
+
+```yaml
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        gmat-version: [R2025a, R2026a]
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - uses: astro-tools/setup-gmat@v0
+        with:
+          version: ${{ matrix.gmat-version }}
+          cache: true
+      - run: pip install gmat-run
+      - run: pytest
+```
+
+Each cell gets its own cache entry, so adding a version costs a one-time cold
+install per OS.
+
+The `(runner, GMAT version, Python version)` cells that setup-gmat actually
+ships are listed in
+[setup-gmat's README](https://github.com/astro-tools/setup-gmat#supported-versions),
+along with the Python-ABI-per-release pinning rule — pin Python to a version
+that the targeted GMAT release shipped gmatpy bindings for, or
+`BuildApiStartupFile.py` will fail at install time with a missing `_pyXYZ`
+module.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -86,6 +86,13 @@ See [Working directories](working-directories.md) for the full rules — pre-exi
 artefacts, absolute filenames in the script, permission errors, and the `overwrite=`
 opt-in for re-running into a populated workspace.
 
+## Running in CI
+
+In GitHub Actions, install GMAT with
+[`astro-tools/setup-gmat`](https://github.com/astro-tools/setup-gmat) and add a
+`pip install gmat-run` step — see
+[Run gmat-run in your CI](ci-with-setup-gmat.md) for a copy-paste workflow.
+
 ## Errors
 
 Every exception gmat-run raises inherits from [`GmatError`][gmat_run.GmatError]. Branch

--- a/docs/install-gmat.md
+++ b/docs/install-gmat.md
@@ -4,6 +4,10 @@ gmat-run does not ship GMAT binaries. Install GMAT separately from
 [gmat.gsfc.nasa.gov](https://gmat.gsfc.nasa.gov/) or directly from
 [SourceForge](https://sourceforge.net/projects/gmat/files/GMAT/).
 
+If you're running gmat-run in GitHub Actions, see
+[Run gmat-run in your CI](ci-with-setup-gmat.md) instead — `setup-gmat`
+handles the install for you.
+
 ## Supported versions
 
 | GMAT version          | Status                                                                                |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
   - Install GMAT: install-gmat.md
   - Working directories: working-directories.md
   - Wall-clock timeouts: timeouts.md
+  - Run gmat-run in CI: ci-with-setup-gmat.md
   - CLI usage: cli.md
   - Examples:
       - examples/index.md


### PR DESCRIPTION
## Summary

- New cookbook page `docs/ci-with-setup-gmat.md` walks downstream users through wiring gmat-run into a GitHub Actions workflow built on `astro-tools/setup-gmat@v0`. Sections: minimal workflow, optional extras, caching, multi-version matrix.
- Slotted into `mkdocs.yml` nav next to the other cookbook pages.
- Cross-linked from `getting-started.md` (new "Running in CI" subsection) and `install-gmat.md` (one-liner steering CI users to the new page).

The supported `(runner, GMAT version, Python version)` matrix and the Python-ABI-per-release pinning rule are linked through to setup-gmat's README rather than duplicated here, since that's the upstream's source of truth.

## Test plan

- [x] `uv run mkdocs build --strict` passes with no warnings (validates nav wiring + autorefs cross-links).
- [x] `uv run ruff check` and `uv run ruff format --check` clean.
- [ ] Minimal workflow snippet pasted into a scratch repo and verified end-to-end on Actions; smoke command exits 0. Will note the scratch repo + run URL here once done.

Closes #89