### PR TITLE
Raise overall coverage gate from 80% to 90%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,9 @@ jobs:
       # data is identical across runners, so there's no point re-asserting
       # it on every cell. Per-package gate (parsers/) matches the v0.1
       # charter DoD; overall gate is the project-wide floor.
-      - name: Enforce overall coverage (>=80%)
+      - name: Enforce overall coverage (>=90%)
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && matrix.gmat-version == 'R2026a'
-        run: uv run coverage report --fail-under=80
+        run: uv run coverage report --fail-under=90
 
       - name: Enforce parsers coverage (>=95%)
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' && matrix.gmat-version == 'R2026a'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,14 +44,14 @@ are touching the run/load path.
 
 CI enforces two coverage gates on the Ubuntu / Python 3.12 cell:
 
-- Overall coverage must be ≥ 80%.
+- Overall coverage must be ≥ 90%.
 - The `src/gmat_run/parsers/` package must be ≥ 95%.
 
 To reproduce locally:
 
 ```bash
 uv run pytest -m "integration or not integration" --cov
-uv run coverage report --fail-under=80
+uv run coverage report --fail-under=90
 uv run coverage report --include='src/gmat_run/parsers/*' --fail-under=95
 ```
 


### PR DESCRIPTION
## Summary

- Bumps CI's overall coverage gate from `--fail-under=80` to `--fail-under=90` (the v1.0 charter target), well ahead of the v1.0 cut.
- Updates `CONTRIBUTING.md` to cite the new floor.
- Parsers gate stays at 95% (out of scope per the issue).

## Coverage today

Measured locally on Ubuntu / Python 3.12 / R2026a, `uv run pytest -m "integration or not integration" --cov`. The before/after numbers are identical — this PR adds no tests and no `# pragma: no cover` annotations; it only ratchets the gate up toward the floor that's already been holding for several releases.

| Module | Cov |
|---|---|
| `__init__.py`, `cli.py`, `errors.py`, `parsers/__init__.py`, `parsers/_kernels/__init__.py`, `parsers/contact.py`, `parsers/epoch.py`, `parsers/reportfile.py`, `time.py`, `writers/__init__.py` | 100% |
| `results.py` | 99% |
| `install.py`, `parsers/aem_ephemeris.py`, `runtime.py`, `writers/oem.py` | 98% |
| `parsers/ephemeris.py` | 96% |
| `parsers/stk_ephemeris.py` | 95% |
| `parsers/spk.py` | 93% |
| `mission.py` | **88%** |
| **TOTAL** | **96%** |

## Why `mission.py` is below 90%

The 51 missed statements are all defensive `except Exception: continue`/`return` arms in private helpers (`_discover_attitude_inputs`, `_rewrite_output_paths`, `_initialize_spacecraft`, `_read`/`_coerce` plugin fallbacks, `_check_inside_workspace_collisions`, etc.). They handle gmatpy/C++ misbehaviour — e.g. an object that exposes a type-enum but not the field accessor it implies, a `Moderator.GetListOfObjects` call that raises mid-walk, a workspace path whose `.resolve()` raises `OSError`. These are exactly the "would require GMAT C++ misbehaviour to trigger" paths the issue calls out as a candidate for `# pragma: no cover` — but none of them sit on a public-API branch, the overall floor is comfortably ≥ 90% without intervention, and adding `pragma` annotations now would be churn for no gate benefit. Leaving them as-is.

The public surface of `Mission` itself is exercised end-to-end by `test_mission.py` plus the integration suite.

## Test plan

- [x] `uv run pytest -m "integration or not integration" --cov` (passes locally; 658 tests, 96% overall)
- [x] `uv run coverage report --fail-under=90` (passes locally)
- [x] `uv run coverage report --include='src/gmat_run/parsers/*' --fail-under=95` (passes locally; 97%)
- [ ] CI overall + parsers gates green on the PR

Closes #90