### PR TITLE
Add Mission.summary() and notebook reprs for Mission and Results

### DIFF
--- a/docs/examples/01_load_run_plot.ipynb
+++ b/docs/examples/01_load_run_plot.ipynb
@@ -35,10 +35,10 @@
    "id": "069b67f5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-26T16:35:33.526096Z",
-     "iopub.status.busy": "2026-04-26T16:35:33.525948Z",
-     "iopub.status.idle": "2026-04-26T16:35:37.403950Z",
-     "shell.execute_reply": "2026-04-26T16:35:37.402931Z"
+     "iopub.execute_input": "2026-05-03T16:35:08.886248Z",
+     "iopub.status.busy": "2026-05-03T16:35:08.886079Z",
+     "iopub.status.idle": "2026-05-03T16:35:12.400181Z",
+     "shell.execute_reply": "2026-05-03T16:35:12.399019Z"
     }
    },
    "outputs": [
@@ -84,10 +84,10 @@
    "id": "3311d486",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-26T16:35:37.405614Z",
-     "iopub.status.busy": "2026-04-26T16:35:37.405378Z",
-     "iopub.status.idle": "2026-04-26T16:35:37.652098Z",
-     "shell.execute_reply": "2026-04-26T16:35:37.651016Z"
+     "iopub.execute_input": "2026-05-03T16:35:12.402024Z",
+     "iopub.status.busy": "2026-05-03T16:35:12.401591Z",
+     "iopub.status.idle": "2026-05-03T16:35:12.644939Z",
+     "shell.execute_reply": "2026-05-03T16:35:12.643769Z"
     }
    },
    "outputs": [
@@ -111,6 +111,49 @@
   },
   {
    "cell_type": "markdown",
+   "id": "fa7525f4",
+   "metadata": {},
+   "source": [
+    "### Inspect the loaded mission\n",
+    "\n",
+    "`mission` has a notebook-friendly repr that prints a structured summary of the script rather than the default `<...object at 0x...>` form. Resources are grouped by type, outputs are listed by resource name, and the mission sequence is shown one level deep — useful for sanity-checking what's inside a script before running it.\n",
+    "\n",
+    "Calling `mission.summary()` returns the same record as a structured [`MissionSummary`](https://astro-tools.github.io/gmat-run/reference/summary/) dataclass."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "7baf7527",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-03T16:35:12.646398Z",
+     "iopub.status.busy": "2026-05-03T16:35:12.646242Z",
+     "iopub.status.idle": "2026-05-03T16:35:12.652299Z",
+     "shell.execute_reply": "2026-05-03T16:35:12.651271Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"gmat-run-mission-summary\"><strong>Mission:</strong> <code>Ex_TLE_Propagation.script</code><table class=\"gmat-run-resources\"><thead><tr><th style=\"text-align:left\">Resource type</th><th style=\"text-align:right\">Count</th><th style=\"text-align:left\">Names</th></tr></thead><tbody><tr><td style=\"text-align:left\">Spacecraft</td><td style=\"text-align:right\">1</td><td style=\"text-align:left\">ExampleSat</td></tr><tr><td style=\"text-align:left\">Propagator</td><td style=\"text-align:right\">1</td><td style=\"text-align:left\">TLEProp</td></tr><tr><td style=\"text-align:left\">CoordinateSystem</td><td style=\"text-align:right\">4</td><td style=\"text-align:left\">EarthMJ2000Eq, EarthMJ2000Ec, EarthFixed, EarthICRF</td></tr><tr><td style=\"text-align:left\">ReportFile</td><td style=\"text-align:right\">1</td><td style=\"text-align:left\">RF</td></tr><tr><td style=\"text-align:left\">Other</td><td style=\"text-align:right\">9</td><td style=\"text-align:left\">SolarSystemBarycenter, ExampleSat.UTCGregorian, ExampleSat.X, ExampleSat.Y, ExampleSat.Z, ExampleSat.VX, ExampleSat.VY, ExampleSat.VZ, ExampleSat.ElapsedDays</td></tr></tbody></table><strong>Outputs</strong><table class=\"gmat-run-outputs\"><thead><tr><th style=\"text-align:left\">Resource type</th><th style=\"text-align:left\">Names</th></tr></thead><tbody><tr><td style=\"text-align:left\">ReportFile</td><td style=\"text-align:left\">RF</td></tr></tbody></table><strong>Mission sequence</strong> (2 commands)<ol><li><code>BeginMissionSequence</code> — %----------------------------------------</li><li><code>Propagate</code> — Propagate TLEProp(ExampleSat) {ExampleSat.ElapsedDays = 1.0};</li></ol></div>"
+      ],
+      "text/plain": [
+       "Mission('Ex_TLE_Propagation.script', spacecraft=1, commands=2)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mission"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "6289f391",
    "metadata": {},
    "source": [
@@ -123,14 +166,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "37a9eec8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-26T16:35:37.653702Z",
-     "iopub.status.busy": "2026-04-26T16:35:37.653532Z",
-     "iopub.status.idle": "2026-04-26T16:35:37.745239Z",
-     "shell.execute_reply": "2026-04-26T16:35:37.744195Z"
+     "iopub.execute_input": "2026-05-03T16:35:12.653816Z",
+     "iopub.status.busy": "2026-05-03T16:35:12.653660Z",
+     "iopub.status.idle": "2026-05-03T16:35:12.742886Z",
+     "shell.execute_reply": "2026-05-03T16:35:12.741827Z"
     }
    },
    "outputs": [
@@ -235,7 +278,7 @@
        "4       6.537478       2.697625       2.347662  "
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -248,6 +291,47 @@
   },
   {
    "cell_type": "markdown",
+   "id": "b708869f",
+   "metadata": {},
+   "source": [
+    "### Inspect the Results\n",
+    "\n",
+    "`Results` has the same notebook treatment: bare-evaluating it lists the reports, ephemerides, and contacts the run produced (by name only — the DataFrames are not materialised, so this stays cheap)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "f7132fb1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-05-03T16:35:12.744364Z",
+     "iopub.status.busy": "2026-05-03T16:35:12.744199Z",
+     "iopub.status.idle": "2026-05-03T16:35:12.748101Z",
+     "shell.execute_reply": "2026-05-03T16:35:12.747134Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div class=\"gmat-run-results\"><strong>Results</strong><table><thead><tr><th style=\"text-align:left\">Output</th><th style=\"text-align:right\">Count</th><th style=\"text-align:left\">Names</th></tr></thead><tbody><tr><td style=\"text-align:left\"><code>reports</code></td><td style=\"text-align:right\">1</td><td style=\"text-align:left\">RF</td></tr><tr><td style=\"text-align:left\"><code>ephemerides</code></td><td style=\"text-align:right\">0</td><td style=\"text-align:left\"><em>none</em></td></tr><tr><td style=\"text-align:left\"><code>contacts</code></td><td style=\"text-align:right\">0</td><td style=\"text-align:left\"><em>none</em></td></tr></tbody></table></div>"
+      ],
+      "text/plain": [
+       "Results(reports=1, ephemerides=0, contacts=0)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c8f93971",
    "metadata": {},
    "source": [
@@ -256,14 +340,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 6,
    "id": "2ae2939c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-26T16:35:37.746826Z",
-     "iopub.status.busy": "2026-04-26T16:35:37.746665Z",
-     "iopub.status.idle": "2026-04-26T16:35:37.751976Z",
-     "shell.execute_reply": "2026-04-26T16:35:37.750963Z"
+     "iopub.execute_input": "2026-05-03T16:35:12.749459Z",
+     "iopub.status.busy": "2026-05-03T16:35:12.749311Z",
+     "iopub.status.idle": "2026-05-03T16:35:12.754117Z",
+     "shell.execute_reply": "2026-05-03T16:35:12.753223Z"
     }
    },
    "outputs": [
@@ -280,7 +364,7 @@
        "dtype: object"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 6,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -301,14 +385,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 7,
    "id": "346f1d57",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-26T16:35:37.753539Z",
-     "iopub.status.busy": "2026-04-26T16:35:37.753317Z",
-     "iopub.status.idle": "2026-04-26T16:35:38.166256Z",
-     "shell.execute_reply": "2026-04-26T16:35:38.165359Z"
+     "iopub.execute_input": "2026-05-03T16:35:12.755655Z",
+     "iopub.status.busy": "2026-05-03T16:35:12.755466Z",
+     "iopub.status.idle": "2026-05-03T16:35:13.150591Z",
+     "shell.execute_reply": "2026-05-03T16:35:13.149653Z"
     }
    },
    "outputs": [
@@ -348,7 +432,13 @@
    "cell_type": "markdown",
    "id": "6d0c67a9",
    "metadata": {},
-   "source": "## Where to next\n\n- **Override script fields from Python.** The [Getting started guide](https://astro-tools.github.io/gmat-run/getting-started/) shows how to write to fields via subscript access (e.g. `mission['Sat.SMA'] = 7000`) before running.\n- **Read other output types.** `Results` also exposes `.ephemerides` (CCSDS-OEM and STK-TimePosVel formats) and `.contacts` (`ContactLocator`) as DataFrames — see the [API reference](https://astro-tools.github.io/gmat-run/reference/).\n- **Run from the shell.** The [`gmat-run` CLI](https://astro-tools.github.io/gmat-run/cli/) wraps the same load → run → write loop for shell scripts and smoke tests."
+   "source": [
+    "## Where to next\n",
+    "\n",
+    "- **Override script fields from Python.** The [Getting started guide](https://astro-tools.github.io/gmat-run/getting-started/) shows how to write to fields via subscript access (e.g. `mission['Sat.SMA'] = 7000`) before running.\n",
+    "- **Read other output types.** `Results` also exposes `.ephemerides` (CCSDS-OEM and STK-TimePosVel formats) and `.contacts` (`ContactLocator`) as DataFrames — see the [API reference](https://astro-tools.github.io/gmat-run/reference/).\n",
+    "- **Run from the shell.** The [`gmat-run` CLI](https://astro-tools.github.io/gmat-run/cli/) wraps the same load → run → write loop for shell scripts and smoke tests."
+   ]
   }
  ],
  "metadata": {

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -17,6 +17,11 @@ The reference splits into one page per module:
   [`Mission.run`][gmat_run.Mission.run]: `reports`, `ephemerides`, `contacts`
   as lazy `Mapping[str, pandas.DataFrame]`, plus
   [`Results.persist`][gmat_run.Results.persist].
+- [Mission summary](summary.md) — the dataclass schema returned by
+  [`Mission.summary`][gmat_run.Mission.summary]
+  ([`MissionSummary`][gmat_run.MissionSummary],
+  [`ResourceGroup`][gmat_run.ResourceGroup],
+  [`CommandOutline`][gmat_run.CommandOutline]).
 - [Install discovery](install.md) —
   [`locate_gmat`][gmat_run.locate_gmat] and the
   [`GmatInstall`][gmat_run.GmatInstall] dataclass.

--- a/docs/reference/summary.md
+++ b/docs/reference/summary.md
@@ -1,0 +1,45 @@
+# Mission summary
+
+[`Mission.summary`][gmat_run.Mission.summary] returns a structured snapshot of
+a loaded mission: resources grouped by type, declared output resources, and
+the top-level mission-sequence outline. The same snapshot backs the notebook
+reprs on [`Mission`][gmat_run.Mission] and [`Results`][gmat_run.Results] —
+ending a cell on a bare `mission` reference renders the table inline instead
+of the default `<gmat_run.mission.Mission object at 0x…>` form.
+
+The walk is name-only and one level deep into branch commands. It does not
+materialise field values (use `mission["Sat.SMA"]` for that) and it does not
+render deeper nesting as a tree — a `Target` containing several `Vary`
+commands each containing a `Propagate` shows the `Vary`s and a count of the
+deeper descendants.
+
+```python
+from gmat_run import Mission
+
+mission = Mission.load("flyby.script")
+summary = mission.summary()
+
+print(summary)
+# MissionSummary('flyby.script')
+#
+# Resources
+#   Spacecraft (1): Sat
+#   ForceModel (1): FM
+#   Propagator (1): Prop
+#   ReportFile (1): RF
+#
+# Outputs
+#   ReportFile: RF
+#
+# Mission sequence (2 commands)
+#   1. Propagate — Propagate Prop(Sat) {Sat.ElapsedDays = 1};
+#   2. Maneuver — Maneuver TOI(Sat);
+```
+
+## Schema
+
+::: gmat_run.MissionSummary
+
+::: gmat_run.ResourceGroup
+
+::: gmat_run.CommandOutline

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
       - reference/index.md
       - Mission: reference/mission.md
       - Results: reference/results.md
+      - Mission summary: reference/summary.md
       - Install discovery: reference/install.md
       - Runtime bootstrap: reference/runtime.md
       - Exceptions: reference/errors.md

--- a/src/gmat_run/__init__.py
+++ b/src/gmat_run/__init__.py
@@ -12,10 +12,12 @@ from gmat_run.install import GmatInstall, locate_gmat
 from gmat_run.mission import Mission
 from gmat_run.results import Results
 from gmat_run.runtime import bootstrap
+from gmat_run.summary import CommandOutline, MissionSummary, ResourceGroup
 
 __version__ = "0.3.0"
 
 __all__ = [
+    "CommandOutline",
     "GmatError",
     "GmatFieldError",
     "GmatInstall",
@@ -24,6 +26,8 @@ __all__ = [
     "GmatOutputParseError",
     "GmatRunError",
     "Mission",
+    "MissionSummary",
+    "ResourceGroup",
     "Results",
     "__version__",
     "bootstrap",

--- a/src/gmat_run/mission.py
+++ b/src/gmat_run/mission.py
@@ -38,6 +38,7 @@ from gmat_run.install import GmatInstall, locate_gmat
 from gmat_run.parsers.aem_ephemeris import parse as _parse_aem_ephemeris
 from gmat_run.results import Results
 from gmat_run.runtime import bootstrap
+from gmat_run.summary import MissionSummary, build_mission_summary
 
 __all__ = ["Mission"]
 
@@ -233,6 +234,29 @@ class Mission:
         ``__getitem__`` / ``__setitem__`` interface.
         """
         return self._gmat
+
+    def summary(self) -> MissionSummary:
+        """Return a structured snapshot of this loaded mission.
+
+        See :class:`~gmat_run.summary.MissionSummary` for the schema. Walks
+        the gmat object graph each call — there is no cache, so a Mission
+        whose fields were edited via ``__setitem__`` and re-summarised
+        reflects the latest state. The walk only enumerates resources by name
+        and the command graph one level deep; it does not materialise field
+        values (use ``mission["Sat.SMA"]`` for that).
+        """
+        return build_mission_summary(self._gmat, self.script_path)
+
+    def __repr__(self) -> str:
+        summary = self.summary()
+        return (
+            f"Mission({summary.script_name!r}, "
+            f"spacecraft={summary.spacecraft_count}, "
+            f"commands={summary.command_count})"
+        )
+
+    def _repr_html_(self) -> str:
+        return self.summary()._repr_html_()
 
     def __getitem__(self, dotted: str) -> Any:
         resource, field = _split_path(dotted)

--- a/src/gmat_run/results.py
+++ b/src/gmat_run/results.py
@@ -36,6 +36,7 @@ from gmat_run.parsers.spk import is_spk_ephemeris as _is_spk_ephemeris
 from gmat_run.parsers.spk import parse as _parse_spk_ephemeris
 from gmat_run.parsers.stk_ephemeris import is_stk_ephemeris as _is_stk_ephemeris
 from gmat_run.parsers.stk_ephemeris import parse as _parse_stk_ephemeris
+from gmat_run.summary import format_results_html as _format_results_html
 from gmat_run.writers.oem import write_oem as _write_oem
 
 __all__ = ["Results"]
@@ -226,6 +227,20 @@ class Results:
         self.contact_paths = MappingProxyType(con_paths)
         self.ephemerides = _LazyEphemerides(eph_paths)
         self.contacts = _LazyContacts(con_paths)
+
+    def __repr__(self) -> str:
+        return (
+            f"Results(reports={len(self.reports)}, "
+            f"ephemerides={len(self.ephemerides)}, "
+            f"contacts={len(self.contacts)})"
+        )
+
+    def _repr_html_(self) -> str:
+        return _format_results_html(
+            report_names=tuple(self.reports),
+            ephemeris_names=tuple(self.ephemerides),
+            contact_names=tuple(self.contacts),
+        )
 
     def persist(self, path: str | os.PathLike[str]) -> Results:
         """Copy every output artefact under :attr:`output_dir` into ``path``.

--- a/src/gmat_run/summary.py
+++ b/src/gmat_run/summary.py
@@ -1,0 +1,565 @@
+"""Read-only snapshot of a loaded :class:`~gmat_run.mission.Mission` graph.
+
+Backs :meth:`gmat_run.mission.Mission.summary` and the notebook-friendly
+``__repr__`` / ``_repr_html_`` on both :class:`~gmat_run.mission.Mission` and
+:class:`~gmat_run.results.Results`.
+
+The walkers here only call gmatpy's public interface — ``Moderator`` and the
+``GmatBase`` / ``GmatCommand`` contracts — so a fake gmat module that mirrors
+those (like the one in ``tests/test_mission.py``) drives the same code path
+as real gmatpy.
+
+The snapshot is name-only: resource names, command type names, and a
+truncated first-line summary per command. It does not materialise field
+values — ``mission["Sat.SMA"]`` already serves that need.
+"""
+
+from __future__ import annotations
+
+import html
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Final
+
+__all__ = [
+    "CommandOutline",
+    "MissionSummary",
+    "ResourceGroup",
+    "build_mission_summary",
+    "format_results_html",
+]
+
+
+# --- categorisation -----------------------------------------------------------
+
+# Display order for resource categories in :class:`MissionSummary`. The named
+# buckets come from the issue; "Other" catches anything reachable from the
+# configured-object enumeration that doesn't match a named type.
+_RESOURCE_CATEGORY_ORDER: Final = (
+    "Spacecraft",
+    "ForceModel",
+    "Propagator",
+    "CoordinateSystem",
+    "ImpulsiveBurn",
+    "FiniteBurn",
+    "ReportFile",
+    "EphemerisFile",
+    "ContactLocator",
+    "Solver",
+    "Subscriber",
+    "Other",
+)
+
+# Subset that produces files at run time. Ordered to match the keys on
+# :class:`gmat_run.results.Results` (``reports`` / ``ephemerides`` /
+# ``contacts``).
+_OUTPUT_CATEGORY_ORDER: Final = (
+    "ReportFile",
+    "EphemerisFile",
+    "ContactLocator",
+)
+
+# GMAT ``GetTypeName()`` -> display category. ``PropSetup`` is what scripts
+# call ``Propagator``, and ``ODEModel`` is what scripts call ``ForceModel``
+# (see the class hierarchy in ``.claude/skills/gmat-python/references/objects.md``
+# under ``src/.repo-template`` for the cross-reference). Both legacy spellings
+# are accepted in case a future GMAT release exposes the script-level name
+# directly.
+_TYPE_NAME_TO_CATEGORY: Final = {
+    "Spacecraft": "Spacecraft",
+    "ODEModel": "ForceModel",
+    "ForceModel": "ForceModel",
+    "PropSetup": "Propagator",
+    "Propagator": "Propagator",
+    "CoordinateSystem": "CoordinateSystem",
+    "ImpulsiveBurn": "ImpulsiveBurn",
+    "FiniteBurn": "FiniteBurn",
+    "ReportFile": "ReportFile",
+    "EphemerisFile": "EphemerisFile",
+    "ContactLocator": "ContactLocator",
+}
+
+# Enum attribute names probed on the gmat module to enumerate configured
+# objects. ``UNKNOWN_OBJECT`` is the union over every configured type when
+# present; the named buckets are walked in addition so a fake gmat module
+# that only exposes a subset of enums still finds its resources. Each name is
+# resolved with ``getattr(..., None)`` and tolerated when missing.
+_RESOURCE_ENUM_ATTRS: Final = (
+    "UNKNOWN_OBJECT",
+    "SPACECRAFT",
+    "FORCE_MODEL",
+    "PROP_SETUP",
+    "COORDINATE_SYSTEM",
+    "BURN",
+    "SUBSCRIBER",
+    "EVENT_LOCATOR",
+    "SOLVER",
+)
+
+# Maximum width for a single command's first-line summary. GMAT's
+# ``GetGeneratingString`` for a Propagate can run hundreds of characters;
+# truncating keeps notebook reprs readable without dropping the leading text.
+_COMMAND_SUMMARY_WIDTH: Final = 100
+
+
+# --- dataclasses --------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ResourceGroup:
+    """One resource category and the resource names that fall under it.
+
+    Names appear in the order GMAT returns them from
+    ``Moderator.GetListOfObjects`` for the matching enum, which corresponds to
+    declaration order in the loaded ``.script``.
+    """
+
+    category: str
+    names: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class CommandOutline:
+    """One node in the mission-sequence outline.
+
+    ``children`` is the depth-1 expansion of a branch command (``If``,
+    ``For``, ``While``, ``Target``, ``Optimize``, ``BeginScript``, ...).
+    Deeper nesting is not materialised; ``nested_count`` is the number of
+    descendants past the first nested level so the caller can tell that, e.g.,
+    a ``Target`` with three ``Vary`` children each containing a ``Propagate``
+    has 3 nested commands beyond what ``children`` shows.
+
+    ``summary`` is the first non-blank line of the command's
+    ``GetGeneratingString`` output, truncated. It is ``""`` when the engine
+    returns nothing useful — some plugin commands simply don't implement that
+    method.
+    """
+
+    type_name: str
+    summary: str
+    children: tuple[CommandOutline, ...] = ()
+    nested_count: int = 0
+
+
+@dataclass(frozen=True)
+class MissionSummary:
+    """Read-only snapshot of a loaded mission's structure.
+
+    Returned by :meth:`gmat_run.mission.Mission.summary`. Backs both
+    :meth:`gmat_run.mission.Mission.__repr__` (one-line text) and
+    :meth:`gmat_run.mission.Mission._repr_html_` (notebook table).
+
+    Attributes:
+        script_name: ``Path.name`` of the loaded script.
+        resource_groups: One :class:`ResourceGroup` per non-empty category,
+            in :data:`_RESOURCE_CATEGORY_ORDER`.
+        output_resources: Subset of ``resource_groups`` covering only the
+            categories that produce files at run time
+            (``ReportFile`` / ``EphemerisFile`` / ``ContactLocator``).
+        commands: Top-level mission-sequence commands in declaration order.
+    """
+
+    script_name: str
+    resource_groups: tuple[ResourceGroup, ...]
+    output_resources: tuple[ResourceGroup, ...]
+    commands: tuple[CommandOutline, ...]
+
+    @property
+    def spacecraft_count(self) -> int:
+        """Number of Spacecraft resources in the loaded script."""
+        for group in self.resource_groups:
+            if group.category == "Spacecraft":
+                return len(group.names)
+        return 0
+
+    @property
+    def command_count(self) -> int:
+        """Number of top-level commands in the mission sequence."""
+        return len(self.commands)
+
+    def __repr__(self) -> str:
+        lines: list[str] = [f"MissionSummary({self.script_name!r})"]
+        if self.resource_groups:
+            lines.append("")
+            lines.append("Resources")
+            for group in self.resource_groups:
+                names = ", ".join(group.names)
+                lines.append(f"  {group.category} ({len(group.names)}): {names}")
+        if self.output_resources:
+            lines.append("")
+            lines.append("Outputs")
+            for group in self.output_resources:
+                names = ", ".join(group.names)
+                lines.append(f"  {group.category}: {names}")
+        lines.append("")
+        lines.append(f"Mission sequence ({self.command_count} commands)")
+        if not self.commands:
+            lines.append("  (empty)")
+        else:
+            for idx, cmd in enumerate(self.commands, start=1):
+                lines.append(f"  {idx}. {_format_command_line(cmd)}")
+                for sub in cmd.children:
+                    lines.append(f"      - {_format_command_line(sub)}")
+                if cmd.nested_count:
+                    lines.append(f"      ({cmd.nested_count} nested commands)")
+        return "\n".join(lines)
+
+    def _repr_html_(self) -> str:
+        return _format_mission_html(self)
+
+
+# --- public walkers -----------------------------------------------------------
+
+
+def build_mission_summary(gmat: ModuleType, script_path: Path) -> MissionSummary:
+    """Build a :class:`MissionSummary` snapshot from a loaded gmatpy graph.
+
+    Args:
+        gmat: The bootstrapped gmatpy module (or a fake mirroring its
+            ``Moderator`` / ``GmatBase`` / ``GmatCommand`` surface).
+        script_path: Source script path; only ``script_path.name`` is used in
+            the snapshot.
+    """
+    by_category = _walk_resources(gmat)
+    resource_groups = tuple(
+        ResourceGroup(category=cat, names=tuple(by_category[cat]))
+        for cat in _RESOURCE_CATEGORY_ORDER
+        if by_category.get(cat)
+    )
+    output_resources = tuple(
+        ResourceGroup(category=cat, names=tuple(by_category[cat]))
+        for cat in _OUTPUT_CATEGORY_ORDER
+        if by_category.get(cat)
+    )
+    commands = tuple(_walk_commands(gmat))
+    return MissionSummary(
+        script_name=script_path.name,
+        resource_groups=resource_groups,
+        output_resources=output_resources,
+        commands=commands,
+    )
+
+
+def format_results_html(
+    *,
+    report_names: Iterable[str],
+    ephemeris_names: Iterable[str],
+    contact_names: Iterable[str],
+) -> str:
+    """Render a small HTML table for :meth:`gmat_run.results.Results._repr_html_`.
+
+    Lists names per output mapping. No DataFrames are materialised; this only
+    sees the keys.
+    """
+    rows: list[tuple[str, tuple[str, ...]]] = [
+        ("reports", tuple(report_names)),
+        ("ephemerides", tuple(ephemeris_names)),
+        ("contacts", tuple(contact_names)),
+    ]
+    parts: list[str] = ['<div class="gmat-run-results">']
+    parts.append("<strong>Results</strong>")
+    parts.append("<table>")
+    parts.append(
+        "<thead><tr>"
+        '<th style="text-align:left">Output</th>'
+        '<th style="text-align:right">Count</th>'
+        '<th style="text-align:left">Names</th>'
+        "</tr></thead>"
+    )
+    parts.append("<tbody>")
+    for label, names in rows:
+        cell = ", ".join(html.escape(n) for n in names) if names else "<em>none</em>"
+        parts.append(
+            f"<tr>"
+            f'<td style="text-align:left"><code>{label}</code></td>'
+            f'<td style="text-align:right">{len(names)}</td>'
+            f'<td style="text-align:left">{cell}</td>'
+            f"</tr>"
+        )
+    parts.append("</tbody></table>")
+    parts.append("</div>")
+    return "".join(parts)
+
+
+# --- resource walk ------------------------------------------------------------
+
+
+def _walk_resources(gmat: ModuleType) -> dict[str, list[str]]:
+    """Enumerate configured objects and bucket them by display category.
+
+    Walks every enum in :data:`_RESOURCE_ENUM_ATTRS` the gmat module exposes,
+    dedupes names across enums (since ``UNKNOWN_OBJECT`` overlaps the named
+    buckets), classifies each via :func:`_categorize`, and returns a dict
+    keyed by category. Categories with zero entries are absent from the
+    result.
+    """
+    moderator_proxy = getattr(gmat, "Moderator", None)
+    if moderator_proxy is None:
+        return {}
+    moderator = moderator_proxy.Instance()
+    seen: set[str] = set()
+    by_category: dict[str, list[str]] = {}
+    for attr in _RESOURCE_ENUM_ATTRS:
+        type_id = getattr(gmat, attr, None)
+        if type_id is None:
+            continue
+        try:
+            names = list(moderator.GetListOfObjects(type_id))
+        except Exception:
+            continue
+        for name in names:
+            if name in seen:
+                continue
+            seen.add(name)
+            obj = _safe_get_object(gmat, name)
+            if obj is None:
+                continue
+            category = _categorize(obj)
+            by_category.setdefault(category, []).append(name)
+    return by_category
+
+
+def _categorize(obj: Any) -> str:
+    """Return the display category for one configured object."""
+    type_name = _safe_type_name(obj)
+    if type_name in _TYPE_NAME_TO_CATEGORY:
+        return _TYPE_NAME_TO_CATEGORY[type_name]
+    if _is_of_type(obj, "Solver"):
+        return "Solver"
+    if _is_of_type(obj, "Subscriber"):
+        return "Subscriber"
+    return "Other"
+
+
+# --- command walk -------------------------------------------------------------
+
+
+def _walk_commands(gmat: ModuleType) -> list[CommandOutline]:
+    """Walk the loaded mission command sequence one level deep.
+
+    Returns an empty list when the gmat module exposes no ``Moderator`` or
+    when ``GetFirstCommand`` raises (fakes that don't model the command
+    graph). ``BeginMissionSequence`` / ``NoOp`` is treated as the sentinel
+    head of the linked list and skipped — real GMAT prepends one even for an
+    empty mission.
+    """
+    moderator_proxy = getattr(gmat, "Moderator", None)
+    if moderator_proxy is None:
+        return []
+    try:
+        first = moderator_proxy.Instance().GetFirstCommand()
+    except Exception:
+        return []
+    if first is None:
+        return []
+    node = first
+    head_type = _safe_type_name(first)
+    if head_type in {"NoOp", "BeginMissionSequence"}:
+        try:
+            node = first.GetNext()
+        except Exception:
+            return []
+    outlines: list[CommandOutline] = []
+    while node is not None:
+        outlines.append(_outline_command(node, depth=0))
+        try:
+            node = node.GetNext()
+        except Exception:
+            break
+    return outlines
+
+
+def _outline_command(node: Any, *, depth: int) -> CommandOutline:
+    """Build a :class:`CommandOutline` for a single command node.
+
+    ``depth=0`` materialises the children of a branch command. ``depth>=1``
+    short-circuits child materialisation so deeper nesting is summarised by
+    :attr:`CommandOutline.nested_count` on the depth-0 ancestor.
+    """
+    type_name = _safe_type_name(node) or "Command"
+    summary = _command_summary(node)
+    children: tuple[CommandOutline, ...] = ()
+    nested_count = 0
+    if depth == 0 and _is_branch(node):
+        child = _safe_child_command(node)
+        child_outlines: list[CommandOutline] = []
+        nested = 0
+        while child is not None:
+            child_outlines.append(_outline_command(child, depth=1))
+            nested += _count_descendants(child)
+            try:
+                child = child.GetNext()
+            except Exception:
+                break
+        children = tuple(child_outlines)
+        nested_count = nested
+    return CommandOutline(
+        type_name=type_name,
+        summary=summary,
+        children=children,
+        nested_count=nested_count,
+    )
+
+
+def _count_descendants(node: Any) -> int:
+    """Total nodes nested under ``node`` (depth >= 2 from the top-level)."""
+    if not _is_branch(node):
+        return 0
+    count = 0
+    child = _safe_child_command(node)
+    while child is not None:
+        count += 1
+        count += _count_descendants(child)
+        try:
+            child = child.GetNext()
+        except Exception:
+            break
+    return count
+
+
+def _command_summary(node: Any) -> str:
+    """First non-blank line of ``GetGeneratingString``, truncated.
+
+    Returns ``""`` when the engine returns nothing or raises — the type name
+    in :attr:`CommandOutline.type_name` carries the essential information.
+    """
+    try:
+        text = str(node.GetGeneratingString())
+    except Exception:
+        return ""
+    if not text:
+        return ""
+    line = next((s.strip() for s in text.splitlines() if s.strip()), "")
+    if len(line) > _COMMAND_SUMMARY_WIDTH:
+        line = line[: _COMMAND_SUMMARY_WIDTH - 1].rstrip() + "…"
+    return line
+
+
+def _is_branch(node: Any) -> bool:
+    """True if the command node has nested children (``If`` / ``For`` / …)."""
+    try:
+        return bool(node.IsOfType("BranchCommand"))
+    except Exception:
+        return False
+
+
+def _safe_child_command(node: Any) -> Any:
+    """``GetChildCommand()`` tolerant of nullary vs. indexed signatures."""
+    try:
+        return node.GetChildCommand()
+    except TypeError:
+        try:
+            return node.GetChildCommand(0)
+        except Exception:
+            return None
+    except Exception:
+        return None
+
+
+# --- shared object helpers ----------------------------------------------------
+
+
+def _safe_get_object(gmat: ModuleType, name: str) -> Any:
+    try:
+        return gmat.GetObject(name)
+    except Exception:
+        return None
+
+
+def _safe_type_name(obj: Any) -> str:
+    try:
+        return str(obj.GetTypeName())
+    except Exception:
+        return ""
+
+
+def _is_of_type(obj: Any, type_name: str) -> bool:
+    try:
+        return bool(obj.IsOfType(type_name))
+    except Exception:
+        return False
+
+
+# --- HTML rendering -----------------------------------------------------------
+
+
+def _format_mission_html(summary: MissionSummary) -> str:
+    """Render the notebook HTML for a :class:`MissionSummary`."""
+    parts: list[str] = ['<div class="gmat-run-mission-summary">']
+    parts.append(f"<strong>Mission:</strong> <code>{html.escape(summary.script_name)}</code>")
+
+    if summary.resource_groups:
+        parts.append('<table class="gmat-run-resources">')
+        parts.append(
+            "<thead><tr>"
+            '<th style="text-align:left">Resource type</th>'
+            '<th style="text-align:right">Count</th>'
+            '<th style="text-align:left">Names</th>'
+            "</tr></thead>"
+        )
+        parts.append("<tbody>")
+        for group in summary.resource_groups:
+            names_html = ", ".join(html.escape(n) for n in group.names)
+            parts.append(
+                f"<tr>"
+                f'<td style="text-align:left">{html.escape(group.category)}</td>'
+                f'<td style="text-align:right">{len(group.names)}</td>'
+                f'<td style="text-align:left">{names_html}</td>'
+                f"</tr>"
+            )
+        parts.append("</tbody></table>")
+
+    if summary.output_resources:
+        parts.append("<strong>Outputs</strong>")
+        parts.append('<table class="gmat-run-outputs">')
+        parts.append(
+            "<thead><tr>"
+            '<th style="text-align:left">Resource type</th>'
+            '<th style="text-align:left">Names</th>'
+            "</tr></thead>"
+        )
+        parts.append("<tbody>")
+        for group in summary.output_resources:
+            names_html = ", ".join(html.escape(n) for n in group.names)
+            parts.append(
+                f"<tr>"
+                f'<td style="text-align:left">{html.escape(group.category)}</td>'
+                f'<td style="text-align:left">{names_html}</td>'
+                f"</tr>"
+            )
+        parts.append("</tbody></table>")
+
+    parts.append(f"<strong>Mission sequence</strong> ({summary.command_count} commands)")
+    if summary.commands:
+        parts.append("<ol>")
+        for cmd in summary.commands:
+            parts.append("<li>" + _format_command_html(cmd))
+            if cmd.children:
+                parts.append("<ul>")
+                for sub in cmd.children:
+                    parts.append("<li>" + _format_command_html(sub) + "</li>")
+                parts.append("</ul>")
+            if cmd.nested_count:
+                parts.append(f"<div><em>({cmd.nested_count} nested commands)</em></div>")
+            parts.append("</li>")
+        parts.append("</ol>")
+    else:
+        parts.append("<div><em>(empty)</em></div>")
+
+    parts.append("</div>")
+    return "".join(parts)
+
+
+def _format_command_html(cmd: CommandOutline) -> str:
+    type_html = f"<code>{html.escape(cmd.type_name)}</code>"
+    if cmd.summary:
+        return f"{type_html} — {html.escape(cmd.summary)}"
+    return type_html
+
+
+def _format_command_line(cmd: CommandOutline) -> str:
+    if cmd.summary:
+        return f"{cmd.type_name} — {cmd.summary}"
+    return cmd.type_name

--- a/tests/integration/test_summary.py
+++ b/tests/integration/test_summary.py
@@ -1,0 +1,89 @@
+"""Integration test for :meth:`Mission.summary` against a real GMAT install.
+
+Loads the ``Ex_LEOEphemeris`` fixture (already used by the OEM round-trip
+tests) and asserts the snapshot covers the script's resources, output
+resources, and command sequence as gmatpy reports them. Also locks in the
+contract that both :class:`Mission` and :class:`Results` have non-default
+``__repr__`` and ``_repr_html_`` methods — the issue's acceptance criterion
+that the address-style repr is gone.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gmat_run import Mission
+
+pytestmark = pytest.mark.integration
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "Ex_LEOEphemeris.script"
+
+
+@pytest.fixture(scope="module")
+def loaded_mission(gmat_available: None) -> Mission:
+    return Mission.load(_FIXTURE)
+
+
+def test_summary_lists_named_resources(loaded_mission: Mission) -> None:
+    summary = loaded_mission.summary()
+    assert summary.script_name == "Ex_LEOEphemeris.script"
+    categories = {g.category: g.names for g in summary.resource_groups}
+    # Sat is the only Spacecraft; FM and Prop are the only ForceModel and
+    # Propagator. EF is the only EphemerisFile (and the only output).
+    assert categories.get("Spacecraft") == ("Sat",)
+    assert categories.get("ForceModel") == ("FM",)
+    assert categories.get("Propagator") == ("Prop",)
+    assert categories.get("EphemerisFile") == ("EF",)
+    assert summary.spacecraft_count == 1
+
+
+def test_output_resources_match_declared_files(loaded_mission: Mission) -> None:
+    summary = loaded_mission.summary()
+    output_categories = {g.category: g.names for g in summary.output_resources}
+    assert output_categories == {"EphemerisFile": ("EF",)}
+
+
+def test_command_sequence_contains_propagate(loaded_mission: Mission) -> None:
+    summary = loaded_mission.summary()
+    types = [c.type_name for c in summary.commands]
+    # The script's mission sequence is a single ``Propagate``.
+    assert "Propagate" in types
+    assert summary.command_count >= 1
+
+
+def test_mission_repr_is_not_default_address_form(loaded_mission: Mission) -> None:
+    text = repr(loaded_mission)
+    assert "<gmat_run.mission.Mission object" not in text
+    assert text.startswith("Mission(")
+    assert "spacecraft=1" in text
+
+
+def test_mission_repr_html_renders_html_table(loaded_mission: Mission) -> None:
+    html_str = loaded_mission._repr_html_()
+    assert "<table" in html_str
+    assert "Sat" in html_str  # the Spacecraft name shows up in the resource table
+
+
+def test_results_repr_and_repr_html_are_not_default(loaded_mission: Mission) -> None:
+    result = loaded_mission.run()
+    try:
+        text = repr(result)
+        assert "<gmat_run.results.Results object" not in text
+        assert text.startswith("Results(")
+        # The fixture declares one EphemerisFile and no ReportFiles or
+        # ContactLocators, so the per-mapping counts pin to a known shape.
+        assert "ephemerides=1" in text
+        assert "reports=0" in text
+        assert "contacts=0" in text
+
+        html_str = result._repr_html_()
+        assert "<table" in html_str
+        assert "<code>ephemerides</code>" in html_str
+        assert "EF" in html_str  # resource name from the script
+    finally:
+        # Drop the Results so its TemporaryDirectory is cleaned up before the
+        # module-scoped Mission fixture goes out of scope (Windows file
+        # handles get cranky otherwise).
+        del result

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -15,6 +15,7 @@ import gc
 import os
 import warnings
 from collections.abc import Iterator
+from itertools import pairwise
 from pathlib import Path
 from types import ModuleType
 from typing import Any
@@ -178,6 +179,48 @@ class _FakeAPIException(Exception):
     """Stand-in for the real ``gmatpy.APIException`` raised by the engine."""
 
 
+class _FakeCommand:
+    """Minimal stand-in for a GmatCommand node, used by Mission.summary tests."""
+
+    def __init__(
+        self,
+        type_name: str,
+        *,
+        generating: str = "",
+        children: list[_FakeCommand] | None = None,
+        is_branch: bool = False,
+    ) -> None:
+        self._type = type_name
+        self._generating = generating
+        self._children = children or []
+        self._is_branch = is_branch
+        self._next: _FakeCommand | None = None
+
+    def GetTypeName(self) -> str:
+        return self._type
+
+    def GetGeneratingString(self) -> str:
+        return self._generating
+
+    def IsOfType(self, type_name: str) -> bool:
+        if type_name == "BranchCommand":
+            return self._is_branch
+        return type_name == self._type
+
+    def GetNext(self) -> _FakeCommand | None:
+        return self._next
+
+    def GetChildCommand(self, *_args: Any) -> _FakeCommand | None:
+        return self._children[0] if self._children else None
+
+
+def _link_commands(*commands: _FakeCommand) -> _FakeCommand:
+    """Wire the sequence as a sibling chain via ``GetNext`` and return the head."""
+    for prev, nxt in pairwise(commands):
+        prev._next = nxt
+    return commands[0]
+
+
 def _make_fake_gmat(
     objects: dict[str, _FakeObject] | None = None,
     *,
@@ -185,6 +228,7 @@ def _make_fake_gmat(
     run_script_status: int = 1,
     run_script_raises: BaseException | None = None,
     log_text: str = "fake gmat log\n",
+    first_command: _FakeCommand | None = None,
 ) -> ModuleType:
     """Build a fake gmatpy module with the bits Mission touches.
 
@@ -193,6 +237,11 @@ def _make_fake_gmat(
     ``GmatGlobal.Instance().SetOutputPath``, ``Moderator.Instance()`` (with
     ``GetListOfObjects`` keyed by the ``SUBSCRIBER`` / ``EVENT_LOCATOR`` enum
     values), and ``APIException``.
+
+    ``first_command`` is the head of the mission-sequence linked list returned
+    by :meth:`gmat.Moderator.Instance().GetFirstCommand`. ``None`` (the
+    default) makes ``GetFirstCommand`` return ``None`` — :func:`Mission.summary`
+    treats that as an empty mission sequence.
     """
     module = ModuleType("fake_gmat")
     for attr, code in _TYPE_CODES.items():
@@ -220,6 +269,9 @@ def _make_fake_gmat(
                 for name, obj in registry.items()
                 if _OBJECT_TYPE_OF_CLASS.get(obj.GetTypeName()) == kind
             ]
+
+        def GetFirstCommand(self) -> _FakeCommand | None:
+            return first_command
 
     class _ModeratorProxy:
         @staticmethod
@@ -1445,3 +1497,104 @@ class TestAttitudeInputs:
         mission.gmat._registry.clear()
         second = dict(mission.attitude_input_paths)
         assert first == second
+
+
+# --- Mission.summary / __repr__ / _repr_html_ ---------------------------------
+
+
+class TestMissionSummary:
+    """Cover the dataclass-shaped summary and notebook reprs on Mission."""
+
+    def test_summary_returns_mission_summary_with_resource_groups(self, tmp_path: Path) -> None:
+        gmat = _make_fake_gmat(
+            {
+                "Sat": _spacecraft(),
+                "ReportFile1": _report_file(),
+                "EphFile1": _ephemeris_file(),
+                "Contacts": _contact_locator(),
+            }
+        )
+        install = _make_install(tmp_path / "gmat")
+        mission = Mission(gmat=gmat, install=install, script_path=tmp_path / "flyby.script")
+
+        summary = mission.summary()
+        from gmat_run.summary import MissionSummary
+
+        assert isinstance(summary, MissionSummary)
+        assert summary.script_name == "flyby.script"
+        categories = {g.category: g.names for g in summary.resource_groups}
+        assert categories["Spacecraft"] == ("Sat",)
+        assert categories["ReportFile"] == ("ReportFile1",)
+        assert categories["EphemerisFile"] == ("EphFile1",)
+        assert categories["ContactLocator"] == ("Contacts",)
+        assert summary.spacecraft_count == 1
+
+    def test_summary_output_resources_only_lists_file_producers(self, tmp_path: Path) -> None:
+        gmat = _make_fake_gmat(
+            {
+                "Sat": _spacecraft(),
+                "ReportFile1": _report_file(),
+            }
+        )
+        install = _make_install(tmp_path / "gmat")
+        mission = Mission(gmat=gmat, install=install, script_path=tmp_path / "outputs.script")
+
+        summary = mission.summary()
+        output_categories = [g.category for g in summary.output_resources]
+        assert output_categories == ["ReportFile"]
+
+    def test_summary_walks_command_sequence_when_exposed(self, tmp_path: Path) -> None:
+        head = _link_commands(
+            _FakeCommand("BeginMissionSequence"),
+            _FakeCommand("Propagate", generating="Propagate Prop(Sat) {Sat.ElapsedDays = 1};"),
+            _FakeCommand("Maneuver", generating="Maneuver TOI(Sat);"),
+        )
+        gmat = _make_fake_gmat({"Sat": _spacecraft()}, first_command=head)
+        install = _make_install(tmp_path / "gmat")
+        mission = Mission(gmat=gmat, install=install, script_path=tmp_path / "seq.script")
+
+        summary = mission.summary()
+        assert [c.type_name for c in summary.commands] == ["Propagate", "Maneuver"]
+        assert summary.command_count == 2
+
+    def test_summary_reflects_post_load_field_writes(self, tmp_path: Path) -> None:
+        # The summary walks the live graph each call — no caching — so
+        # adding a resource via the underlying registry between summary()
+        # invocations should be visible on the second one.
+        gmat = _make_fake_gmat({"Sat": _spacecraft()})
+        install = _make_install(tmp_path / "gmat")
+        mission = Mission(gmat=gmat, install=install, script_path=tmp_path / "x.script")
+
+        first = mission.summary()
+        assert first.spacecraft_count == 1
+
+        gmat._registry["Sat2"] = _spacecraft("Sat2")
+        second = mission.summary()
+        assert second.spacecraft_count == 2
+
+    def test_repr_replaces_default_address_form(self, tmp_path: Path) -> None:
+        gmat = _make_fake_gmat({"Sat": _spacecraft()})
+        install = _make_install(tmp_path / "gmat")
+        mission = Mission(gmat=gmat, install=install, script_path=tmp_path / "flyby.script")
+        text = repr(mission)
+        assert "<gmat_run.mission.Mission object" not in text
+
+    def test_repr_format_shows_script_spacecraft_and_command_counts(self, tmp_path: Path) -> None:
+        head = _link_commands(
+            _FakeCommand("BeginMissionSequence"),
+            _FakeCommand("Propagate"),
+            _FakeCommand("Maneuver"),
+        )
+        gmat = _make_fake_gmat({"Sat": _spacecraft()}, first_command=head)
+        install = _make_install(tmp_path / "gmat")
+        mission = Mission(gmat=gmat, install=install, script_path=tmp_path / "flyby.script")
+        assert repr(mission) == "Mission('flyby.script', spacecraft=1, commands=2)"
+
+    def test_repr_html_returns_html_string(self, tmp_path: Path) -> None:
+        gmat = _make_fake_gmat({"Sat": _spacecraft()})
+        install = _make_install(tmp_path / "gmat")
+        mission = Mission(gmat=gmat, install=install, script_path=tmp_path / "flyby.script")
+        html_str = mission._repr_html_()
+        assert "<table" in html_str
+        assert "<code>flyby.script</code>" in html_str
+        assert "Spacecraft" in html_str

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -599,3 +599,51 @@ def test_write_oem_all_with_no_ephemerides_creates_empty_dir(tmp_path: Path) -> 
     dest = result.write_oem_all(tmp_path / "empty")
     assert dest.is_dir()
     assert list(dest.iterdir()) == []
+
+
+# --- __repr__ / _repr_html_ --------------------------------------------------
+
+
+def test_repr_replaces_default_address_form(tmp_path: Path) -> None:
+    result = _empty(tmp_path)
+    assert "<gmat_run.results.Results object" not in repr(result)
+
+
+def test_repr_format_shows_per_mapping_counts(tmp_path: Path) -> None:
+    result = Results(
+        output_dir=tmp_path,
+        log="",
+        report_paths={"RF1": tmp_path / "rf1.txt", "RF2": tmp_path / "rf2.txt"},
+        ephemeris_paths={"Eph1": tmp_path / "e1.oem"},
+    )
+    assert repr(result) == "Results(reports=2, ephemerides=1, contacts=0)"
+
+
+def test_repr_html_returns_table_listing_mapping_names(tmp_path: Path) -> None:
+    result = Results(
+        output_dir=tmp_path,
+        log="",
+        report_paths={"RF1": tmp_path / "rf1.txt"},
+        ephemeris_paths={"Eph1": tmp_path / "e1.oem"},
+    )
+    html_str = result._repr_html_()
+    assert "<table" in html_str
+    assert "<code>reports</code>" in html_str
+    assert "<code>ephemerides</code>" in html_str
+    assert "<code>contacts</code>" in html_str
+    assert "RF1" in html_str
+    assert "Eph1" in html_str
+    assert "<em>none</em>" in html_str  # contacts is empty
+
+
+def test_repr_html_does_not_materialise_dataframes(tmp_path: Path) -> None:
+    # The HTML repr only sees keys; touching reports[name] would parse the
+    # underlying file (which doesn't exist here) and raise. Verifying the
+    # repr renders without I/O is the regression we care about: notebook
+    # users get a useful overview of a Results without paying the parse cost.
+    result = Results(
+        output_dir=tmp_path,
+        log="",
+        report_paths={"RF1": tmp_path / "missing.txt"},
+    )
+    assert "RF1" in result._repr_html_()

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,0 +1,618 @@
+"""Unit tests for :mod:`gmat_run.summary`.
+
+The summary walker only touches a slice of the gmatpy surface —
+``Moderator.GetListOfObjects``, ``GetObject``, the ``GmatBase`` contract
+(``GetTypeName`` / ``IsOfType``), and the command-graph linked list
+(``GetFirstCommand`` / ``GetNext`` / ``GetChildCommand`` / ``IsOfType``). The
+minimal fakes below mirror exactly that surface, so they exercise the same
+code paths as real gmatpy without dragging in the larger fake from
+``test_mission.py``.
+"""
+
+from __future__ import annotations
+
+from itertools import pairwise
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+from gmat_run.summary import (
+    CommandOutline,
+    MissionSummary,
+    ResourceGroup,
+    build_mission_summary,
+    format_results_html,
+)
+
+# --- minimal fakes ------------------------------------------------------------
+
+
+class _FakeBase:
+    """Stand-in for a configured GMAT object.
+
+    The ``IsOfType`` set always includes the object's own ``type_name`` so a
+    test that classifies via class name (``Spacecraft``, ``ReportFile``, ...)
+    doesn't need to spell out the inheritance chain.
+    """
+
+    def __init__(
+        self,
+        type_name: str,
+        name: str,
+        *,
+        is_of_type: tuple[str, ...] = (),
+    ) -> None:
+        self._type = type_name
+        self._name = name
+        self._is_of_type = set(is_of_type) | {type_name}
+
+    def GetTypeName(self) -> str:
+        return self._type
+
+    def GetName(self) -> str:
+        return self._name
+
+    def IsOfType(self, type_name: str) -> bool:
+        return type_name in self._is_of_type
+
+
+class _FakeCommand:
+    """Stand-in for a GmatCommand node in the mission sequence."""
+
+    def __init__(
+        self,
+        type_name: str,
+        *,
+        generating: str = "",
+        children: list[_FakeCommand] | None = None,
+        is_branch: bool = False,
+    ) -> None:
+        self._type = type_name
+        self._generating = generating
+        self._children = children or []
+        self._is_branch = is_branch
+        self._next: _FakeCommand | None = None
+
+    def GetTypeName(self) -> str:
+        return self._type
+
+    def GetGeneratingString(self) -> str:
+        return self._generating
+
+    def IsOfType(self, type_name: str) -> bool:
+        if type_name == "BranchCommand":
+            return self._is_branch
+        return type_name == self._type
+
+    def GetNext(self) -> _FakeCommand | None:
+        return self._next
+
+    def GetChildCommand(self, *_args: Any) -> _FakeCommand | None:
+        return self._children[0] if self._children else None
+
+
+def _link(*commands: _FakeCommand) -> _FakeCommand:
+    """Wire siblings via ``GetNext`` and return the head."""
+    for prev, nxt in pairwise(commands):
+        prev._next = nxt
+    return commands[0]
+
+
+def _make_gmat(
+    *,
+    objects: dict[str, _FakeBase] | None = None,
+    first_command: _FakeCommand | None = None,
+) -> ModuleType:
+    """Build a tiny fake gmat module with just the surface summary touches."""
+    module = ModuleType("fake_gmat_summary")
+    # Single enum is enough — the walker dedupes by name across enums, and
+    # the fake's GetListOfObjects returns the same registry for any id.
+    module.UNKNOWN_OBJECT = 1  # type: ignore[attr-defined]
+    registry: dict[str, _FakeBase] = dict(objects or {})
+
+    class _FakeModerator:
+        def GetListOfObjects(self, _type_id: int) -> list[str]:
+            return list(registry.keys())
+
+        def GetFirstCommand(self) -> _FakeCommand | None:
+            return first_command
+
+    fake_moderator = _FakeModerator()
+
+    class _ModeratorProxy:
+        @staticmethod
+        def Instance() -> _FakeModerator:
+            return fake_moderator
+
+    module.Moderator = _ModeratorProxy  # type: ignore[attr-defined]
+    module.GetObject = lambda name: registry.get(name)  # type: ignore[attr-defined]
+    return module
+
+
+# --- empty mission ------------------------------------------------------------
+
+
+def test_empty_mission_summary_has_no_resources_or_commands() -> None:
+    summary = build_mission_summary(_make_gmat(), Path("empty.script"))
+    assert summary.script_name == "empty.script"
+    assert summary.resource_groups == ()
+    assert summary.output_resources == ()
+    assert summary.commands == ()
+    assert summary.spacecraft_count == 0
+    assert summary.command_count == 0
+
+
+def test_summary_with_no_moderator_returns_empty() -> None:
+    # A gmat module without a Moderator at all (extreme defensive case)
+    # should still yield a usable MissionSummary.
+    module = ModuleType("no_moderator_gmat")
+    summary = build_mission_summary(module, Path("orphan.script"))
+    assert summary.resource_groups == ()
+    assert summary.commands == ()
+
+
+# --- categorisation -----------------------------------------------------------
+
+
+def test_named_resource_types_land_in_their_buckets() -> None:
+    summary = build_mission_summary(
+        _make_gmat(
+            objects={
+                "Sat": _FakeBase("Spacecraft", "Sat"),
+                "FM": _FakeBase("ODEModel", "FM"),
+                "Prop": _FakeBase("PropSetup", "Prop"),
+                "EME": _FakeBase("CoordinateSystem", "EME"),
+                "TOI": _FakeBase("ImpulsiveBurn", "TOI"),
+                "Continuous": _FakeBase("FiniteBurn", "Continuous"),
+                "RF": _FakeBase("ReportFile", "RF"),
+                "Eph": _FakeBase("EphemerisFile", "Eph"),
+                "Contact": _FakeBase("ContactLocator", "Contact"),
+            }
+        ),
+        Path("everything.script"),
+    )
+    categories = {g.category: g.names for g in summary.resource_groups}
+    assert categories == {
+        "Spacecraft": ("Sat",),
+        "ForceModel": ("FM",),
+        "Propagator": ("Prop",),
+        "CoordinateSystem": ("EME",),
+        "ImpulsiveBurn": ("TOI",),
+        "FiniteBurn": ("Continuous",),
+        "ReportFile": ("RF",),
+        "EphemerisFile": ("Eph",),
+        "ContactLocator": ("Contact",),
+    }
+    assert summary.spacecraft_count == 1
+
+
+def test_solver_subclass_classified_via_is_of_type() -> None:
+    summary = build_mission_summary(
+        _make_gmat(
+            objects={
+                "DC": _FakeBase("DifferentialCorrector", "DC", is_of_type=("Solver",)),
+            }
+        ),
+        Path("dc.script"),
+    )
+    assert summary.resource_groups == (ResourceGroup(category="Solver", names=("DC",)),)
+
+
+def test_subscriber_subclass_classified_via_is_of_type() -> None:
+    # OrbitView / GroundTrackPlot / XYPlot are GUI-only Subscriber subclasses
+    # not in the named bucket list. They should land under "Subscriber".
+    summary = build_mission_summary(
+        _make_gmat(
+            objects={
+                "OV": _FakeBase("OrbitView", "OV", is_of_type=("Subscriber",)),
+                "GT": _FakeBase("GroundTrackPlot", "GT", is_of_type=("Subscriber",)),
+            }
+        ),
+        Path("plots.script"),
+    )
+    assert summary.resource_groups == (ResourceGroup(category="Subscriber", names=("OV", "GT")),)
+
+
+def test_unknown_type_lands_in_other_bucket() -> None:
+    summary = build_mission_summary(
+        _make_gmat(
+            objects={"Tank": _FakeBase("FuelTank", "Tank")},
+        ),
+        Path("hardware.script"),
+    )
+    assert summary.resource_groups == (ResourceGroup(category="Other", names=("Tank",)),)
+
+
+def test_resource_groups_follow_declared_order() -> None:
+    # Display order is fixed by the summary module, not by registry order.
+    summary = build_mission_summary(
+        _make_gmat(
+            objects={
+                "RF": _FakeBase("ReportFile", "RF"),
+                "Sat": _FakeBase("Spacecraft", "Sat"),
+                "FM": _FakeBase("ODEModel", "FM"),
+            }
+        ),
+        Path("order.script"),
+    )
+    categories = [g.category for g in summary.resource_groups]
+    assert categories == ["Spacecraft", "ForceModel", "ReportFile"]
+
+
+def test_categories_with_no_members_are_omitted() -> None:
+    # Only Spacecraft is configured — no FiniteBurn group should appear.
+    summary = build_mission_summary(
+        _make_gmat(objects={"Sat": _FakeBase("Spacecraft", "Sat")}),
+        Path("only-sat.script"),
+    )
+    assert [g.category for g in summary.resource_groups] == ["Spacecraft"]
+
+
+# --- output resources ---------------------------------------------------------
+
+
+def test_output_resources_only_lists_file_producing_categories() -> None:
+    # Spacecraft / ForceModel are present but never appear under outputs.
+    summary = build_mission_summary(
+        _make_gmat(
+            objects={
+                "Sat": _FakeBase("Spacecraft", "Sat"),
+                "FM": _FakeBase("ODEModel", "FM"),
+                "RF": _FakeBase("ReportFile", "RF"),
+                "Eph": _FakeBase("EphemerisFile", "Eph"),
+            }
+        ),
+        Path("outputs.script"),
+    )
+    output_categories = [g.category for g in summary.output_resources]
+    assert output_categories == ["ReportFile", "EphemerisFile"]
+
+
+def test_output_resources_empty_when_no_file_producers_declared() -> None:
+    summary = build_mission_summary(
+        _make_gmat(objects={"Sat": _FakeBase("Spacecraft", "Sat")}),
+        Path("no-output.script"),
+    )
+    assert summary.output_resources == ()
+
+
+# --- command walk -------------------------------------------------------------
+
+
+def test_command_walk_returns_top_level_commands_in_order() -> None:
+    head = _link(
+        _FakeCommand("BeginMissionSequence"),
+        _FakeCommand("Propagate", generating="Propagate Prop(Sat) {Sat.ElapsedDays = 1};"),
+        _FakeCommand("Maneuver", generating="Maneuver TOI(Sat);"),
+    )
+    summary = build_mission_summary(_make_gmat(first_command=head), Path("seq.script"))
+    assert [c.type_name for c in summary.commands] == ["Propagate", "Maneuver"]
+    assert summary.command_count == 2
+    assert summary.commands[0].summary == "Propagate Prop(Sat) {Sat.ElapsedDays = 1};"
+
+
+def test_command_walk_accepts_first_command_being_user_command() -> None:
+    # Some fakes (and conceivably future GMAT changes) return the first user
+    # command directly without a BeginMissionSequence sentinel head. The
+    # walker should not skip it just because the head isn't NoOp.
+    head = _link(
+        _FakeCommand("Propagate", generating="Propagate Prop(Sat);"),
+        _FakeCommand("Maneuver", generating="Maneuver TOI(Sat);"),
+    )
+    summary = build_mission_summary(_make_gmat(first_command=head), Path("seq.script"))
+    assert [c.type_name for c in summary.commands] == ["Propagate", "Maneuver"]
+
+
+def test_command_walk_skips_no_op_head() -> None:
+    head = _link(
+        _FakeCommand("NoOp"),
+        _FakeCommand("Propagate", generating="Propagate Prop(Sat);"),
+    )
+    summary = build_mission_summary(_make_gmat(first_command=head), Path("seq.script"))
+    assert [c.type_name for c in summary.commands] == ["Propagate"]
+
+
+def test_branch_command_renders_children_one_level_deep() -> None:
+    vary1 = _FakeCommand("Vary", generating="Vary DC(TOI.Element1 = 0.5);")
+    vary2 = _FakeCommand("Vary", generating="Vary DC(TOI.Element2 = 0.5);")
+    achieve = _FakeCommand("Achieve", generating="Achieve DC(Sat.SMA = 7100);")
+    target = _FakeCommand(
+        "Target",
+        generating="Target DC;",
+        children=[_link(vary1, vary2, achieve)],
+        is_branch=True,
+    )
+    summary = build_mission_summary(
+        _make_gmat(first_command=_link(_FakeCommand("BeginMissionSequence"), target)),
+        Path("target.script"),
+    )
+    (cmd,) = summary.commands
+    assert cmd.type_name == "Target"
+    assert [c.type_name for c in cmd.children] == ["Vary", "Vary", "Achieve"]
+    assert cmd.nested_count == 0
+
+
+def test_nested_count_captures_descendants_below_depth_one() -> None:
+    # Build: Target -> [Vary, Inner-Branch -> [Propagate, Maneuver]]
+    # The Inner-Branch is at depth 1 (rendered as a child); the Propagate
+    # and Maneuver inside it live at depth 2 and contribute to nested_count.
+    inner = _FakeCommand(
+        "If",
+        generating="If Sat.SMA > 7000;",
+        children=[
+            _link(
+                _FakeCommand("Propagate", generating="Propagate Prop(Sat);"),
+                _FakeCommand("Maneuver", generating="Maneuver TOI(Sat);"),
+            )
+        ],
+        is_branch=True,
+    )
+    vary = _FakeCommand("Vary", generating="Vary DC(TOI.Element1 = 0.5);")
+    target = _FakeCommand(
+        "Target",
+        generating="Target DC;",
+        children=[_link(vary, inner)],
+        is_branch=True,
+    )
+    summary = build_mission_summary(
+        _make_gmat(first_command=_link(_FakeCommand("BeginMissionSequence"), target)),
+        Path("nested.script"),
+    )
+    (cmd,) = summary.commands
+    assert [c.type_name for c in cmd.children] == ["Vary", "If"]
+    # 2 commands inside If — both descendants of the depth-1 Inner-Branch,
+    # so they are summarised by the count rather than the children tuple.
+    assert cmd.nested_count == 2
+
+
+def test_branch_with_no_children_renders_empty() -> None:
+    # If GMAT exposes a branch command but it has no body, the walker should
+    # still produce a CommandOutline with empty children rather than skip.
+    branch = _FakeCommand("BeginScript", is_branch=True, children=[])
+    summary = build_mission_summary(
+        _make_gmat(first_command=_link(_FakeCommand("BeginMissionSequence"), branch)),
+        Path("empty-branch.script"),
+    )
+    (cmd,) = summary.commands
+    assert cmd.children == ()
+    assert cmd.nested_count == 0
+
+
+def test_command_summary_truncated_to_width() -> None:
+    long_line = "Propagate Prop(Sat) {Sat.ElapsedDays = 1, " + ("X" * 200) + "};"
+    head = _link(
+        _FakeCommand("BeginMissionSequence"),
+        _FakeCommand("Propagate", generating=long_line),
+    )
+    summary = build_mission_summary(_make_gmat(first_command=head), Path("long.script"))
+    cmd = summary.commands[0]
+    assert len(cmd.summary) <= 100
+    assert cmd.summary.endswith("…")
+
+
+def test_command_summary_keeps_only_first_non_blank_line() -> None:
+    multi = "\n\nPropagate Prop(Sat);\nGMAT details on the next line\n"
+    head = _link(
+        _FakeCommand("BeginMissionSequence"),
+        _FakeCommand("Propagate", generating=multi),
+    )
+    summary = build_mission_summary(_make_gmat(first_command=head), Path("multi.script"))
+    assert summary.commands[0].summary == "Propagate Prop(Sat);"
+
+
+def test_command_summary_blank_when_engine_returns_empty() -> None:
+    head = _link(
+        _FakeCommand("BeginMissionSequence"),
+        _FakeCommand("Maneuver", generating=""),
+    )
+    summary = build_mission_summary(_make_gmat(first_command=head), Path("blank.script"))
+    cmd = summary.commands[0]
+    assert cmd.type_name == "Maneuver"
+    assert cmd.summary == ""
+
+
+# --- text repr ---------------------------------------------------------------
+
+
+def test_text_repr_renders_resources_outputs_and_sequence() -> None:
+    head = _link(
+        _FakeCommand("BeginMissionSequence"),
+        _FakeCommand("Propagate", generating="Propagate Prop(Sat) {Sat.ElapsedDays = 1};"),
+    )
+    summary = build_mission_summary(
+        _make_gmat(
+            objects={
+                "Sat": _FakeBase("Spacecraft", "Sat"),
+                "RF": _FakeBase("ReportFile", "RF"),
+            },
+            first_command=head,
+        ),
+        Path("flyby.script"),
+    )
+    text = repr(summary)
+    assert "MissionSummary('flyby.script')" in text
+    assert "Spacecraft (1): Sat" in text
+    assert "ReportFile (1): RF" in text
+    assert "Outputs" in text
+    assert "Mission sequence (1 commands)" in text
+    assert "1. Propagate — Propagate Prop(Sat) {Sat.ElapsedDays = 1};" in text
+
+
+def test_text_repr_handles_empty_mission() -> None:
+    summary = build_mission_summary(_make_gmat(), Path("empty.script"))
+    text = repr(summary)
+    assert "MissionSummary('empty.script')" in text
+    assert "Mission sequence (0 commands)" in text
+    assert "(empty)" in text
+
+
+def test_text_repr_marks_nested_count_in_branch() -> None:
+    inner = _FakeCommand(
+        "If",
+        generating="If Sat.SMA > 7000;",
+        children=[
+            _link(
+                _FakeCommand("Propagate", generating="Propagate Prop(Sat);"),
+            )
+        ],
+        is_branch=True,
+    )
+    target = _FakeCommand(
+        "Target",
+        generating="Target DC;",
+        children=[_link(inner)],
+        is_branch=True,
+    )
+    summary = build_mission_summary(
+        _make_gmat(first_command=_link(_FakeCommand("BeginMissionSequence"), target)),
+        Path("nested.script"),
+    )
+    text = repr(summary)
+    assert "(1 nested commands)" in text
+
+
+# --- HTML repr ---------------------------------------------------------------
+
+
+def test_html_repr_includes_resource_table_and_sequence() -> None:
+    head = _link(
+        _FakeCommand("BeginMissionSequence"),
+        _FakeCommand("Propagate", generating="Propagate Prop(Sat);"),
+    )
+    summary = build_mission_summary(
+        _make_gmat(
+            objects={"Sat": _FakeBase("Spacecraft", "Sat")},
+            first_command=head,
+        ),
+        Path("flyby.script"),
+    )
+    html_str = summary._repr_html_()
+    assert "<table" in html_str
+    assert "<code>flyby.script</code>" in html_str
+    assert "Spacecraft" in html_str
+    assert "<ol>" in html_str
+    assert "Propagate" in html_str
+
+
+def test_html_repr_escapes_resource_names() -> None:
+    summary = build_mission_summary(
+        _make_gmat(objects={"<bad>": _FakeBase("Spacecraft", "<bad>")}),
+        Path("safe.script"),
+    )
+    html_str = summary._repr_html_()
+    assert "<bad>" not in html_str.replace("&lt;bad&gt;", "")
+    assert "&lt;bad&gt;" in html_str
+
+
+def test_html_repr_for_empty_mission_marks_sequence_empty() -> None:
+    summary = build_mission_summary(_make_gmat(), Path("empty.script"))
+    html_str = summary._repr_html_()
+    assert "(empty)" in html_str
+    assert "0 commands" in html_str
+
+
+def test_html_repr_renders_branch_children_and_nested_count() -> None:
+    inner = _FakeCommand(
+        "If",
+        generating="If Sat.SMA > 7000;",
+        children=[_link(_FakeCommand("Propagate", generating="Propagate Prop(Sat);"))],
+        is_branch=True,
+    )
+    target = _FakeCommand(
+        "Target",
+        generating="Target DC;",
+        children=[_link(_FakeCommand("Vary", generating="Vary DC;"), inner)],
+        is_branch=True,
+    )
+    summary = build_mission_summary(
+        _make_gmat(first_command=_link(_FakeCommand("BeginMissionSequence"), target)),
+        Path("nested.script"),
+    )
+    html_str = summary._repr_html_()
+    # Inner <ul> for the depth-1 children, plus the nested-count notice for
+    # the descendants past depth 1.
+    assert "<ul>" in html_str
+    assert "Vary" in html_str
+    assert "(1 nested commands)" in html_str
+
+
+def test_html_repr_falls_back_to_type_only_when_summary_blank() -> None:
+    # GMAT command without a generating string renders as just the type name —
+    # the HTML/text formatters drop the dash separator entirely.
+    head = _link(
+        _FakeCommand("BeginMissionSequence"),
+        _FakeCommand("Maneuver", generating=""),
+    )
+    summary = build_mission_summary(_make_gmat(first_command=head), Path("blank.script"))
+    html_str = summary._repr_html_()
+    text = repr(summary)
+    assert "Maneuver" in html_str
+    assert " — " not in html_str.split("<ol>", 1)[1].split("</ol>", 1)[0]
+    assert "1. Maneuver" in text
+
+
+# --- format_results_html -----------------------------------------------------
+
+
+def test_format_results_html_lists_each_mapping() -> None:
+    out = format_results_html(
+        report_names=("RF1", "RF2"),
+        ephemeris_names=("Eph1",),
+        contact_names=(),
+    )
+    assert "<code>reports</code>" in out
+    assert "<code>ephemerides</code>" in out
+    assert "<code>contacts</code>" in out
+    assert "RF1, RF2" in out
+    assert "Eph1" in out
+    assert "<em>none</em>" in out
+
+
+def test_format_results_html_escapes_names() -> None:
+    out = format_results_html(
+        report_names=("<RF>",),
+        ephemeris_names=(),
+        contact_names=(),
+    )
+    assert "<RF>" not in out.replace("&lt;RF&gt;", "")
+    assert "&lt;RF&gt;" in out
+
+
+def test_format_results_html_when_all_mappings_empty() -> None:
+    out = format_results_html(
+        report_names=(),
+        ephemeris_names=(),
+        contact_names=(),
+    )
+    assert out.count("<em>none</em>") == 3
+
+
+# --- dataclass shape sanity --------------------------------------------------
+
+
+def test_resource_group_is_frozen() -> None:
+    group = ResourceGroup(category="Spacecraft", names=("Sat",))
+    try:
+        group.category = "ForceModel"  # type: ignore[misc]
+    except Exception:  # frozen dataclass raises FrozenInstanceError
+        pass
+    else:
+        raise AssertionError("expected ResourceGroup to reject mutation")
+
+
+def test_command_outline_defaults() -> None:
+    outline = CommandOutline(type_name="Propagate", summary="Propagate Prop(Sat);")
+    assert outline.children == ()
+    assert outline.nested_count == 0
+
+
+def test_mission_summary_is_a_dataclass_record() -> None:
+    summary = MissionSummary(
+        script_name="x.script",
+        resource_groups=(),
+        output_resources=(),
+        commands=(),
+    )
+    assert summary.script_name == "x.script"
+    assert summary.spacecraft_count == 0
+    assert summary.command_count == 0


### PR DESCRIPTION
## Summary

- `Mission.summary()` returns a new `MissionSummary` dataclass that groups resources by type (Spacecraft, ForceModel, Propagator, CoordinateSystem, ImpulsiveBurn / FiniteBurn, ReportFile, EphemerisFile, ContactLocator, Solver, Subscriber, Other), lists declared output resources, and outlines the top-level mission sequence with one-level-deep branch expansion.
- `Mission.__repr__` becomes the one-line `Mission('flyby.script', spacecraft=1, commands=2)`; `Mission._repr_html_` and `Results._repr_html_` render small HTML tables in notebook cells; `Results.__repr__` becomes `Results(reports=R, ephemerides=E, contacts=C)`.
- Read-only over the gmat object graph — the walk only enumerates names and command-graph nodes; it does not materialise field values or DataFrames.

## Test plan

- [x] `uv run pytest` — 685 unit tests, all green.
- [x] `uv run pytest tests/integration -m integration` — 21 integration tests against R2026a, all green.
- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run mypy` — clean.
- [x] Coverage gates: 95% overall (≥ 90%), parsers 97% (≥ 95%).
- [x] `uv run mkdocs build` — rendered the new `Mission summary` reference page; `01_load_run_plot.ipynb` re-executed against R2026a so the notebook outputs include the new HTML reprs.

Closes #91