### PR TITLE
Add canary CI cell for canonical `ghcr.io/astro-tools/gmat` image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,3 +126,23 @@ jobs:
           python-version: '3.12'
       - run: pip install .
       - run: python -c "import gmat_run"
+
+  # Drift canary for the canonical GMAT image published by setup-gmat. The
+  # main `test` job runs in action-mode (`setup-gmat@v0`) on bare runners; a
+  # downstream user running container-mode CI inside `ghcr.io/astro-tools/gmat`
+  # would never benefit from that signal if the image and the action drifted
+  # apart. This single cell exercises the load → run → DataFrame round-trip
+  # inside the image, so a future image rebuild that strips a plugin, mangles
+  # `gmat_startup_file.txt`, drops a Python ABI from the bundled gmatpy set,
+  # or silently retags `:R2026a` breaks here before downstream users hit it.
+  # Tag pinned to R2026a (the test job's primary GMAT version); a R2025a cell
+  # is a follow-up after the multi-version image axis lands.
+  canonical-image-smoke:
+    name: canonical image smoke
+    runs-on: ubuntu-latest
+    container: ghcr.io/astro-tools/gmat:R2026a
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - run: pip install .
+      - run: python tests/canonical_image_smoke.py

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -35,6 +35,20 @@ R2026a ships builds for Python 3.10, 3.11, and 3.12. Older Python interpreters
 or 3.13+ are not supported by the bundled `gmatpy` and cannot be made to work
 without rebuilding GMAT from source.
 
+## Canonical-image drift is covered by a single CI canary
+
+The main `test` matrix runs in action-mode (`astro-tools/setup-gmat@v0`) on
+bare runners — it does not exercise the canonical `ghcr.io/astro-tools/gmat`
+container image. A separate `canonical-image-smoke` CI cell runs `pip install
+gmat-run` and a small `Mission.load → run → assert non-empty ReportFile`
+round-trip inside `ghcr.io/astro-tools/gmat:R2026a` on every PR and every
+push to `main`. It is the canary for image-vs-action drift: a stripped
+plugin, a mangled `gmat_startup_file.txt`, a dropped Python ABI from the
+bundled `gmatpy` set, or a tag that silently retargets a different GMAT
+upload all surface here before downstream consumers running container-mode
+CI hit them. The cell is pinned to `:R2026a`; the matrix coverage of the
+image across multiple GMAT releases lives in setup-gmat itself.
+
 ## R2022a is not exercised in CI
 
 R2022a's bundled `gmatpy` tops out at Python 3.9 across all three OSes, while

--- a/tests/canonical_image_smoke.py
+++ b/tests/canonical_image_smoke.py
@@ -1,0 +1,52 @@
+"""Standalone smoke runner for the ``canonical-image-smoke`` CI cell.
+
+The cell installs gmat-run with no extras (mirroring ``minimal-install``) and
+runs this script inside ``ghcr.io/astro-tools/gmat:Rxxxxa``. Because the cell
+has no dev dependencies, this is a plain ``python <script>`` runnable rather
+than a pytest test — pytest is not on the install path here.
+
+What it catches: drift between the canonical image and what gmat-run expects.
+A missing propagator integrator, a mangled ``gmat_startup_file.txt``, a
+dropped Python ABI from the bundled gmatpy set, or a tag that silently moves
+to a different GMAT upload all break the load → run → DataFrame round-trip
+this script exercises.
+
+Runnable locally for debugging against any GMAT install that
+``gmat_run.locate_gmat`` can find::
+
+    python tests/canonical_image_smoke.py
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+import pandas as pd
+
+from gmat_run import Mission
+
+FIXTURE = Path(__file__).parent / "integration" / "fixtures" / "Ex_MinimalLEO.script"
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as td:
+        script = Path(td) / "minimal_leo.script"
+        shutil.copyfile(FIXTURE, script)
+
+        mission = Mission.load(script)
+        result = mission.run()
+
+        df = result.reports["RF"]
+        assert isinstance(df, pd.DataFrame), f"expected DataFrame, got {type(df)!r}"
+        assert not df.empty, "ReportFile DataFrame is empty"
+        assert "Sat.SMA" in df.columns, f"missing Sat.SMA column; got {list(df.columns)}"
+
+        print(f"OK: ReportFile 'RF' parsed as {len(df)}-row DataFrame")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/fixtures/Ex_MinimalLEO.script
+++ b/tests/integration/fixtures/Ex_MinimalLEO.script
@@ -1,0 +1,29 @@
+Create Spacecraft Sat
+Sat.DateFormat = UTCGregorian
+Sat.Epoch = '01 Jan 2026 12:00:00.000'
+Sat.CoordinateSystem = EarthMJ2000Eq
+Sat.DisplayStateType = Keplerian
+Sat.SMA = 7000
+Sat.ECC = 0.001
+Sat.INC = 28.5
+Sat.RAAN = 75
+Sat.AOP = 90
+Sat.TA = 0
+
+Create ForceModel FM
+FM.CentralBody = Earth
+FM.PrimaryBodies = {Earth}
+
+Create Propagator Prop
+Prop.FM = FM
+Prop.Type = PrinceDormand78
+Prop.InitialStepSize = 60
+Prop.Accuracy = 1e-9
+
+Create ReportFile RF
+RF.Filename = 'leo_state.txt'
+RF.Add = {Sat.UTCGregorian, Sat.X, Sat.Y, Sat.Z, Sat.SMA}
+RF.WriteHeaders = True
+
+BeginMissionSequence
+Propagate Prop(Sat) {Sat.ElapsedSecs = 600}

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -1,16 +1,21 @@
 """Smoke test: a minimal self-contained mission round-trips end to end.
 
-Runs an inline ``.script`` against a real GMAT install and asserts the full
-pipeline (install discovery, gmatpy bootstrap, script load, output
-redirection, run, log capture, report parsing) produces a sane DataFrame.
-The fixture script is written into ``tmp_path`` rather than picked from
-``samples/`` so the test is independent of which stock samples ship with a
-given GMAT release. The stock-sample regression coverage lives in
+Runs ``tests/integration/fixtures/Ex_MinimalLEO.script`` (a circular LEO
+propagated for ten minutes with one ReportFile) against a real GMAT install
+and asserts the full pipeline (install discovery, gmatpy bootstrap, script
+load, output redirection, run, log capture, report parsing) produces a sane
+DataFrame. The fixture is hand-written rather than picked from ``samples/``
+so the test is independent of which stock samples ship with a given GMAT
+release; the stock-sample regression coverage lives in
 :mod:`tests.integration.test_round_trip`.
+
+The same fixture is reused by ``tests/canonical_image_smoke.py``, the
+standalone runner driven by the ``canonical-image-smoke`` CI cell.
 """
 
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 
 import pandas as pd
@@ -21,48 +26,14 @@ from gmat_run import Mission
 pytestmark = pytest.mark.integration
 
 
-# A small self-contained mission: a circular LEO propagated for ten minutes
-# with one ReportFile that lists the spacecraft state at each step. Avoids
-# external data files (TLEs, OEMs, mass-properties tables) so the test runs
-# on any GMAT install with the standard EOP/leap-second files in place.
-_MINIMAL_SCRIPT = """\
-Create Spacecraft Sat
-Sat.DateFormat = UTCGregorian
-Sat.Epoch = '01 Jan 2026 12:00:00.000'
-Sat.CoordinateSystem = EarthMJ2000Eq
-Sat.DisplayStateType = Keplerian
-Sat.SMA = 7000
-Sat.ECC = 0.001
-Sat.INC = 28.5
-Sat.RAAN = 75
-Sat.AOP = 90
-Sat.TA = 0
-
-Create ForceModel FM
-FM.CentralBody = Earth
-FM.PrimaryBodies = {Earth}
-
-Create Propagator Prop
-Prop.FM = FM
-Prop.Type = PrinceDormand78
-Prop.InitialStepSize = 60
-Prop.Accuracy = 1e-9
-
-Create ReportFile RF
-RF.Filename = 'leo_state.txt'
-RF.Add = {Sat.UTCGregorian, Sat.X, Sat.Y, Sat.Z, Sat.SMA}
-RF.WriteHeaders = True
-
-BeginMissionSequence
-Propagate Prop(Sat) {Sat.ElapsedSecs = 600}
-"""
+_FIXTURE_SCRIPT = Path(__file__).parent / "fixtures" / "Ex_MinimalLEO.script"
 
 
 @pytest.fixture
 def minimal_script(tmp_path: Path) -> Path:
-    """Write the minimal mission script into ``tmp_path`` and return its path."""
+    """Copy the minimal mission fixture into ``tmp_path`` and return its path."""
     script_path = tmp_path / "minimal_leo.script"
-    script_path.write_text(_MINIMAL_SCRIPT, encoding="utf-8")
+    shutil.copyfile(_FIXTURE_SCRIPT, script_path)
     return script_path
 
 


### PR DESCRIPTION
## Summary
- Adds a `canonical-image-smoke` CI cell that runs `pip install .` + a `Mission.load → run → assert non-empty ReportFile DataFrame` round-trip inside `ghcr.io/astro-tools/gmat:R2026a` on every PR and push to `main`. Catches drift between the canonical image and what gmat-run expects (stripped plugin, mangled `gmat_startup_file.txt`, dropped Python ABI, retagged release) before downstream container-mode users hit it.
- Extracts the inline `_MINIMAL_SCRIPT` from `tests/integration/test_smoke.py` into `tests/integration/fixtures/Ex_MinimalLEO.script` so the existing pytest smoke and the new standalone canary share one fixture.
- Standalone runner at `tests/canonical_image_smoke.py` — plain `python <script>` (not pytest), because the canary cell intentionally installs no dev deps, mirroring `minimal-install`. Locally runnable for debugging via `python tests/canonical_image_smoke.py`.
- Adds a paragraph to `docs/known-limitations.md` describing the canary so a downstream user reading our docs can see we test the image we publish.

The main `test` matrix stays in action-mode per #87 — this is *one* additional cell, not a switch of the matrix.

## Test plan
- [ ] `canonical-image-smoke` cell goes green on this PR's CI run (first end-to-end exercise of the cell).
- [ ] Wall-clock figure for the cell recorded here once green: _TBD_.
- [ ] Existing `test`, `lint`, `typecheck`, `minimal-install` cells stay green (the only refactor under their feet is the inline-script → fixture-file extraction).

Closes #93