### PR TITLE
Cut v0.4.0: bump version, add CHANGELOG, polish README/docs links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to gmat-run are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] — 2026-05-03
+
+### Added
+
+- `Mission.summary()` returns a [`MissionSummary`][gmat_run.MissionSummary]
+  with the resolved GMAT install, the parsed [`ResourceGroup`][gmat_run.ResourceGroup]s
+  and [`CommandOutline`][gmat_run.CommandOutline] for the mission sequence.
+  `Mission` and `Results` both gain `_repr_html_` so a notebook cell that
+  ends in either renders a structured table instead of a `<…>` repr (#91, #99).
+- `docs/ci-with-setup-gmat.md` — a cookbook page showing how to wire
+  `astro-tools/setup-gmat@v0` into a downstream project's GitHub Actions
+  workflow, including caching, optional extras, and a multi-version
+  matrix (#89, #97).
+
+### Changed
+
+- CI now uses `astro-tools/setup-gmat@v0` instead of an inline GMAT install
+  step. The action handles download, cache, `BuildApiStartupFile.py`, and
+  `GMAT_ROOT` export — the workflow shrinks to one step (#87, #95).
+- CI matrix expanded from one GMAT release to two: every PR runs the full
+  cross-product of Ubuntu / Windows / macOS × Python 3.10 / 3.11 / 3.12 ×
+  R2025a / R2026a (18 cells). Both releases are now first-class supported
+  (#88, #96).
+- Overall coverage gate raised from ≥ 80% to ≥ 90% on the
+  Ubuntu / Python 3.12 / R2026a cell (#90, #98).
+- New `canonical-image-smoke` CI cell exercises `pip install gmat-run`
+  and a `Mission.load → run → assert non-empty ReportFile` round-trip
+  inside `ghcr.io/astro-tools/gmat:R2026a` on every PR. The action and
+  the canonical image can drift apart silently; this is the canary that
+  catches it before downstream container-mode CI users do (#93, #100).
+
 ## [0.3.0] — 2026-04-28
 
 ### Added
@@ -107,6 +138,7 @@ Initial public release.
 - Release workflow: build, PyPI trusted publishing, and
   `gh release create --generate-notes` on `v*` tags (#31).
 
+[0.4.0]: https://github.com/astro-tools/gmat-run/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/astro-tools/gmat-run/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/astro-tools/gmat-run/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/astro-tools/gmat-run/compare/v0.1.0...v0.1.1

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ and sample output.
 Full docs at **<https://astro-tools.github.io/gmat-run/>**, including a
 [getting-started guide](https://astro-tools.github.io/gmat-run/getting-started/),
 [GMAT install instructions](https://astro-tools.github.io/gmat-run/install-gmat/),
+a [Run gmat-run in your CI](https://astro-tools.github.io/gmat-run/ci-with-setup-gmat/)
+cookbook page,
 the [CLI reference](https://astro-tools.github.io/gmat-run/cli/),
 and the [API reference](https://astro-tools.github.io/gmat-run/reference/).
 

--- a/docs/ci-with-setup-gmat.md
+++ b/docs/ci-with-setup-gmat.md
@@ -58,7 +58,7 @@ the same step as gmat-run itself:
 | Extra          | Pulls in                                                                    |
 | -------------- | --------------------------------------------------------------------------- |
 | `[spiceypy]`   | SPK ephemeris parsing in [`Results.ephemerides`][gmat_run.Results].         |
-| `[ccsds-ndm]`  | CCSDS-NDM (OEM/OPM) parsing on the same lazy mapping.                       |
+| `[ccsds-ndm]`  | CCSDS-OEM export via [`Results.write_oem`][gmat_run.Results.write_oem].     |
 | `[astropy]`    | [`gmat_run.time`](reference/time.md) leap-second-correct time-scale conversion. |
 
 The extras compose; pass several in one bracketed list as above.

--- a/docs/examples/04_export_oem.ipynb
+++ b/docs/examples/04_export_oem.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Export an ephemeris to CCSDS-OEM\n",
     "\n",
-    "This notebook demonstrates the v0.3 headline feature: take whatever ephemeris GMAT just wrote, hand it to `Results.write_oem(...)`, and get a clean CCSDS-OEM file out.\n",
+    "This notebook walks through `Results.write_oem(...)`: take whatever ephemeris GMAT just wrote, hand it to the writer, and get a clean CCSDS-OEM file out.\n",
     "\n",
     "The interesting case is the one that does real work — a *format conversion*. We point GMAT at a stock sample (`Ex_STKEphemOutput.script`) that emits an `EphemerisFile` in **STK TimePosVel** format, parse it through `result.ephemerides[...]`, and write the same trajectory back out as CCSDS-OEM. The `gmat-run` writer handles the frame-name translation (STK's `J2000` &rarr; CCSDS's `EME2000`), tags the file with our originator and object name, and emits `CCSDS_OEM_VERS = 1.0` so the output round-trips through GMAT's own OEM reader.\n",
     "\n",

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,5 +30,7 @@ result.reports["ReportFile1"].plot(x="UTCGregorian", y="Sat.Earth.Altitude")
 
 - [Getting started](getting-started.md) — install gmat-run and run your first mission.
 - [Install GMAT](install-gmat.md) — get the GMAT engine on your machine.
+- [Run gmat-run in your CI](ci-with-setup-gmat.md) — wire `astro-tools/setup-gmat`
+  into a GitHub Actions workflow.
 - [API reference](reference/index.md) — the public Python API.
 - [Known limitations](known-limitations.md) — gmatpy single-init constraint and other gotchas.

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -112,7 +112,7 @@ but you cannot ask GMAT to *emit* an AEM trace of a propagated spacecraft.
 ## Parser format restrictions
 
 The parsers in [`gmat_run.parsers`](reference/parsers.md) cover the formats
-GMAT actually emits in v0.3; uncommon variants raise
+GMAT actually emits in v0.4; uncommon variants raise
 [`GmatOutputParseError`][gmat_run.GmatOutputParseError].
 
 - **CCSDS-OEM ephemeris**: covariance blocks (`COVARIANCE_START` …

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gmat-run"
-version = "0.3.0"
+version = "0.4.0"
 description = "Run GMAT mission scripts from Python and get results as pandas DataFrames."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/gmat_run/__init__.py
+++ b/src/gmat_run/__init__.py
@@ -14,7 +14,7 @@ from gmat_run.results import Results
 from gmat_run.runtime import bootstrap
 from gmat_run.summary import CommandOutline, MissionSummary, ResourceGroup
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 __all__ = [
     "CommandOutline",

--- a/src/gmat_run/parsers/ephemeris.py
+++ b/src/gmat_run/parsers/ephemeris.py
@@ -213,7 +213,7 @@ def _split(lines: list[str], path: Path) -> tuple[dict[str, str], list[_Segment]
             continue
 
         if in_covariance:
-            # Covariance blocks are not exposed in v0.2 — silently consumed.
+            # Covariance blocks are not exposed — silently consumed.
             continue
 
         if in_meta:

--- a/src/gmat_run/writers/oem.py
+++ b/src/gmat_run/writers/oem.py
@@ -11,8 +11,8 @@ The writer is gated behind the ``[ccsds-ndm]`` extra; importing this module
 without ``ccsds-ndm`` installed surfaces an :class:`ImportError` with a hint
 the moment :func:`write_oem` is called.
 
-Multi-segment OEM output is deliberately not supported in v0.3 — every call
-emits a single segment containing every row of the DataFrame in file order.
+Multi-segment OEM output is deliberately not supported — every call emits a
+single segment containing every row of the DataFrame in file order.
 ``df.attrs["segments"]`` is ignored. Covariance blocks are also out of scope.
 """
 

--- a/tests/test_parsers_ephemeris.py
+++ b/tests/test_parsers_ephemeris.py
@@ -314,7 +314,7 @@ def test_non_numeric_state_raises(tmp_path: Path) -> None:
 
 
 def test_covariance_blocks_silently_consumed(tmp_path: Path) -> None:
-    """v0.2 doesn't expose covariance; the parser must skip the block cleanly."""
+    """The parser does not expose covariance; the block must be skipped cleanly."""
     cov = (
         "COVARIANCE_START\n"
         "EPOCH = 2026-01-01T12:00:00.000\n"

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -168,7 +168,7 @@ def test_unknown_report_key_raises(tmp_path: Path) -> None:
     assert excinfo.value.args == ("does_not_exist",)
 
 
-# --- ephemerides (lazy, v0.2) ------------------------------------------------
+# --- ephemerides (lazy) ------------------------------------------------------
 
 
 _EPH_FILE = """\

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -4,4 +4,4 @@ import gmat_run
 
 
 def test_import() -> None:
-    assert gmat_run.__version__ == "0.3.0"
+    assert gmat_run.__version__ == "0.4.0"

--- a/uv.lock
+++ b/uv.lock
@@ -861,7 +861,7 @@ wheels = [
 
 [[package]]
 name = "gmat-run"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

Release-cut PR for v0.4.0. Bumps versions, adds the `[0.4.0]` CHANGELOG section, and folds in the small README / docs polish that #94 calls for.

### Code/version

- `__version__` → `0.4.0` in `pyproject.toml`, `src/gmat_run/__init__.py`, `tests/test_smoke.py`, `uv.lock`.

### CHANGELOG

- New `[0.4.0]` section grouped Added / Changed:
  - Added: `Mission.summary()` + notebook reprs (#99), CI cookbook page (#97).
  - Changed: setup-gmat@v0 migration (#95), R2025a + R2026a CI matrix (#96), 90% coverage gate (#98), canonical-image canary cell (#100).
- New `[0.4.0]` compare link.

### README / docs

- README: link the new "Run gmat-run in your CI" cookbook page from the Documentation section. Matrix and extras tables are unchanged from v0.3.
- `docs/index.md`: add the CI cookbook page to "Where to next".
- `docs/known-limitations.md`: bump the parser-format-coverage caveat from "v0.3" to "v0.4" (matches the v0.2→v0.3 bump from PR #86).
- `docs/ci-with-setup-gmat.md`: fix the `[ccsds-ndm]` row in the extras table — the extra gates `Results.write_oem` (CCSDS-OEM export), not OEM/OPM parsing on `Results.ephemerides`. Drift from the README's wording, caught while auditing.

### Milestone hygiene

- v0.4 milestone added to PRs #95-#100 (issues were already tagged).
- Issue #50 (Code-500 parser) closed wontfix.

## Test plan

- [x] `uv run ruff check`, `uv run ruff format --check`, `uv run mypy`, `uv run pytest -m "not integration"` all green locally.
- [x] CI green on this PR (full integration matrix on Ubuntu/Windows/macOS × Py 3.10/3.11/3.12 × R2025a/R2026a, plus the canonical-image canary).
- [ ] After merge: cut the annotated `v0.4.0` tag — release workflow handles PyPI publish + docs deploy.
- [ ] After release: clean install of `pip install gmat-run==0.4.0` runs the smoke test and the v0.3 example notebooks end-to-end (DoD from #94).

Closes #94.