### PR TITLE
Point CONTRIBUTING Discussions link at the org-wide board

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,5 +77,7 @@ existing issues to make sure the work belongs here and not in a future repo.
 
 ## Questions
 
-Open a [discussion](https://github.com/astro-tools/gmat-run/discussions) rather than
-an issue for open-ended questions, usage help, or brainstorming.
+Open a [discussion](https://github.com/orgs/astro-tools/discussions) rather
+than an issue for open-ended questions, usage help, or brainstorming. The
+astro-tools org runs a single shared discussions space — there is no
+per-repo discussions board.


### PR DESCRIPTION
## Summary

- `CONTRIBUTING.md` sent users at `https://github.com/astro-tools/gmat-run/discussions`, which 404s — the astro-tools org runs a single shared Discussions space, not per-repo boards.
- Swap the URL to `https://github.com/orgs/astro-tools/discussions` and add a one-liner explaining there is no per-repo board, so the link doesn't read as a broken setup.
- Mirrors the equivalent gmat-sweep fix in [`66f4ce9`](https://github.com/astro-tools/gmat-sweep/commit/66f4ce9).

## Test plan

- [ ] Re-read the `## Questions` paragraph in `CONTRIBUTING.md` on the PR diff.
- [ ] Click the link in the rendered diff and confirm it resolves to the org-wide Discussions space.

Closes #102