### PR TITLE
Resolve relative paths consistently across the public path API

### DIFF
--- a/src/gmat_run/_path_utils.py
+++ b/src/gmat_run/_path_utils.py
@@ -1,0 +1,27 @@
+"""Path-normalisation helper shared across the public path-shaped API.
+
+Every public surface that accepts a filesystem path argument funnels it
+through :func:`resolve_user_path` so callers see the same behaviour
+everywhere: ``~`` is expanded, relative paths are resolved against the
+caller's CWD at submit time, and absolute paths are passed through
+unchanged. The boundary normalisation kills GMAT's install-time
+``OUTPUT_PATH``-relative footgun for workspace arguments and gives stored
+path attributes (:attr:`Mission.script_path`, :attr:`Results.output_dir`,
+``write_oem`` return values) a canonical absolute form.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def resolve_user_path(path: str | os.PathLike[str]) -> Path:
+    """Return ``Path(path)`` with ``~`` expanded and resolved to absolute.
+
+    Always returns an absolute :class:`~pathlib.Path`. ``.resolve()`` on an
+    already-absolute path is a no-op, so callers who pre-resolved are
+    unaffected. Symlinks are resolved as a side effect — that's the
+    documented contract of :meth:`Path.resolve`.
+    """
+    return Path(path).expanduser().resolve()

--- a/src/gmat_run/mission.py
+++ b/src/gmat_run/mission.py
@@ -33,6 +33,7 @@ from typing import Any, Final
 import numpy as np
 import pandas as pd
 
+from gmat_run._path_utils import resolve_user_path
 from gmat_run.errors import GmatFieldError, GmatLoadError, GmatRunError
 from gmat_run.install import GmatInstall, locate_gmat
 from gmat_run.parsers.aem_ephemeris import parse as _parse_aem_ephemeris
@@ -154,13 +155,17 @@ class Mission:
         :func:`~gmat_run.runtime.bootstrap`, and parses the script via
         ``gmat.LoadScript``.
 
+        ``path`` is resolved against the caller's CWD at submit time
+        (``~`` is expanded, relative paths become absolute). The resolved
+        value is exposed via :attr:`script_path`.
+
         Raises:
             GmatNotFoundError: No usable GMAT install was found.
             GmatLoadError: gmatpy could not be loaded, or
                 ``LoadScript`` returned ``False`` (parse error — check the
                 GMAT log file).
         """
-        script_path = Path(path).expanduser()
+        script_path = resolve_user_path(path)
         install = locate_gmat(gmat_root)
         gmat = bootstrap(install)
         if not gmat.LoadScript(str(script_path)):
@@ -332,11 +337,15 @@ class Mission:
           notice prepended to :attr:`Results.log`.
 
         Args:
-            working_dir: Directory GMAT writes its outputs into. ``None``
-                creates a fresh :class:`tempfile.TemporaryDirectory` whose
-                lifetime is tied to the returned :class:`Results` — the
-                directory survives until the caller drops the result, so lazy
-                report parsing keeps working without a context manager. Call
+            working_dir: Directory GMAT writes its outputs into. ``~`` is
+                expanded and relative paths are resolved against the
+                caller's CWD at submit time, so the stored
+                :attr:`Results.output_dir` is always absolute regardless of
+                what the caller passed in. ``None`` creates a fresh
+                :class:`tempfile.TemporaryDirectory` whose lifetime is tied
+                to the returned :class:`Results` — the directory survives
+                until the caller drops the result, so lazy report parsing
+                keeps working without a context manager. Call
                 :meth:`Results.persist` before that to copy the artefacts to a
                 permanent location.
             overwrite: When ``True``, unlink any pre-existing files in
@@ -812,7 +821,7 @@ def _prepare_workspace(
     if working_dir is None:
         tempdir = tempfile.TemporaryDirectory(prefix="gmat-run-")
         return Path(tempdir.name), tempdir
-    path = Path(working_dir).expanduser()
+    path = resolve_user_path(working_dir)
     try:
         path.mkdir(parents=True, exist_ok=True)
     except OSError as exc:

--- a/src/gmat_run/results.py
+++ b/src/gmat_run/results.py
@@ -29,6 +29,7 @@ from types import MappingProxyType
 
 import pandas as pd
 
+from gmat_run._path_utils import resolve_user_path
 from gmat_run.parsers.contact import parse as _parse_contact
 from gmat_run.parsers.ephemeris import parse as _parse_oem_ephemeris
 from gmat_run.parsers.reportfile import parse as _parse_reportfile
@@ -265,12 +266,15 @@ class Results:
 
         Args:
             path: Directory to copy artefacts into. Created if missing.
+                ``~`` is expanded and relative paths are resolved against
+                the caller's CWD at submit time, so :attr:`output_dir`
+                stays absolute after the call.
 
         Returns:
             ``self``, so the call composes with ``Mission.run().persist(...)``.
         """
-        dest = Path(path).expanduser()
-        if self.output_dir.exists() and dest.resolve() == self.output_dir.resolve():
+        dest = resolve_user_path(path)
+        if self.output_dir.exists() and dest == self.output_dir.resolve():
             return self
         dest.mkdir(parents=True, exist_ok=True)
         if self.output_dir.exists() and self.output_dir.is_dir():

--- a/src/gmat_run/writers/oem.py
+++ b/src/gmat_run/writers/oem.py
@@ -25,6 +25,8 @@ from typing import Any, Final
 
 import pandas as pd
 
+from gmat_run._path_utils import resolve_user_path
+
 __all__ = ["write_oem"]
 
 # CCSDS 502.0-B-2 §A.5 reference frames the writer accepts as canonical.
@@ -83,7 +85,10 @@ def write_oem(
             attrs the parser surfaces (``coordinate_system``,
             ``central_body``, ``time_scale`` / ``epoch_scales``, optionally
             ``object_name``, ``interpolation``, ``interpolation_degree``).
-        path: Destination ``.oem`` file. Parent directories are created.
+        path: Destination ``.oem`` file. ``~`` is expanded and relative
+            paths are resolved against the caller's CWD at submit time;
+            the returned :class:`~pathlib.Path` is always absolute. Parent
+            directories are created.
         originator: Value for the ``ORIGINATOR`` header field. Defaults to
             ``"gmat-run"`` (the file header from the source ephemeris is
             *not* preserved — the new file is a new artefact).
@@ -203,7 +208,7 @@ def write_oem(
     # emit).
     oem.version = "2.0"
 
-    dest = Path(path)
+    dest = resolve_user_path(path)
     dest.parent.mkdir(parents=True, exist_ok=True)
     NdmKvnIo().to_file(oem, dest)
     _rewrite_oem_version_line(dest)

--- a/tests/integration/test_working_dir.py
+++ b/tests/integration/test_working_dir.py
@@ -100,3 +100,29 @@ def test_collision_gate_requires_overwrite_for_explicit_working_dir(
     # file is freshly written, not appended. The size sanity check would
     # surface an "old + new" concatenation regression instantly.
     assert third.reports["RF"].equals(first.reports["RF"])
+
+
+def test_relative_working_dir_resolves_against_caller_cwd(
+    gmat_available: None,
+    minimal_script: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A relative ``working_dir`` lands under the caller's CWD at submit
+    # time, not under GMAT's install-time ``OUTPUT_PATH``. Without the
+    # boundary-normalisation, the rewritten Filename handed to
+    # ``SetField`` would be relative and GMAT would write under
+    # ``<install>/output/relative_outputs/`` — silent footgun.
+    cwd = tmp_path / "caller_cwd"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+
+    result = Mission.load(minimal_script).run(working_dir="relative_outputs")
+
+    expected = (cwd / "relative_outputs").resolve()
+    assert result.output_dir == expected
+    assert (expected / "leo_state.txt").is_file()
+    # The captured report's source path must also live under the resolved
+    # workspace — proves the rewrite handed GMAT an absolute path, not
+    # one anchored at GMAT's install-time OUTPUT_PATH.
+    assert result.reports._paths["RF"] == expected / "leo_state.txt"  # type: ignore[attr-defined]

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -425,8 +425,26 @@ def test_load_returns_mission_handle(patched_load: ModuleType, tmp_path: Path) -
     mission = Mission.load(script)
 
     assert mission.gmat is patched_load
-    assert mission.script_path == script
+    assert mission.script_path == script.resolve()
     assert mission.install.version == "R2026a"
+
+
+def test_load_resolves_relative_script_path_against_cwd(
+    patched_load: ModuleType, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A bare relative script path must end up absolute on ``mission.script_path``
+    # so downstream lookups (e.g. ``attitude_input_paths``) that resolve
+    # filenames against ``script_path.parent`` see a fully-qualified parent
+    # regardless of subsequent ``chdir`` in the caller.
+    script_dir = tmp_path / "scripts"
+    script_dir.mkdir()
+    (script_dir / "flyby.script").write_text("# fake\n", encoding="utf-8")
+    monkeypatch.chdir(script_dir)
+
+    mission = Mission.load("flyby.script")
+
+    assert mission.script_path.is_absolute()
+    assert mission.script_path == (script_dir / "flyby.script").resolve()
 
 
 def test_load_raises_gmat_load_error_on_parse_failure(
@@ -1312,6 +1330,36 @@ class TestMissionRunWorkingDir:
         result = mission.run(overwrite=True)
 
         assert result.output_dir.is_dir()
+
+    def test_run_resolves_relative_working_dir_against_cwd(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A relative ``working_dir`` is anchored to the caller's CWD at submit
+        # time, not to GMAT's install-time ``OUTPUT_PATH``. Without the
+        # resolution, the path would propagate relative through
+        # ``_rewrite_output_paths`` into ``SetField("Filename", ...)`` and
+        # GMAT would land outputs under ``<gmat-install>/output/<rel>``.
+        mission, _ = _run_mission(tmp_path)
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+
+        result = mission.run(working_dir="outputs/run_0")
+
+        assert result.output_dir.is_absolute()
+        assert result.output_dir == (cwd / "outputs/run_0").resolve()
+
+    def test_run_expands_tilde_in_working_dir(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Tilde-expansion was already implicit via ``Path.expanduser``; this
+        # is a regression guard so the helper's contract is pinned.
+        monkeypatch.setenv("HOME", str(tmp_path))
+        mission, _ = _run_mission(tmp_path)
+
+        result = mission.run(working_dir="~/run_home")
+
+        assert result.output_dir == (tmp_path / "run_home").resolve()
 
 
 # --- Mission.attitude_inputs --------------------------------------------------

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -1353,8 +1353,12 @@ class TestMissionRunWorkingDir:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         # Tilde-expansion was already implicit via ``Path.expanduser``; this
-        # is a regression guard so the helper's contract is pinned.
+        # is a regression guard so the helper's contract is pinned. Both
+        # HOME (POSIX) and USERPROFILE (Windows) are stubbed so the
+        # assertion is platform-independent — Python's expanduser reads
+        # USERPROFILE on Windows.
         monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
         mission, _ = _run_mission(tmp_path)
 
         result = mission.run(working_dir="~/run_home")

--- a/tests/test_path_utils.py
+++ b/tests/test_path_utils.py
@@ -1,0 +1,52 @@
+"""Unit tests for :mod:`gmat_run._path_utils`.
+
+The helper centralises the path-normalisation rule applied at every
+public path-shaped boundary (``Mission.load``, ``Mission.run``,
+``Results.persist``, ``write_oem``). The tests pin its contract directly
+so any future tightening or loosening has a single place to assert.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gmat_run._path_utils import resolve_user_path
+
+
+def test_resolves_relative_against_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    result = resolve_user_path("outputs/run_0")
+    assert result == (tmp_path / "outputs/run_0").resolve()
+    assert result.is_absolute()
+
+
+def test_absolute_path_is_noop(tmp_path: Path) -> None:
+    abs_input = tmp_path / "abs"
+    result = resolve_user_path(abs_input)
+    assert result == abs_input.resolve()
+    assert result.is_absolute()
+
+
+def test_tilde_is_expanded() -> None:
+    result = resolve_user_path("~/some-target")
+    assert result == (Path.home() / "some-target").resolve()
+    assert "~" not in str(result)
+
+
+def test_pathlike_input_accepted(tmp_path: Path) -> None:
+    result = resolve_user_path(tmp_path / "sub")
+    assert result == (tmp_path / "sub").resolve()
+
+
+def test_empty_string_resolves_to_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    result = resolve_user_path("")
+    assert result == tmp_path.resolve()
+
+
+def test_dot_resolves_to_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    result = resolve_user_path(".")
+    assert result == tmp_path.resolve()

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -556,6 +556,33 @@ class TestPersist:
         assert (second / "r1.txt").exists()
         assert result.reports._paths["R1"] == second / "r1.txt"  # type: ignore[attr-defined]
 
+    def test_resolves_relative_dest_against_cwd(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A relative ``dest`` is anchored to the caller's CWD at submit
+        # time, not interpreted relative to the workspace or some other
+        # implicit base.
+        result, _ = _result_with_workspace(tmp_path)
+        cwd = tmp_path / "cwd"
+        cwd.mkdir()
+        monkeypatch.chdir(cwd)
+
+        result.persist("persisted/run_x")
+
+        expected = (cwd / "persisted/run_x").resolve()
+        assert result.output_dir.is_absolute()
+        assert result.output_dir == expected
+        assert (expected / "r1.txt").exists()
+
+    def test_expands_tilde_in_dest(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Regression guard so the path-helper contract is pinned.
+        monkeypatch.setenv("HOME", str(tmp_path))
+        result, _ = _result_with_workspace(tmp_path)
+
+        result.persist("~/persisted_home")
+
+        assert result.output_dir == (tmp_path / "persisted_home").resolve()
+
 
 # --- write_oem / write_oem_all ----------------------------------------------
 

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -575,8 +575,11 @@ class TestPersist:
         assert (expected / "r1.txt").exists()
 
     def test_expands_tilde_in_dest(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        # Regression guard so the path-helper contract is pinned.
+        # Regression guard so the path-helper contract is pinned. Both HOME
+        # (POSIX) and USERPROFILE (Windows) are stubbed because Python's
+        # expanduser reads USERPROFILE on Windows, not HOME.
         monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
         result, _ = _result_with_workspace(tmp_path)
 
         result.persist("~/persisted_home")

--- a/tests/test_writers_oem.py
+++ b/tests/test_writers_oem.py
@@ -86,8 +86,11 @@ def test_resolves_relative_path_against_cwd(
 
 
 def test_expands_tilde_in_destination(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    # Regression guard for the path-helper's expanduser contract.
+    # Regression guard for the path-helper's expanduser contract. Both HOME
+    # (POSIX) and USERPROFILE (Windows) are stubbed because Python's
+    # expanduser reads USERPROFILE on Windows, not HOME.
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
     df = _hand_built_oem_frame()
 
     out = write_oem(df, "~/run.oem")

--- a/tests/test_writers_oem.py
+++ b/tests/test_writers_oem.py
@@ -64,7 +64,35 @@ def test_round_trip_preserves_state_columns_and_attrs(tmp_path: Path) -> None:
 def test_returns_destination_path(tmp_path: Path) -> None:
     df = _hand_built_oem_frame()
     out = write_oem(df, tmp_path / "out.oem")
-    assert out == tmp_path / "out.oem"
+    assert out == (tmp_path / "out.oem").resolve()
+    assert out.exists()
+
+
+def test_resolves_relative_path_against_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A relative destination is anchored to the caller's CWD at submit
+    # time, not silently resolved against some other base.
+    df = _hand_built_oem_frame()
+    cwd = tmp_path / "cwd"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+
+    out = write_oem(df, "outputs/run.oem")
+
+    assert out.is_absolute()
+    assert out == (cwd / "outputs/run.oem").resolve()
+    assert out.exists()
+
+
+def test_expands_tilde_in_destination(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Regression guard for the path-helper's expanduser contract.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    df = _hand_built_oem_frame()
+
+    out = write_oem(df, "~/run.oem")
+
+    assert out == (tmp_path / "run.oem").resolve()
     assert out.exists()
 
 


### PR DESCRIPTION
## Summary

- Every public path-shaped surface (`Mission.load`, `Mission.run(working_dir=...)`, `Results.persist`, `write_oem`) now normalises its path argument via a shared helper that expands `~` and resolves relatives against the caller's CWD at submit time. Stored path attributes (`Mission.script_path`, `Results.output_dir`, `write_oem`'s return) are always absolute.
- Before this change the four entry points behaved inconsistently: `Mission.run` only `expanduser`'d, letting relatives propagate through `_rewrite_output_paths` into `SetField("Filename", ...)` where GMAT silently anchored them against its install-time `OUTPUT_PATH`; `write_oem` didn't even `expanduser`; `Results.persist` resolved only for comparison, not before copy.
- Callers already passing absolute paths see no behavioural change.

## Test plan

- [x] `uv run pytest` — 700 unit tests pass (including 6 new in `tests/test_path_utils.py` + 5 regression-guard tests across `test_mission.py` / `test_results.py` / `test_writers_oem.py`).
- [x] `uv run pytest tests/integration/test_working_dir.py -m integration` — 2 integration tests pass against the local GMAT R2026a, including the new `test_relative_working_dir_resolves_against_caller_cwd` that pins the original footgun closed.
- [x] `uv run ruff check src tests` — clean.
- [x] `uv run ruff format --check src tests` — clean.
- [x] `uv run mypy src` — strict; no issues in 21 source files.

Closes #105