### PR TITLE
Extend Mission override grammar: multi-dot sub-resource paths and Variable values

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,14 @@ contacts = result.contacts["ContactLocator1"]
 
 `Mission.load` discovers a local GMAT install (honouring the `GMAT_ROOT` environment variable
 or a `gmat_root=` argument), bootstraps `gmatpy`, and parses the script into the live GMAT
-object graph. Subscript access reads and writes fields against that graph with type coercion.
+object graph. Subscript access reads and writes fields against that graph with type coercion:
+
+| Pattern | Example |
+|---------|---------|
+| `Resource.Field` | `mission["Sat.SMA"] = 7000` |
+| `Resource.SubResource.Field` | `mission["FM.Drag.CSSISpaceWeatherFile"] = "/path/CSSI.txt"` |
+| `Variable.Value` | `mission["elapsed_seconds.Value"] = 86400.0` |
+
 `mission.run()` executes the mission sequence headlessly, captures GMAT's log, and returns a
 `Results` exposing three lazy mappings — `reports`, `ephemerides`, and `contacts` — each
 keyed by the GMAT resource name and parsing to a DataFrame on first access. See

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -49,6 +49,17 @@ mission["Sat.SMA"] = 6878.0     # write through SetField
 mission["DefaultProp.InitialStepSize"] = 60
 ```
 
+The grammar covers three flavours:
+
+| Pattern | Example | When to reach for it |
+|---------|---------|----------------------|
+| `Resource.Field` | `mission["Sat.SMA"] = 7000` | Top-level field on any GMAT Resource |
+| `Resource.SubResource.Field` | `mission["FM.Drag.CSSISpaceWeatherFile"] = "/path/CSSI.txt"` | A field on a sub-resource the parent Resource owns (force-model drag, hardware sub-fields, etc.) |
+| `Variable.Value` | `mission["elapsed_seconds.Value"] = 86400.0` | The numeric value of a script-level `Create Variable` block |
+
+GMAT routes the dotted tail through to the right sub-object internally, so the grammar is
+one consistent shape across all three cases.
+
 [`mission.run()`][gmat_run.Mission.run] executes the mission sequence headlessly
 and returns a [`Results`][gmat_run.Results] object keyed by the resource names
 declared in the script. Parsing is lazy — a DataFrame is materialised on first

--- a/src/gmat_run/mission.py
+++ b/src/gmat_run/mission.py
@@ -4,11 +4,19 @@ The single public entry point is :class:`Mission`. :meth:`Mission.load`
 discovers a local GMAT install, bootstraps ``gmatpy``, parses a
 ``.script`` into the live GMAT object graph, and returns a handle.
 
-Field access uses dotted-path keys against that graph: ``mission["Sat.SMA"]``
-returns a typed Python value, ``mission["Sat.SMA"] = 7000`` writes one back
-through ``SetField``. The path format is exactly ``Resource.Field`` — one dot,
-two non-empty segments. Owned-object pass-through (``Sat.Tanks.MainTank.…``)
-is deferred.
+Field access uses dotted-path keys against that graph. The grammar covers
+three flavours:
+
+- ``mission["Sat.SMA"]`` — top-level ``Resource.Field``.
+- ``mission["FM.Drag.CSSISpaceWeatherFile"]`` — sub-resource fields via
+  ``Resource.SubResource.Field`` (N≥2 dots after the resource name).
+- ``mission["my_var.Value"]`` — script-level ``Create Variable`` blocks,
+  addressed via the ``Variable.Value`` suffix.
+
+Reads return typed Python values; writes coerce through the same type
+gates and round-trip with reads (``mission[path] = v; assert mission[path] == v``).
+Everything after the first dot is passed verbatim to GMAT, which routes
+sub-resource paths internally — no Python-side object-graph walk.
 
 :meth:`Mission.run` executes the loaded mission sequence headlessly, captures
 GMAT's log into the returned :class:`~gmat_run.results.Results`, and surfaces
@@ -264,6 +272,18 @@ class Mission:
         return self.summary()._repr_html_()
 
     def __getitem__(self, dotted: str) -> Any:
+        """Return the value of the GMAT field at ``dotted``.
+
+        ``dotted`` is one of ``"Resource.Field"``,
+        ``"Resource.SubResource.Field"`` (e.g. ``"FM.Drag.CSSISpaceWeatherFile"``),
+        or ``"<variable>.Value"`` for script-level ``Create Variable`` blocks.
+        Everything after the first dot is passed to GMAT as a field name;
+        GMAT routes sub-resource access internally.
+
+        Raises:
+            GmatFieldError: ``Resource`` does not exist in the loaded script,
+                or the (sub-)field name is unknown on the resolved object.
+        """
         resource, field = _split_path(dotted)
         obj = self._resolve_resource(resource, dotted, value=None)
         pid = self._resolve_field(obj, field, dotted, value=None)
@@ -271,6 +291,23 @@ class Mission:
         return self._read(obj, pid, field, type_code)
 
     def __setitem__(self, dotted: str, value: Any) -> None:
+        """Write ``value`` to the GMAT field at ``dotted``.
+
+        Grammar matches :meth:`__getitem__`. The value is type-coerced
+        against GMAT's parameter type — ``int`` / ``float`` /
+        ``numpy.floating`` / ``numpy.integer`` are interchangeable for
+        real-typed fields, ``bool`` is required for boolean fields, etc.
+
+        ``Variable.Value`` writes the numeric value of a script-level
+        ``Create Variable`` block; ``Resource.SubResource.Field`` writes
+        through to a sub-resource (e.g.
+        ``mission["FM.Drag.CSSISpaceWeatherFile"] = "/abs/path"``).
+
+        Raises:
+            GmatFieldError: ``Resource`` does not exist; the (sub-)field
+                name is unknown; the value type does not match the field's
+                expected type; or the engine rejected the write.
+        """
         resource, field = _split_path(dotted, value=value)
         obj = self._resolve_resource(resource, dotted, value=value)
         pid = self._resolve_field(obj, field, dotted, value=value)
@@ -733,9 +770,16 @@ def _strip_numpy(value: Any) -> Any:
 
 
 def _split_path(dotted: str, *, value: Any = None) -> tuple[str, str]:
-    if not isinstance(dotted, str) or dotted.count(".") != 1:
+    # Grammar: ``Resource.Field`` (single-dot), ``Resource.SubResource.Field``
+    # (multi-dot, e.g. ``FM.Drag.CSSISpaceWeatherFile``), and the special-case
+    # ``Variable.Value`` for script-level ``Create Variable`` blocks.
+    # Everything after the first dot is passed verbatim to GMAT, which routes
+    # dotted sub-resource paths internally via ``GetParameterID`` / ``GetField``
+    # / ``SetField`` on the top-level Resource — no Python-side walk needed.
+    if not isinstance(dotted, str) or "." not in dotted:
         raise GmatFieldError(
-            f"invalid dotted path '{dotted}'; expected exactly one dot ('Resource.Field')",
+            f"invalid dotted path '{dotted}'; expected at least one dot "
+            "('Resource.Field' or 'Resource.SubResource.Field')",
             str(dotted),
             value,
         )

--- a/tests/integration/fixtures/Ex_DragLEO.script
+++ b/tests/integration/fixtures/Ex_DragLEO.script
@@ -1,0 +1,35 @@
+Create Spacecraft Sat
+Sat.DateFormat = UTCGregorian
+Sat.Epoch = '01 Jan 2026 12:00:00.000'
+Sat.CoordinateSystem = EarthMJ2000Eq
+Sat.DisplayStateType = Keplerian
+Sat.SMA = 6878.137
+Sat.ECC = 0.0001
+Sat.INC = 51.6
+Sat.RAAN = 75
+Sat.AOP = 90
+Sat.TA = 0
+Sat.DryMass = 850
+Sat.Cd = 2.2
+Sat.DragArea = 15
+
+Create ForceModel FM
+FM.CentralBody = Earth
+FM.PrimaryBodies = {Earth}
+FM.Drag.AtmosphereModel = JacchiaRoberts
+FM.Drag.HistoricWeatherSource = 'ConstantFluxAndGeoMag'
+FM.Drag.PredictedWeatherSource = 'ConstantFluxAndGeoMag'
+
+Create Propagator Prop
+Prop.FM = FM
+Prop.Type = PrinceDormand78
+Prop.InitialStepSize = 60
+Prop.Accuracy = 1e-9
+
+Create ReportFile RF
+RF.Filename = 'leo_state.txt'
+RF.Add = {Sat.UTCGregorian, Sat.SMA}
+RF.WriteHeaders = True
+
+BeginMissionSequence
+Propagate Prop(Sat) {Sat.ElapsedSecs = 600}

--- a/tests/integration/fixtures/Ex_VariableOverride.script
+++ b/tests/integration/fixtures/Ex_VariableOverride.script
@@ -1,0 +1,32 @@
+Create Spacecraft Sat
+Sat.DateFormat = UTCGregorian
+Sat.Epoch = '01 Jan 2026 12:00:00.000'
+Sat.CoordinateSystem = EarthMJ2000Eq
+Sat.DisplayStateType = Keplerian
+Sat.SMA = 7000
+Sat.ECC = 0.001
+Sat.INC = 28.5
+Sat.RAAN = 75
+Sat.AOP = 90
+Sat.TA = 0
+
+Create ForceModel FM
+FM.CentralBody = Earth
+FM.PrimaryBodies = {Earth}
+
+Create Propagator Prop
+Prop.FM = FM
+Prop.Type = PrinceDormand78
+Prop.InitialStepSize = 60
+Prop.Accuracy = 1e-9
+
+Create Variable propagate_seconds
+propagate_seconds = 600
+
+Create ReportFile RF
+RF.Filename = 'variable_state.txt'
+RF.Add = {Sat.UTCGregorian, Sat.SMA, propagate_seconds}
+RF.WriteHeaders = True
+
+BeginMissionSequence
+Propagate Prop(Sat) {Sat.ElapsedSecs = propagate_seconds}

--- a/tests/integration/test_overrides_grammar.py
+++ b/tests/integration/test_overrides_grammar.py
@@ -1,0 +1,108 @@
+"""Integration coverage for the v0.5 override-grammar extensions.
+
+Two flavours added to ``Mission.__setitem__``:
+
+* ``Resource.SubResource.Field`` (multi-dot) — exercised via
+  ``FM.Drag.CSSISpaceWeatherFile`` against a drag-enabled LEO fixture.
+* ``Variable.Value`` — exercised against a fixture that declares
+  ``Create Variable`` and propagates for the variable's value.
+
+The fixtures live next to the existing minimal-LEO smoke fixture so the
+test is independent of which stock samples ship with a given GMAT
+release.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from gmat_run import Mission
+from gmat_run.errors import GmatFieldError
+
+pytestmark = pytest.mark.integration
+
+
+_DRAG_FIXTURE = Path(__file__).parent / "fixtures" / "Ex_DragLEO.script"
+_VAR_FIXTURE = Path(__file__).parent / "fixtures" / "Ex_VariableOverride.script"
+
+
+@pytest.fixture
+def drag_script(tmp_path: Path) -> Path:
+    dst = tmp_path / "drag_leo.script"
+    shutil.copyfile(_DRAG_FIXTURE, dst)
+    return dst
+
+
+@pytest.fixture
+def variable_script(tmp_path: Path) -> Path:
+    dst = tmp_path / "variable.script"
+    shutil.copyfile(_VAR_FIXTURE, dst)
+    return dst
+
+
+def test_multi_dot_override_round_trips_through_real_gmat(
+    gmat_available: None,
+    drag_script: Path,
+) -> None:
+    """Write to ``FM.Drag.CSSISpaceWeatherFile`` and read it back.
+
+    The motivating use case is ``paper-tle-divergence-atlas``'s ~24k
+    Starlink propagations swapping the weather file per run. Before v0.5
+    the paper carried a regex helper that rewrote the script text; this
+    pin is the public contract that lets that helper retire.
+    """
+    target = "/tmp/test_cssi.txt"
+    mission = Mission.load(drag_script)
+
+    mission["FM.Drag.CSSISpaceWeatherFile"] = target
+
+    assert mission["FM.Drag.CSSISpaceWeatherFile"] == target
+    # AtmosphereModel reads through the same sub-resource path too — proves
+    # the dotted-tail routing isn't specific to one field.
+    assert mission["FM.Drag.AtmosphereModel"] == "JacchiaRoberts"
+
+
+def test_multi_dot_unknown_field_raises_typed_error(
+    gmat_available: None,
+    drag_script: Path,
+) -> None:
+    """A sub-resource path with a wrong leaf surfaces ``GmatFieldError``.
+
+    The error preserves the dotted tail in the message so a caller spots
+    whether the typo is in the parent or the leaf without re-parsing the
+    underlying GMAT message.
+    """
+    mission = Mission.load(drag_script)
+    with pytest.raises(GmatFieldError) as excinfo:
+        _ = mission["FM.Drag.NotARealField"]
+    assert "unknown field 'Drag.NotARealField'" in str(excinfo.value)
+
+
+def test_variable_value_override_takes_effect_at_runtime(
+    gmat_available: None,
+    variable_script: Path,
+) -> None:
+    """``Variable.Value`` is the documented contract for script-Variable overrides.
+
+    The fixture script propagates for ``propagate_seconds`` seconds, where
+    that bound is itself a ``Create Variable`` block. Overriding the
+    variable before run() shortens the propagation; the captured
+    ReportFile column for the variable carries the override value.
+    """
+    overridden = 90.0  # seconds — well under the script's default of 600
+    mission = Mission.load(variable_script)
+    mission["propagate_seconds.Value"] = overridden
+
+    # Read-back: the override is visible on the live Variable.
+    assert mission["propagate_seconds.Value"] == overridden
+
+    result = mission.run()
+    df = result.reports["RF"]
+    assert isinstance(df, pd.DataFrame)
+    # The Variable column tracks the overridden value across the run.
+    assert df["propagate_seconds"].iloc[0] == pytest.approx(overridden)
+    assert df["propagate_seconds"].iloc[-1] == pytest.approx(overridden)

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -383,6 +383,31 @@ def _contact_locator(name: str = "Contacts", filename: str = "contacts.txt") -> 
     return _FakeObject("ContactLocator", name, fields)
 
 
+def _force_model(name: str = "FM") -> _FakeObject:
+    """ForceModel with a drag sub-resource — the canonical multi-dot case.
+
+    GMAT internally routes ``FM.Drag.<field>`` through the DragForce
+    sub-object. The fake registers dotted field names directly so the
+    grammar layer's path-passthrough is exercised without modelling the
+    sub-object explicitly.
+    """
+    fields: dict[str, tuple[int, Any, bool]] = {
+        "CentralBody": (_TYPE_CODES["OBJECT_TYPE"], "Earth", False),
+        "Drag": (_TYPE_CODES["ENUMERATION_TYPE"], "JacchiaRoberts", False),
+        "Drag.AtmosphereModel": (_TYPE_CODES["ENUMERATION_TYPE"], "JacchiaRoberts", False),
+        "Drag.CSSISpaceWeatherFile": (_TYPE_CODES["FILENAME_TYPE"], "weather.txt", False),
+    }
+    return _FakeObject("ForceModel", name, fields)
+
+
+def _variable(name: str = "elapsed_seconds", initial: float = 0.0) -> _FakeObject:
+    """GMAT ``Variable`` resource — the ``Variable.Value`` override case."""
+    fields: dict[str, tuple[int, Any, bool]] = {
+        "Value": (_TYPE_CODES["REAL_TYPE"], initial, False),
+    }
+    return _FakeObject("Variable", name, fields)
+
+
 # --- fixtures -----------------------------------------------------------------
 
 
@@ -811,12 +836,18 @@ class TestErrors:
     def test_path_with_no_dot(self, mission: Mission) -> None:
         with pytest.raises(GmatFieldError) as excinfo:
             _ = mission["Sat"]
-        assert "exactly one dot" in str(excinfo.value)
+        assert "at least one dot" in str(excinfo.value)
 
-    def test_path_with_multiple_dots(self, mission: Mission) -> None:
+    def test_path_with_multiple_dots_is_valid_grammar(self, mission: Mission) -> None:
+        # Multi-dot is the SubResource grammar (e.g. FM.Drag.CSSISpaceWeatherFile).
+        # The split-path layer accepts it; whether the resolved (sub-)field
+        # exists is GMAT's call. Here the fake Spacecraft has no
+        # ``Tanks.MainTank`` parameter, so the field resolver raises
+        # ``unknown field`` against the resource's type — not a split-level
+        # syntax error.
         with pytest.raises(GmatFieldError) as excinfo:
             _ = mission["Sat.Tanks.MainTank"]
-        assert "exactly one dot" in str(excinfo.value)
+        assert "unknown field 'Tanks.MainTank'" in str(excinfo.value)
 
     def test_path_with_empty_resource(self, mission: Mission) -> None:
         with pytest.raises(GmatFieldError) as excinfo:
@@ -847,6 +878,91 @@ def test_setitem_calls_set_field_on_underlying_object(mission: Mission) -> None:
     assert isinstance(sat, _FakeObject)
     mission["Sat.SMA"] = 7123.45
     assert ("SMA", 7123.45) in sat.set_calls
+
+
+# --- extended grammar: multi-dot sub-resource paths and Variable.Value -------
+
+
+class TestExtendedGrammar:
+    """``Resource.SubResource.Field`` and ``Variable.Value`` round-trip tests.
+
+    GMAT's ``GetParameterID``/``GetField``/``SetField`` accept dotted
+    sub-resource paths natively — ``FM.Drag.CSSISpaceWeatherFile`` is
+    routed through the DragForce sub-object inside GMAT, with no
+    Python-side walk needed. The grammar layer just relaxes the
+    single-dot restriction.
+    """
+
+    def _mission_with(self, tmp_path: Path, **extras: _FakeObject) -> Mission:
+        objects: dict[str, _FakeObject] = {"Sat": _spacecraft()}
+        objects.update(extras)
+        gmat = _make_fake_gmat(objects)
+        install = _make_install(tmp_path / "gmat")
+        return Mission(gmat=gmat, install=install, script_path=tmp_path / "mission.script")
+
+    # --- multi-dot (#103) ----------------------------------------------------
+
+    def test_multi_dot_read_returns_value(self, tmp_path: Path) -> None:
+        mission = self._mission_with(tmp_path, FM=_force_model())
+        assert mission["FM.Drag.CSSISpaceWeatherFile"] == "weather.txt"
+
+    def test_multi_dot_write_persists(self, tmp_path: Path) -> None:
+        fm = _force_model()
+        mission = self._mission_with(tmp_path, FM=fm)
+        mission["FM.Drag.CSSISpaceWeatherFile"] = "/abs/cssi.txt"
+        assert ("Drag.CSSISpaceWeatherFile", "/abs/cssi.txt") in fm.set_calls
+        assert mission["FM.Drag.CSSISpaceWeatherFile"] == "/abs/cssi.txt"
+
+    def test_multi_dot_unknown_field_raises_gmat_field_error(self, tmp_path: Path) -> None:
+        mission = self._mission_with(tmp_path, FM=_force_model())
+        with pytest.raises(GmatFieldError) as excinfo:
+            _ = mission["FM.Drag.NotAField"]
+        # The error names the failing field portion verbatim so users can
+        # spot whether the typo is in the parent or the leaf.
+        assert "unknown field 'Drag.NotAField'" in str(excinfo.value)
+
+    def test_multi_dot_unknown_resource_raises_gmat_field_error(self, tmp_path: Path) -> None:
+        mission = self._mission_with(tmp_path)
+        with pytest.raises(GmatFieldError) as excinfo:
+            _ = mission["DoesNotExist.Drag.Field"]
+        assert "unknown resource 'DoesNotExist'" in str(excinfo.value)
+
+    # --- Variable.Value (#104) -----------------------------------------------
+
+    def test_variable_value_read_returns_float(self, tmp_path: Path) -> None:
+        mission = self._mission_with(tmp_path, elapsed_seconds=_variable("elapsed_seconds", 0.0))
+        assert mission["elapsed_seconds.Value"] == 0.0
+
+    def test_variable_value_write_persists_as_float(self, tmp_path: Path) -> None:
+        var = _variable("elapsed_seconds", 0.0)
+        mission = self._mission_with(tmp_path, elapsed_seconds=var)
+        mission["elapsed_seconds.Value"] = 86400.0
+        assert ("Value", 86400.0) in var.set_calls
+        assert mission["elapsed_seconds.Value"] == 86400.0
+
+    def test_variable_value_accepts_int(self, tmp_path: Path) -> None:
+        # The real-type coercion path admits ``int`` for a REAL_TYPE field.
+        mission = self._mission_with(tmp_path, elapsed_seconds=_variable())
+        mission["elapsed_seconds.Value"] = 86400  # int, not float
+        assert mission["elapsed_seconds.Value"] == 86400.0
+
+    def test_variable_value_accepts_numpy_scalar(self, tmp_path: Path) -> None:
+        # Regression guard for the numpy-strip coercion path (#85) on the
+        # Variable.Value contract specifically.
+        import numpy as np
+
+        mission = self._mission_with(tmp_path, elapsed_seconds=_variable())
+        mission["elapsed_seconds.Value"] = np.float64(7200.5)
+        assert mission["elapsed_seconds.Value"] == 7200.5
+
+    def test_variable_value_unknown_variable_raises_gmat_field_error(self, tmp_path: Path) -> None:
+        mission = self._mission_with(tmp_path)
+        with pytest.raises(GmatFieldError) as excinfo:
+            mission["nope.Value"] = 1.0
+        assert "unknown resource 'nope'" in str(excinfo.value)
+        # The error payload carries the rejected value, so a caller catching
+        # the exception can re-raise with context without re-parsing the path.
+        assert excinfo.value.value == 1.0
 
 
 # --- Mission.run --------------------------------------------------------------


### PR DESCRIPTION
## Summary

Extends `mission[...]` grammar to cover the two override flavours that previously forced callers to leave gmat-run for regex script rewriting:

| Pattern | Example | Issue |
|---------|---------|-------|
| `Resource.Field` | `mission["Sat.SMA"] = 7000` | (existing) |
| `Resource.SubResource.Field` | `mission["FM.Drag.CSSISpaceWeatherFile"] = "/path/CSSI.txt"` | #103 |
| `Variable.Value` | `mission["elapsed_seconds.Value"] = 86400.0` | #104 |

The implementation is one regex relaxation in `_split_path`: from "exactly one dot" to "at least one dot." Everything after the first dot is passed verbatim to GMAT's `GetParameterID` / `GetField` / `SetField`, which routes dotted sub-resource paths internally — no Python-side object-graph walk needed.

Scope reduction from the issue bodies (approved during planning): no new `UnreachableFieldError` class. Recon showed there's no meaningful distinction between "couldn't reach sub-object" and "wrong terminal field" at the gmat-run layer — GMAT itself routes the dotted path and surfaces one error type when it fails. The existing `GmatFieldError` already names the failing sub-object in its message.

## Test plan

- [x] `uv run pytest` — 734 tests pass (unit + integration), including:
  - 9 new unit tests under `TestExtendedGrammar` covering multi-dot read/write, Variable.Value read/write (int + numpy scalar coercion), and unknown-resource / unknown-field error paths.
  - 3 new integration tests in `tests/integration/test_overrides_grammar.py` against real GMAT for `FM.Drag.CSSISpaceWeatherFile` round-trips and a Variable bounding a `Propagate` stopping condition.
  - The existing single-dot regression suite (Sat.SMA, DefaultProp.*, TOI.*) passes unchanged.
- [x] `uv run ruff check src tests` — clean.
- [x] `uv run ruff format --check src tests` — clean.
- [x] `uv run mypy src` — no issues in 21 source files.
- [x] README + getting-started docs updated with the grammar table.

Closes #103
Closes #104