### PR TITLE
Surface solver/targeter iteration data via Results.solver_runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ ephem = result.ephemerides["EphemerisFile1"]
 
 # ContactLocator → DataFrame; df.attrs["report_format"] carries the variant.
 contacts = result.contacts["ContactLocator1"]
+
+# Solver → DataFrame per Target/Optimize run: iteration history, residuals,
+# and a convergence flag. result.converged["DC"] is the quick yes/no.
+iterations = result.solver_runs["DC"]
 ```
 
 `Mission.load` discovers a local GMAT install (honouring the `GMAT_ROOT` environment variable
@@ -95,9 +99,9 @@ object graph. Subscript access reads and writes fields against that graph with t
 | `Variable.Value` | `mission["elapsed_seconds.Value"] = 86400.0` |
 
 `mission.run()` executes the mission sequence headlessly, captures GMAT's log, and returns a
-`Results` exposing three lazy mappings — `reports`, `ephemerides`, and `contacts` — each
-keyed by the GMAT resource name and parsing to a DataFrame on first access. See
-[Outputs](#outputs) below for the formats covered.
+`Results` exposing four lazy mappings — `reports`, `ephemerides`, `contacts`, and
+`solver_runs` — each keyed by the GMAT resource name and parsing to a DataFrame on first
+access. See [Outputs](#outputs) below for the formats covered.
 
 A `gmat-run` console script is also installed for shell-script and smoke-test use:
 
@@ -122,6 +126,11 @@ and sample output.
 - **`ContactLocator`** → DataFrame, supporting Legacy and the five tabular `ReportFormat`
   variants. `df.attrs["report_format"]` carries the variant name so downstream code can
   branch on it without inspecting the column set.
+- **`Solver`** → one DataFrame per `Target` / `Optimize` run, parsed from the iteration
+  log GMAT writes for each `Solver`. One row per iteration, with a column per `Vary`
+  variable, the goal/constraint residuals, and a `status` column; `df.attrs["converged"]`
+  and the `Results.converged` shortcut answer the yes/no. `DifferentialCorrector` and
+  `Yukon` are covered.
 
 ## Documentation
 

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -132,6 +132,33 @@ GMAT actually emits in v0.4; uncommon variants raise
 - **Code-500 binary ephemeris**: not implemented. No public tooling decodes
   the format, and GMAT does not exercise it in its stock R2026a samples.
 
+## Solver iteration logs
+
+[`Results.solver_runs`][gmat_run.Results] parses the per-`Solver` `.data` file
+GMAT writes for a `Target` / `Optimize` run. A few properties of that file
+shape what the mapping can offer.
+
+- **A shared `Solver` keeps only the last block's history.** When several
+  `Target` / `Optimize` blocks name the same `Solver` resource, GMAT writes all
+  of them to one `.data` file, each block overwriting the previous one. The
+  surfaced DataFrame therefore covers the **last** block only;
+  `df.attrs["source_path"]` points at the overwritten file. Declare a separate
+  `Solver` resource per block to keep each block's iteration history.
+- **`DifferentialCorrector` convergence is derived, not stamped.** Unlike the
+  optimizers, a targeter's log ends with the same "Targeting Completed" line
+  whether or not the goal was met. gmat-run computes `converged` from the last
+  iteration's residual against its tolerance, so `df.attrs["converged"]` for a
+  `DifferentialCorrector` is a library judgement, not a value read from the
+  file.
+- **Jacobians are not surfaced.** A `DifferentialCorrector` log also records
+  the sensitivity matrix, its inverse, and scaled variable estimates. These are
+  optimizer-specific (a `Yukon` log has no analogue) and are not parsed into
+  the DataFrame.
+- **Only the `Normal` report style is parsed.** The parser targets the layout
+  GMAT writes at the default `Solver.ReportStyle = Normal`. `Concise`,
+  `Verbose`, and `Debug` styles change the file structure and are not
+  supported.
+
 ## Epoch promotion is not a time-scale conversion
 
 [`gmat_run.parsers.epoch.promote_epochs`][gmat_run.parsers.epoch.promote_epochs]

--- a/docs/reference/parsers.md
+++ b/docs/reference/parsers.md
@@ -43,6 +43,10 @@ you have a stand-alone GMAT output file you want to load without driving a
 
 ::: gmat_run.parsers.contact.parse
 
+## Solver log
+
+::: gmat_run.parsers.solver_log.parse
+
 ## Epoch promotion
 
 ::: gmat_run.parsers.epoch.promote_epochs

--- a/docs/reference/results.md
+++ b/docs/reference/results.md
@@ -1,10 +1,10 @@
 # Results
 
 [`Results`][gmat_run.Results] is the return value of
-[`Mission.run`][gmat_run.Mission.run]. It exposes three keyed views over GMAT's
-output files — `reports`, `ephemerides`, and `contacts` — each typed as
-`Mapping[str, pandas.DataFrame]` and keyed by the resource name as declared in
-the `.script`.
+[`Mission.run`][gmat_run.Mission.run]. It exposes four keyed views over GMAT's
+output files — `reports`, `ephemerides`, `contacts`, and `solver_runs` — each
+typed as `Mapping[str, pandas.DataFrame]` and keyed by the resource name as
+declared in the `.script`.
 
 Parsing is lazy: a `ReportFile` listed in `Results.reports` is read from disk
 and converted to a DataFrame only on first access, then cached for the life of
@@ -32,5 +32,55 @@ small alias table on output:
 Anything else raises `ValueError` rather than emitting a header
 downstream tools cannot interpret. Time systems are restricted to
 `A1`, `TAI`, `UTC`, `TT`, and `TDB` — the five GMAT speaks end-to-end.
+
+## Solver runs
+
+`Results.solver_runs` keys a DataFrame by each `Solver` resource a `Target` or
+`Optimize` block exercised — `result.solver_runs["DC"]`, `result.solver_runs["Yukon1"]`.
+A mission with no solver yields an empty mapping. Each DataFrame has one row
+per iteration's nominal pass:
+
+| Column | Meaning |
+|--------|---------|
+| `iteration` | Iteration number as GMAT reports it. |
+| `<variable>` | One column per `Vary` variable, named verbatim from the script (`MOI.Element1`). |
+| `status` | `"running"` on every row except the last, which carries `"converged"`, `"max_iter"`, or `"failed"`. |
+
+A `DifferentialCorrector` adds, per `Achieve` goal, the quartet `<goal>` (the
+achieved value), `<goal>_desired`, `<goal>_residual` (`achieved - desired`, so a
+positive residual means the achieved value overshot the target), and
+`<goal>_tolerance`. A `Yukon` optimizer instead adds `cost` (the cost-function
+value) and `<constraint>_residual` per nonlinear constraint — its iteration log
+records no achieved value, desired bound, or tolerance for a constraint.
+
+`df.attrs` carries `solver_type`, `solver_mode`, `n_iterations`, `n_variables`,
+`n_goals`, `converged`, and `source_path`.
+
+```python
+runs = result.solver_runs["DC"]
+runs.plot(x="iteration", y="geoSat.Earth.SMA_residual")  # watch it home in
+final = runs.iloc[-1]
+```
+
+`Results.converged` is a `{solver: bool}` shortcut over the same mapping, for
+the common branch:
+
+```python
+if not result.converged["DC"]:
+    raise RuntimeError("targeter did not reach its goal")
+```
+
+**Convergence detection.** A `Yukon` run is converged when its log stamps the
+optimizer-converged marker. A `DifferentialCorrector` log carries no such
+marker — the same "Targeting Completed" line ends a converged and a
+non-converged run alike — so convergence is *derived*: the last iteration is
+converged when every goal's `abs(residual) <= tolerance`. A non-converged run
+that ran out of iterations (`n_iterations` reached the solver's
+`MaximumIterations`) is reported as `"max_iter"`; any other non-converged
+outcome is `"failed"`.
+
+A run-time GMAT error inside a solver block still raises
+[`GmatRunError`][gmat_run.GmatRunError] — `solver_runs` reports solver
+*outcomes*, not underlying run failures.
 
 ::: gmat_run.Results

--- a/src/gmat_run/mission.py
+++ b/src/gmat_run/mission.py
@@ -81,6 +81,11 @@ _AEM_ATTITUDE_VALUE: Final = "CCSDS-AEM"
 # instead of crashing.
 _SPACECRAFT_TYPE_ENUM_ATTR: Final = "SPACECRAFT"
 
+# Object-type-enum attribute used to enumerate Solver resources
+# (DifferentialCorrector, Yukon, …) when discovering per-solver ``.data``
+# iteration logs. Probed with the same defensive ``getattr`` as the others.
+_SOLVER_TYPE_ENUM_ATTR: Final = "SOLVER"
+
 
 class _LazyAttitudeInputs(Mapping[str, pd.DataFrame]):
     """Mapping view over CCSDS-AEM files referenced by Spacecraft resources.
@@ -351,6 +356,14 @@ class Mission:
         After :meth:`run` returns, reading ``mission["RF.Filename"]`` yields
         the resolved absolute path, which points at the file on disk.
 
+        **Solver logs.** Every ``Target`` / ``Optimize`` run writes a
+        per-``Solver`` ``.data`` iteration log. Its ``<Solver>.ReportFile``
+        field is rewritten into ``working_dir`` by the same mechanism, so the
+        log is surfaced through :attr:`Results.solver_runs` and shares the
+        workspace's lifetime. A ``Solver`` resource that no ``Target`` /
+        ``Optimize`` block exercises writes nothing and is simply absent from
+        the mapping.
+
         **Working directory** (when ``working_dir`` is set explicitly):
 
         * The directory is created if missing; if creation or any write into
@@ -415,7 +428,16 @@ class Mission:
         # subscriber, and overriding the Filename field is the only setting
         # the engine consults at write time.
         report_paths, ephemeris_paths, contact_paths = self._rewrite_output_paths(workspace_path)
-        all_paths = (*report_paths.values(), *ephemeris_paths.values(), *contact_paths.values())
+        # Solver .data logs are redirected the same way. The returned paths are
+        # *expected* locations — a Solver no Target/Optimize block exercises
+        # writes nothing, so existence is rechecked after the run below.
+        solver_expected, solver_max_iterations = self._discover_solver_outputs(workspace_path)
+        all_paths = (
+            *report_paths.values(),
+            *ephemeris_paths.values(),
+            *contact_paths.values(),
+            *solver_expected.values(),
+        )
         # Pre-run gate: pre-existing artefacts inside working_dir. Bounded to
         # *resolved* output paths that live under workspace_path — absolute
         # filenames pinned by the script outside the workspace are the user's
@@ -462,12 +484,19 @@ class Mission:
         if notice:
             log = notice + log
 
+        # Keep only the solver logs GMAT actually wrote — a declared-but-unused
+        # Solver leaves the no-solver mapping empty rather than raising.
+        solver_paths = {n: p for n, p in solver_expected.items() if p.exists()}
         results = Results(
             output_dir=workspace_path,
             log=log,
             report_paths=report_paths,
             ephemeris_paths=ephemeris_paths,
             contact_paths=contact_paths,
+            solver_paths=solver_paths,
+            solver_max_iterations={
+                n: solver_max_iterations[n] for n in solver_paths if n in solver_max_iterations
+            },
         )
         # See project memory `gmat-run Mission.run temp-dir lifetime ties to
         # Results`: the temp dir must outlive Mission.run so lazy report
@@ -621,6 +650,62 @@ class Mission:
                         obj.SetField("Filename", str(resolved))
                 bucket[type_name][name] = resolved
         return reports, ephemerides, contacts
+
+    def _discover_solver_outputs(
+        self, workspace_path: Path
+    ) -> tuple[dict[str, Path], dict[str, int]]:
+        """Enumerate ``Solver`` resources and pin each ``.data`` log to the workspace.
+
+        Walks every ``Solver`` resource via ``Moderator.GetListOfObjects``. For
+        each: derives the expected ``.data`` path — the ``ReportFile`` field
+        when set, otherwise the default ``<TypeName><SolverName>.data`` — and,
+        for a relative or unset value, rewrites ``ReportFile`` to an absolute
+        path inside ``workspace_path`` via ``SetField`` so GMAT writes where we
+        expect. An absolute ``ReportFile`` is the user's chosen destination and
+        is left alone, mirroring :meth:`_rewrite_output_paths`. The solver's
+        ``MaximumIterations`` is read alongside — the ``.data`` file does not
+        record it, but the parser needs it to classify a max-iteration stop.
+
+        Resilient to a missing ``SOLVER`` enum and to broken objects — skips
+        quietly rather than aborting the run.
+
+        Returns:
+            ``(paths, max_iterations)`` keyed by solver resource name. The
+            paths are *expected* locations; :meth:`run` rechecks existence
+            after the run, since an unexercised ``Solver`` writes nothing.
+        """
+        type_id = getattr(self._gmat, _SOLVER_TYPE_ENUM_ATTR, None)
+        if type_id is None:
+            return {}, {}
+        moderator = self._gmat.Moderator.Instance()
+        try:
+            names = list(moderator.GetListOfObjects(type_id))
+        except Exception:
+            return {}, {}
+        paths: dict[str, Path] = {}
+        max_iterations: dict[str, int] = {}
+        for name in names:
+            obj = self._gmat.GetObject(name)
+            if obj is None:
+                continue
+            try:
+                type_name = obj.GetTypeName()
+            except Exception:
+                continue
+            declared = ""
+            with suppress(Exception):
+                declared = str(obj.GetField("ReportFile"))
+            path = Path(declared) if declared else Path(f"{type_name}{name}.data")
+            if path.is_absolute():
+                resolved = path
+            else:
+                resolved = workspace_path / path.name
+                with suppress(Exception):
+                    obj.SetField("ReportFile", str(resolved))
+            paths[name] = resolved
+            with suppress(Exception):
+                max_iterations[name] = int(float(str(obj.GetField("MaximumIterations"))))
+        return paths, max_iterations
 
     # --- internal helpers -----------------------------------------------------
 

--- a/src/gmat_run/parsers/solver_log.py
+++ b/src/gmat_run/parsers/solver_log.py
@@ -1,0 +1,591 @@
+"""Parse a GMAT solver ``.data`` file into a :class:`pandas.DataFrame`.
+
+Every ``Target`` / ``Optimize`` run writes a per-``Solver`` text file recording
+its iteration history. GMAT names it ``<TypeName><SolverName>.data`` under
+``OUTPUT_PATH`` unless the script overrides ``<Solver>.ReportFile``; the file is
+produced whether or not that field is set.
+
+The format is solver-specific. :func:`parse` sniffs the header and dispatches:
+
+* ``*** Targeter Text File`` -> :class:`DifferentialCorrector` format. One
+  ``Iteration N`` block per pass, each carrying the ``Vary`` variables and a
+  ``Goals and achieved values:`` table (desired / achieved / tolerance per
+  ``Achieve``). ``DifferentialCorrector`` does not stamp an explicit
+  converged/failed terminator, so convergence is inferred from the last
+  iteration's residual against its tolerance.
+* ``*** Performing Yukon Optimization`` -> :class:`Yukon` format. One
+  ``Iteration N; Function Evaluation M; Nominal Pass`` record per cost-function
+  evaluation, each carrying the variables, the ``Cost Function Value``, and a
+  ``Delta`` per nonlinear constraint. Yukon stamps ``*** The Optimizer
+  Converged!`` explicitly.
+
+Both formats normalise to a DataFrame with one row per nominal pass: an
+``iteration`` column, one ``float64`` column per variable (script names
+verbatim, dots and all), a ``status`` column, and solver-specific value
+columns. ``DifferentialCorrector`` adds the goal quartet ``<goal>`` /
+``<goal>_desired`` / ``<goal>_residual`` / ``<goal>_tolerance``; ``Yukon`` adds
+``cost`` and ``<constraint>_residual`` (the file carries no achieved value,
+desired bound, or tolerance for a Yukon constraint). ``df.attrs`` carries
+``solver_type``, ``solver_mode``, ``n_iterations``, ``n_variables``,
+``n_goals``, ``converged``, and ``source_path``.
+
+The parser is pure file-format work — no ``gmatpy`` import — so it is
+unit-testable against committed fixtures alone, mirroring the other parsers in
+this subpackage. The one runtime input it cannot read from the file is the
+solver's ``MaximumIterations``; :func:`parse` takes it as the optional
+``max_iterations`` keyword so a non-converged run can be told apart as
+``"max_iter"`` rather than the catch-all ``"failed"``.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+from typing import Final
+
+import pandas as pd
+
+from gmat_run.errors import GmatOutputParseError
+
+__all__ = ["parse"]
+
+
+# Solver types this module understands, surfaced in the error raised on an
+# unrecognised header so the caller knows what is and isn't supported.
+_SUPPORTED_SOLVERS: Final = ("DifferentialCorrector", "Yukon")
+
+# Header substrings that select a format-specific parser. Matched against the
+# first few lines so a stray leading blank line does not defeat dispatch.
+_DC_HEADER_MARKER: Final = "Targeter Text File"
+_YUKON_HEADER_MARKER: Final = "Performing Yukon Optimization"
+
+# --- DifferentialCorrector patterns ------------------------------------------
+_DC_ITERATION_RE: Final = re.compile(r"^Iteration\s+(\d+)$")
+_DC_NVARS_RE: Final = re.compile(r"\*\*\*\s+(\d+)\s+variables")
+_DC_NGOALS_RE: Final = re.compile(r"\*\*\*\s+(\d+)\s+goals")
+_DC_MODE_RE: Final = re.compile(r"\*\*\*\s+SolverMode:\s+(\S+)")
+# Goal line: "<name>  Desired: <d> Achieved: <a>". The goal name is a
+# resource-qualified path (dots, no spaces); the two-space gap before
+# "Desired:" is GMAT's column padding. ``.+?`` is non-greedy so the name stops
+# at the first "Desired:" anchor.
+_DC_GOAL_RE: Final = re.compile(
+    r"^(?P<name>.+?)\s+Desired:\s+(?P<desired>\S+)\s+Achieved:\s+(?P<achieved>\S+)$"
+)
+_DC_TOLERANCE_RE: Final = re.compile(r"^Tolerance:\s+(?P<tolerance>\S+)$")
+
+# --- Yukon patterns ----------------------------------------------------------
+_YUKON_NVARS_RE: Final = re.compile(
+    r"\*\*\*\s+(?P<vars>\d+)\s+variables;\s+"
+    r"(?P<eq>\d+)\s+equality constraints;\s+"
+    r"(?P<ineq>\d+)\s+inequality constraints"
+)
+# Record header: "<Solver> Iteration N; Function Evaluation M; <kind>". Only
+# "Nominal Pass" records become rows — perturbation passes are folded away.
+_YUKON_RECORD_RE: Final = re.compile(
+    r"^(?P<solver>\S+)\s+Iteration\s+(?P<iteration>\d+);\s+"
+    r"Function Evaluation\s+(?P<feval>\d+);\s+(?P<kind>.+)$"
+)
+_YUKON_DELTA_RE: Final = re.compile(r"^Delta\s+(?P<name>\S+)\s*=\s*(?P<value>\S+)$")
+_YUKON_TERMINATOR_RE: Final = re.compile(r"Optimization Completed in\s+(\d+)\s+iterations")
+_YUKON_CONVERGED_MARKER: Final = "The Optimizer Converged"
+_YUKON_NOMINAL_KIND: Final = "Nominal Pass"
+
+# "<name> = <value>" — shared by both formats for variable assignments.
+_ASSIGNMENT_RE: Final = re.compile(r"^(?P<name>\S+)\s*=\s*(?P<value>\S+)$")
+
+# Per-row status strings.
+_RUNNING: Final = "running"
+_CONVERGED: Final = "converged"
+_MAX_ITER: Final = "max_iter"
+_FAILED: Final = "failed"
+
+
+# ----------------------------------------------------------------------------
+# Public entry point
+# ----------------------------------------------------------------------------
+
+
+def parse(
+    path: str | os.PathLike[str],
+    *,
+    max_iterations: int | None = None,
+) -> pd.DataFrame:
+    """Parse a GMAT solver ``.data`` file into a :class:`pandas.DataFrame`.
+
+    The returned schema is one row per nominal pass, with columns:
+
+    * ``iteration`` (``int64``) — the iteration number GMAT reports. For Yukon
+      this repeats when an iteration spans several function evaluations.
+    * one ``float64`` column per ``Vary`` variable, named verbatim as the
+      script declares it (``MOI.Element1``, ``X1``, …).
+    * ``status`` (``string``) — ``"running"`` on every row except the last,
+      which carries ``"converged"``, ``"max_iter"``, or ``"failed"``.
+    * **DifferentialCorrector** adds, per ``Achieve`` goal, the quartet
+      ``<goal>`` (achieved), ``<goal>_desired``, ``<goal>_residual``
+      (``achieved - desired``), and ``<goal>_tolerance``.
+    * **Yukon** adds ``cost`` (the ``Cost Function Value``) and, per nonlinear
+      constraint, ``<constraint>_residual`` (GMAT's ``Delta``). Yukon's file
+      carries no achieved value, desired bound, or tolerance for a constraint.
+
+    ``df.attrs``:
+
+    * ``solver_type`` — ``"DifferentialCorrector"`` or ``"Yukon"``.
+    * ``solver_mode`` — from the ``*** SolverMode:`` line; ``"unknown"`` when
+      the format (Yukon) does not write one.
+    * ``n_iterations`` — iterations GMAT reported completing.
+    * ``n_variables`` / ``n_goals`` — variable and goal/constraint counts.
+    * ``converged`` (``bool``) — explicit for Yukon (the converged stamp),
+      inferred for DifferentialCorrector (last-iteration residual vs.
+      tolerance).
+    * ``source_path`` — ``str`` of the file the frame was parsed from.
+
+    Args:
+        path: Path to the solver ``.data`` file on disk.
+        max_iterations: The solver's ``MaximumIterations`` setting. The file
+            does not record it, so without it a non-converged run cannot be
+            told apart as ``"max_iter"`` and falls back to ``"failed"``.
+
+    Returns:
+        A DataFrame with one row per nominal pass, in file order.
+
+    Raises:
+        GmatOutputParseError: The file is empty, its header matches no
+            supported solver type, it contains no iterations, or an iteration
+            block is malformed (missing variables/goals, an unpaired goal
+            line, or a non-numeric value).
+    """
+    path = Path(path)
+
+    # ``utf-8-sig`` strips an optional BOM; ``newline=None`` activates
+    # universal-newline translation so CRLF and LF files parse identically.
+    with path.open(encoding="utf-8-sig", newline=None) as fh:
+        lines = fh.read().splitlines()
+
+    if not any(line.strip() for line in lines):
+        raise GmatOutputParseError("file is empty", path)
+
+    header = "\n".join(lines[:12])
+    if _DC_HEADER_MARKER in header:
+        df = _parse_differential_corrector(lines, path, max_iterations)
+    elif _YUKON_HEADER_MARKER in header:
+        df = _parse_yukon(lines, path, max_iterations)
+    else:
+        raise GmatOutputParseError(
+            "unrecognised solver-log header; supported solver types: "
+            f"{', '.join(_SUPPORTED_SOLVERS)}",
+            path,
+        )
+
+    df.attrs["source_path"] = str(path)
+    return df
+
+
+# ----------------------------------------------------------------------------
+# DifferentialCorrector
+# ----------------------------------------------------------------------------
+
+
+def _parse_differential_corrector(
+    lines: list[str], path: Path, max_iterations: int | None
+) -> pd.DataFrame:
+    """Parse a ``*** Targeter Text File`` into the normalised DataFrame."""
+    solver_mode = _scan_capture(lines, _DC_MODE_RE, default="unknown")
+    declared_vars = _scan_int(lines, _DC_NVARS_RE)
+    declared_goals = _scan_int(lines, _DC_NGOALS_RE)
+
+    starts = [i for i, line in enumerate(lines) if _DC_ITERATION_RE.match(line.strip())]
+    if not starts:
+        raise GmatOutputParseError("targeter file contains no iterations", path)
+
+    # Each block runs to the next ``Iteration`` header; the last to end of
+    # file. The Jacobian / Inverse Jacobian / scaled-estimate blocks that
+    # trail each iteration are simply not consumed by the block parser.
+    bounds = [*starts, len(lines)]
+    records = [_parse_dc_block(lines[bounds[k] : bounds[k + 1]], path) for k in range(len(starts))]
+
+    var_names = list(records[0].variables)
+    goal_names = [goal.name for goal in records[0].goals]
+    _check_dc_consistency(records, var_names, goal_names, path)
+
+    if declared_vars is not None and declared_vars != len(var_names):
+        raise GmatOutputParseError(
+            f"header declares {declared_vars} variables but iterations carry {len(var_names)}",
+            path,
+        )
+    if declared_goals is not None and declared_goals != len(goal_names):
+        raise GmatOutputParseError(
+            f"header declares {declared_goals} goals but iterations carry {len(goal_names)}",
+            path,
+        )
+
+    columns: dict[str, pd.Series] = {
+        "iteration": pd.Series([r.iteration for r in records], dtype="int64"),
+    }
+    for name in var_names:
+        columns[name] = pd.Series([r.variables[name] for r in records], dtype="float64", name=name)
+    for index, goal_name in enumerate(goal_names):
+        achieved = [r.goals[index].achieved for r in records]
+        desired = [r.goals[index].desired for r in records]
+        tolerance = [r.goals[index].tolerance for r in records]
+        columns[goal_name] = pd.Series(achieved, dtype="float64", name=goal_name)
+        columns[f"{goal_name}_desired"] = pd.Series(desired, dtype="float64")
+        columns[f"{goal_name}_residual"] = pd.Series(
+            [a - d for a, d in zip(achieved, desired, strict=True)], dtype="float64"
+        )
+        columns[f"{goal_name}_tolerance"] = pd.Series(tolerance, dtype="float64")
+
+    converged = all(
+        abs(goal.achieved - goal.desired) <= goal.tolerance for goal in records[-1].goals
+    )
+    n_iterations = len(records)
+    columns["status"] = _status_column(len(records), converged, n_iterations, max_iterations)
+
+    df = pd.DataFrame(columns)
+    df.attrs.update(
+        solver_type="DifferentialCorrector",
+        solver_mode=solver_mode,
+        n_iterations=n_iterations,
+        n_variables=len(var_names),
+        n_goals=len(goal_names),
+        converged=converged,
+    )
+    return df
+
+
+class _DcGoal:
+    """One ``Achieve`` goal's values within a single iteration block."""
+
+    __slots__ = ("achieved", "desired", "name", "tolerance")
+
+    def __init__(self, name: str, desired: float, achieved: float, tolerance: float) -> None:
+        self.name = name
+        self.desired = desired
+        self.achieved = achieved
+        self.tolerance = tolerance
+
+
+class _DcBlock:
+    """The parsed contents of one ``Iteration N`` block."""
+
+    __slots__ = ("goals", "iteration", "variables")
+
+    def __init__(self, iteration: int, variables: dict[str, float], goals: list[_DcGoal]) -> None:
+        self.iteration = iteration
+        self.variables = variables
+        self.goals = goals
+
+
+def _parse_dc_block(block: list[str], path: Path) -> _DcBlock:
+    """Parse one ``Iteration N`` block into its variables and goals."""
+    match = _DC_ITERATION_RE.match(block[0].strip())
+    if match is None:  # pragma: no cover — block[0] is an Iteration line by construction
+        raise GmatOutputParseError(f"expected an 'Iteration' header, got {block[0]!r}", path)
+    iteration = int(match.group(1))
+
+    variables = _parse_dc_variables(block, iteration, path)
+    goals = _parse_dc_goals(block, iteration, path)
+    return _DcBlock(iteration, variables, goals)
+
+
+def _parse_dc_variables(block: list[str], iteration: int, path: Path) -> dict[str, float]:
+    """Read the ``Variables:`` section of a DifferentialCorrector block."""
+    index = _section_start(block, "Variables:")
+    if index is None:
+        raise GmatOutputParseError(f"iteration {iteration}: missing 'Variables:' section", path)
+    variables: dict[str, float] = {}
+    for line in block[index:]:
+        stripped = line.strip()
+        if not stripped:
+            break
+        match = _ASSIGNMENT_RE.match(stripped)
+        if match is None:
+            break
+        name = match.group("name")
+        variables[name] = _to_float(
+            match.group("value"), f"iteration {iteration}: variable {name!r}", path
+        )
+    if not variables:
+        raise GmatOutputParseError(f"iteration {iteration}: no variables listed", path)
+    return variables
+
+
+def _parse_dc_goals(block: list[str], iteration: int, path: Path) -> list[_DcGoal]:
+    """Read the ``Goals and achieved values:`` section of a block."""
+    index = _section_start(block, "Goals and achieved values:")
+    if index is None:
+        raise GmatOutputParseError(
+            f"iteration {iteration}: missing 'Goals and achieved values:' section", path
+        )
+    goals: list[_DcGoal] = []
+    cursor = index
+    while cursor < len(block):
+        stripped = block[cursor].strip()
+        if not stripped:
+            break
+        goal_match = _DC_GOAL_RE.match(stripped)
+        if goal_match is None:
+            break
+        tolerance_line = block[cursor + 1].strip() if cursor + 1 < len(block) else ""
+        tolerance_match = _DC_TOLERANCE_RE.match(tolerance_line)
+        if tolerance_match is None:
+            raise GmatOutputParseError(
+                f"iteration {iteration}: goal {goal_match.group('name')!r} is not "
+                "followed by a 'Tolerance:' line",
+                path,
+            )
+        where = f"iteration {iteration}: goal {goal_match.group('name')!r}"
+        goals.append(
+            _DcGoal(
+                name=goal_match.group("name"),
+                desired=_to_float(goal_match.group("desired"), f"{where} desired", path),
+                achieved=_to_float(goal_match.group("achieved"), f"{where} achieved", path),
+                tolerance=_to_float(tolerance_match.group("tolerance"), f"{where} tolerance", path),
+            )
+        )
+        cursor += 2
+    if not goals:
+        raise GmatOutputParseError(f"iteration {iteration}: no goals listed", path)
+    return goals
+
+
+def _check_dc_consistency(
+    records: list[_DcBlock], var_names: list[str], goal_names: list[str], path: Path
+) -> None:
+    """Confirm every iteration block declares the same variables and goals."""
+    for record in records:
+        if list(record.variables) != var_names:
+            raise GmatOutputParseError(
+                f"iteration {record.iteration}: variable set "
+                f"{sorted(record.variables)} differs from {sorted(var_names)}",
+                path,
+            )
+        if [goal.name for goal in record.goals] != goal_names:
+            raise GmatOutputParseError(
+                f"iteration {record.iteration}: goal set "
+                f"{sorted(g.name for g in record.goals)} differs from {sorted(goal_names)}",
+                path,
+            )
+
+
+# ----------------------------------------------------------------------------
+# Yukon
+# ----------------------------------------------------------------------------
+
+
+def _parse_yukon(lines: list[str], path: Path, max_iterations: int | None) -> pd.DataFrame:
+    """Parse a ``*** Performing Yukon Optimization`` file into the DataFrame."""
+    declared = _scan_match(lines, _YUKON_NVARS_RE)
+    declared_vars = int(declared.group("vars")) if declared else None
+    declared_goals = int(declared.group("eq")) + int(declared.group("ineq")) if declared else None
+
+    starts = [i for i, line in enumerate(lines) if _YUKON_RECORD_RE.match(line.strip()) is not None]
+    if not starts:
+        raise GmatOutputParseError("Yukon file contains no iteration records", path)
+
+    bounds = [*starts, len(lines)]
+    records: list[_YukonRecord] = []
+    for k in range(len(starts)):
+        record = _parse_yukon_record(lines[bounds[k] : bounds[k + 1]], path)
+        # Only nominal passes become rows; perturbation passes are folded away.
+        if record is not None:
+            records.append(record)
+    if not records:
+        raise GmatOutputParseError("Yukon file has no nominal-pass records", path)
+
+    var_names = list(records[0].variables)
+    constraint_names = list(records[0].constraints)
+    _check_yukon_consistency(records, var_names, constraint_names, path)
+
+    if declared_vars is not None and declared_vars != len(var_names):
+        raise GmatOutputParseError(
+            f"header declares {declared_vars} variables but records carry {len(var_names)}",
+            path,
+        )
+
+    columns: dict[str, pd.Series] = {
+        "iteration": pd.Series([r.iteration for r in records], dtype="int64"),
+    }
+    for name in var_names:
+        columns[name] = pd.Series([r.variables[name] for r in records], dtype="float64", name=name)
+    columns["cost"] = pd.Series([r.cost for r in records], dtype="float64", name="cost")
+    for name in constraint_names:
+        columns[f"{name}_residual"] = pd.Series(
+            [r.constraints[name] for r in records], dtype="float64"
+        )
+
+    converged = any(_YUKON_CONVERGED_MARKER in line for line in lines)
+    n_iterations = _yukon_iteration_count(lines, records)
+    n_goals = declared_goals if declared_goals is not None else len(constraint_names)
+    columns["status"] = _status_column(len(records), converged, n_iterations, max_iterations)
+
+    df = pd.DataFrame(columns)
+    df.attrs.update(
+        solver_type="Yukon",
+        solver_mode="unknown",
+        n_iterations=n_iterations,
+        n_variables=len(var_names),
+        n_goals=n_goals,
+        converged=converged,
+    )
+    return df
+
+
+class _YukonRecord:
+    """One ``Nominal Pass`` record from a Yukon file."""
+
+    __slots__ = ("constraints", "cost", "iteration", "variables")
+
+    def __init__(
+        self,
+        iteration: int,
+        variables: dict[str, float],
+        cost: float,
+        constraints: dict[str, float],
+    ) -> None:
+        self.iteration = iteration
+        self.variables = variables
+        self.cost = cost
+        self.constraints = constraints
+
+
+def _parse_yukon_record(block: list[str], path: Path) -> _YukonRecord | None:
+    """Parse one Yukon record; return ``None`` for non-nominal passes."""
+    match = _YUKON_RECORD_RE.match(block[0].strip())
+    if match is None:  # pragma: no cover — block[0] is a record header by construction
+        raise GmatOutputParseError(f"expected a Yukon record header, got {block[0]!r}", path)
+    if match.group("kind").strip() != _YUKON_NOMINAL_KIND:
+        return None
+
+    iteration = int(match.group("iteration"))
+    where = f"Yukon iteration {iteration}"
+    variables: dict[str, float] = {}
+    constraints: dict[str, float] = {}
+    cost: float | None = None
+
+    for line in block[1:]:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("Variables:"):
+            variables = _parse_yukon_assignments(stripped[len("Variables:") :], where, path)
+        elif stripped.startswith("Cost Function Value:"):
+            cost = _to_float(
+                stripped[len("Cost Function Value:") :].strip(), f"{where}: cost", path
+            )
+        elif stripped.startswith("Delta "):
+            delta_match = _YUKON_DELTA_RE.match(stripped)
+            if delta_match is not None:
+                name = delta_match.group("name")
+                constraints[name] = _to_float(
+                    delta_match.group("value"), f"{where}: constraint {name!r}", path
+                )
+
+    if not variables:
+        raise GmatOutputParseError(f"{where}: no variables listed", path)
+    if cost is None:
+        raise GmatOutputParseError(f"{where}: missing 'Cost Function Value:'", path)
+    return _YukonRecord(iteration, variables, cost, constraints)
+
+
+def _parse_yukon_assignments(text: str, where: str, path: Path) -> dict[str, float]:
+    """Parse ``"  X1 = 0, X2 = 0"`` into ``{"X1": 0.0, "X2": 0.0}``."""
+    assignments: dict[str, float] = {}
+    for chunk in text.split(","):
+        stripped = chunk.strip()
+        if not stripped:
+            continue
+        match = _ASSIGNMENT_RE.match(stripped)
+        if match is None:
+            raise GmatOutputParseError(f"{where}: malformed assignment {stripped!r}", path)
+        name = match.group("name")
+        assignments[name] = _to_float(match.group("value"), f"{where}: variable {name!r}", path)
+    return assignments
+
+
+def _check_yukon_consistency(
+    records: list[_YukonRecord],
+    var_names: list[str],
+    constraint_names: list[str],
+    path: Path,
+) -> None:
+    """Confirm every record carries the same variables and constraints."""
+    for record in records:
+        if list(record.variables) != var_names:
+            raise GmatOutputParseError(
+                f"Yukon iteration {record.iteration}: variable set "
+                f"{sorted(record.variables)} differs from {sorted(var_names)}",
+                path,
+            )
+        if list(record.constraints) != constraint_names:
+            raise GmatOutputParseError(
+                f"Yukon iteration {record.iteration}: constraint set "
+                f"{sorted(record.constraints)} differs from {sorted(constraint_names)}",
+                path,
+            )
+
+
+def _yukon_iteration_count(lines: list[str], records: list[_YukonRecord]) -> int:
+    """Iterations Yukon reported, from the terminator or the records seen."""
+    for line in lines:
+        match = _YUKON_TERMINATOR_RE.search(line)
+        if match is not None:
+            return int(match.group(1))
+    return max(r.iteration for r in records)
+
+
+# ----------------------------------------------------------------------------
+# Shared helpers
+# ----------------------------------------------------------------------------
+
+
+def _status_column(
+    n_rows: int, converged: bool, n_iterations: int, max_iterations: int | None
+) -> pd.Series:
+    """Build the ``status`` column: ``running`` until the terminal last row."""
+    status = [_RUNNING] * n_rows
+    if converged:
+        terminal = _CONVERGED
+    elif max_iterations is not None and n_iterations >= max_iterations:
+        terminal = _MAX_ITER
+    else:
+        terminal = _FAILED
+    status[-1] = terminal
+    return pd.Series(status, dtype="string", name="status")
+
+
+def _section_start(block: list[str], label: str) -> int | None:
+    """Index of the line *after* the line whose stripped text equals ``label``."""
+    for index, line in enumerate(block):
+        if line.strip() == label:
+            return index + 1
+    return None
+
+
+def _scan_match(lines: list[str], pattern: re.Pattern[str]) -> re.Match[str] | None:
+    """First match of ``pattern`` anywhere in ``lines``, or ``None``."""
+    for line in lines:
+        match = pattern.search(line)
+        if match is not None:
+            return match
+    return None
+
+
+def _scan_capture(lines: list[str], pattern: re.Pattern[str], *, default: str) -> str:
+    """First capture group of ``pattern`` across ``lines``, or ``default``."""
+    match = _scan_match(lines, pattern)
+    return match.group(1) if match is not None else default
+
+
+def _scan_int(lines: list[str], pattern: re.Pattern[str]) -> int | None:
+    """First capture group of ``pattern`` as an ``int``, or ``None``."""
+    match = _scan_match(lines, pattern)
+    return int(match.group(1)) if match is not None else None
+
+
+def _to_float(token: str, where: str, path: Path) -> float:
+    """Convert ``token`` to ``float``; raise a located parse error on failure."""
+    try:
+        return float(token)
+    except ValueError as exc:
+        raise GmatOutputParseError(f"{where}: non-numeric value {token!r}", path) from exc

--- a/src/gmat_run/results.py
+++ b/src/gmat_run/results.py
@@ -1,10 +1,12 @@
 """In-memory aggregate of every output file GMAT wrote during a run.
 
-:class:`Results` is the return value of :meth:`Mission.run`. It exposes three
+:class:`Results` is the return value of :meth:`Mission.run`. It exposes four
 keyed views over those outputs — :attr:`Results.reports`,
-:attr:`Results.ephemerides`, and :attr:`Results.contacts` — each typed as a
-``Mapping[str, pandas.DataFrame]`` and keyed by the GMAT resource name as
-declared in the ``.script``.
+:attr:`Results.ephemerides`, :attr:`Results.contacts`, and
+:attr:`Results.solver_runs` — each typed as a ``Mapping[str, pandas.DataFrame]``
+and keyed by the GMAT resource name as declared in the ``.script``.
+:attr:`Results.converged` is a derived ``{solver: bool}`` shortcut over
+:attr:`Results.solver_runs`.
 
 Parsing is lazy. A ``ReportFile`` listed in :attr:`Results.reports` is read
 from disk and converted to a DataFrame only on first access, then cached for
@@ -33,6 +35,7 @@ from gmat_run._path_utils import resolve_user_path
 from gmat_run.parsers.contact import parse as _parse_contact
 from gmat_run.parsers.ephemeris import parse as _parse_oem_ephemeris
 from gmat_run.parsers.reportfile import parse as _parse_reportfile
+from gmat_run.parsers.solver_log import parse as _parse_solver_log
 from gmat_run.parsers.spk import is_spk_ephemeris as _is_spk_ephemeris
 from gmat_run.parsers.spk import parse as _parse_spk_ephemeris
 from gmat_run.parsers.stk_ephemeris import is_stk_ephemeris as _is_stk_ephemeris
@@ -170,12 +173,57 @@ class _LazyContacts(Mapping[str, pd.DataFrame]):
         self._paths = dict(paths)
 
 
+class _LazySolverRuns(Mapping[str, pd.DataFrame]):
+    """Mapping view over ``Solver`` iteration logs (the per-solver ``.data`` file).
+
+    Mirrors :class:`_LazyReports`: the parser runs once per key on first
+    ``__getitem__``, the DataFrame is cached, and membership/iteration do not
+    parse. Each key carries both its file path and the solver's
+    ``MaximumIterations`` — the ``.data`` file does not record the latter, but
+    :func:`gmat_run.parsers.solver_log.parse` needs it to tell a max-iteration
+    stop apart from a generic failure.
+
+    The DataFrame's columns depend on the solver type (``df.attrs["solver_type"]``):
+    a ``DifferentialCorrector`` carries the goal quartet, a ``Yukon`` carries
+    ``cost`` and per-constraint residuals. See
+    :func:`gmat_run.parsers.solver_log.parse` for the full schema.
+    """
+
+    def __init__(self, paths: Mapping[str, Path], max_iterations: Mapping[str, int]) -> None:
+        self._paths: dict[str, Path] = dict(paths)
+        self._max_iterations: dict[str, int] = dict(max_iterations)
+        self._cache: dict[str, pd.DataFrame] = {}
+
+    def __getitem__(self, key: str) -> pd.DataFrame:
+        if key in self._cache:
+            return self._cache[key]
+        if key not in self._paths:
+            raise KeyError(key)
+        frame = _parse_solver_log(self._paths[key], max_iterations=self._max_iterations.get(key))
+        self._cache[key] = frame
+        return frame
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._paths)
+
+    def __len__(self) -> int:
+        return len(self._paths)
+
+    def __contains__(self, key: object) -> bool:
+        return key in self._paths
+
+    def _rebase(self, paths: Mapping[str, Path]) -> None:
+        # Replace the path mapping in place; MaximumIterations is intrinsic to
+        # the run, not the file location, so it is left untouched.
+        self._paths = dict(paths)
+
+
 class Results:
     """Aggregate of every output file GMAT wrote during a single run.
 
     Construct one per call to :meth:`Mission.run`. Each path mapping is keyed
     by the resource name declared in the ``.script`` (``"ReportFile1"``,
-    ``"EphemerisFile1"``, ``"ContactLocator1"``, …). Path mappings are
+    ``"EphemerisFile1"``, ``"ContactLocator1"``, ``"DC"``, …). Path mappings are
     defensively copied and re-exposed as read-only views, so callers cannot
     mutate the run record after the fact.
 
@@ -191,6 +239,13 @@ class Results:
             resource. Defaults to empty.
         contact_paths: ``{name: path}`` for every ``ContactLocator``
             resource. Defaults to empty.
+        solver_paths: ``{name: path}`` for every ``Solver`` resource whose
+            ``.data`` iteration log was found on disk after the run. Defaults
+            to empty.
+        solver_max_iterations: ``{name: MaximumIterations}`` for those same
+            solvers. Passed through to the solver-log parser so a
+            max-iteration stop can be told apart from a generic failure.
+            Defaults to empty.
     """
 
     output_dir: Path
@@ -200,6 +255,8 @@ class Results:
     ephemeris_paths: Mapping[str, Path]
     contacts: Mapping[str, pd.DataFrame]
     contact_paths: Mapping[str, Path]
+    solver_runs: Mapping[str, pd.DataFrame]
+    solver_paths: Mapping[str, Path]
 
     # When the originating Mission.run() created an isolated temp dir, the
     # TemporaryDirectory handle is parked here so cleanup is tied to this
@@ -215,6 +272,8 @@ class Results:
         report_paths: Mapping[str, Path] | None = None,
         ephemeris_paths: Mapping[str, Path] | None = None,
         contact_paths: Mapping[str, Path] | None = None,
+        solver_paths: Mapping[str, Path] | None = None,
+        solver_max_iterations: Mapping[str, int] | None = None,
     ) -> None:
         self.output_dir = output_dir
         self.log = log
@@ -222,18 +281,22 @@ class Results:
 
         eph_paths: dict[str, Path] = dict(ephemeris_paths or {})
         con_paths: dict[str, Path] = dict(contact_paths or {})
+        slv_paths: dict[str, Path] = dict(solver_paths or {})
 
         self.reports = _LazyReports(report_paths or {})
         self.ephemeris_paths = MappingProxyType(eph_paths)
         self.contact_paths = MappingProxyType(con_paths)
+        self.solver_paths = MappingProxyType(slv_paths)
         self.ephemerides = _LazyEphemerides(eph_paths)
         self.contacts = _LazyContacts(con_paths)
+        self.solver_runs = _LazySolverRuns(slv_paths, solver_max_iterations or {})
 
     def __repr__(self) -> str:
         return (
             f"Results(reports={len(self.reports)}, "
             f"ephemerides={len(self.ephemerides)}, "
-            f"contacts={len(self.contacts)})"
+            f"contacts={len(self.contacts)}, "
+            f"solver_runs={len(self.solver_runs)})"
         )
 
     def _repr_html_(self) -> str:
@@ -241,17 +304,34 @@ class Results:
             report_names=tuple(self.reports),
             ephemeris_names=tuple(self.ephemerides),
             contact_names=tuple(self.contacts),
+            solver_run_names=tuple(self.solver_runs),
         )
+
+    @property
+    def converged(self) -> dict[str, bool]:
+        """``{solver name: bool}`` — did each solver run reach its goal?
+
+        A convenience view over :attr:`solver_runs` for the common branching
+        case (``if not result.converged["DC"]: ...``). Same keys as
+        :attr:`solver_runs`; ``{}`` when the mission declared no solvers.
+
+        Reading this materialises every solver run (it inspects each
+        DataFrame's ``attrs["converged"]``), so the lazy-parse cost is paid on
+        first access — the same trade-off as iterating :attr:`solver_runs`
+        values directly.
+        """
+        return {name: bool(self.solver_runs[name].attrs["converged"]) for name in self.solver_runs}
 
     def persist(self, path: str | os.PathLike[str]) -> Results:
         """Copy every output artefact under :attr:`output_dir` into ``path``.
 
-        Mutates the :class:`Results` in place so future report/ephemeris/contact
-        access reads from the persisted location instead of the (potentially
-        soon-to-be-cleaned) workspace. The :class:`tempfile.TemporaryDirectory`
-        backing a default-workspace run is released as part of the call. Run
-        with an explicit ``working_dir``: that directory is left intact —
-        ``persist`` is a copy, never a move.
+        Mutates the :class:`Results` in place so future
+        report/ephemeris/contact/solver-run access reads from the persisted
+        location instead of the (potentially soon-to-be-cleaned) workspace.
+        The :class:`tempfile.TemporaryDirectory` backing a default-workspace
+        run is released as part of the call. Run with an explicit
+        ``working_dir``: that directory is left intact — ``persist`` is a copy,
+        never a move.
 
         Path mappings are rewritten so any path that lived under the old
         ``output_dir`` now points at the matching file under ``path``.
@@ -292,12 +372,15 @@ class Results:
         new_reports = {n: _migrate(p) for n, p in self.reports._paths.items()}  # type: ignore[attr-defined]
         new_eph = {n: _migrate(p) for n, p in self.ephemeris_paths.items()}
         new_con = {n: _migrate(p) for n, p in self.contact_paths.items()}
+        new_slv = {n: _migrate(p) for n, p in self.solver_paths.items()}
 
         self.reports._rebase(new_reports)  # type: ignore[attr-defined]
         self.ephemerides._rebase(new_eph)  # type: ignore[attr-defined]
         self.contacts._rebase(new_con)  # type: ignore[attr-defined]
+        self.solver_runs._rebase(new_slv)  # type: ignore[attr-defined]
         self.ephemeris_paths = MappingProxyType(new_eph)
         self.contact_paths = MappingProxyType(new_con)
+        self.solver_paths = MappingProxyType(new_slv)
 
         self.output_dir = dest
         if self._workspace is not None:

--- a/src/gmat_run/summary.py
+++ b/src/gmat_run/summary.py
@@ -247,6 +247,7 @@ def format_results_html(
     report_names: Iterable[str],
     ephemeris_names: Iterable[str],
     contact_names: Iterable[str],
+    solver_run_names: Iterable[str],
 ) -> str:
     """Render a small HTML table for :meth:`gmat_run.results.Results._repr_html_`.
 
@@ -257,6 +258,7 @@ def format_results_html(
         ("reports", tuple(report_names)),
         ("ephemerides", tuple(ephemeris_names)),
         ("contacts", tuple(contact_names)),
+        ("solver_runs", tuple(solver_run_names)),
     ]
     parts: list[str] = ['<div class="gmat-run-results">']
     parts.append("<strong>Results</strong>")

--- a/tests/fixtures/solver_log/dc_converged_R2026a.data
+++ b/tests/fixtures/solver_log/dc_converged_R2026a.data
@@ -1,0 +1,172 @@
+********************************************************
+*** Targeter Text File
+*** 
+*** Using Differential Correction
+***
+*** 1 variables
+*** 1 goals
+***
+*** Variables:
+***    MOI.Element1
+***    
+*** Goals:
+***    geoSat.Earth.SMA
+***    
+*** SolverMode:  Solve
+***    
+********************************************************
+
+Iteration 1
+Running Nominal Pass
+Variables:
+   MOI.Element1 = -0.1
+   
+Goals and achieved values:
+   geoSat.Earth.SMA  Desired: 42166.9 Achieved: 57242.59356621061
+   Tolerance: 0.001
+   
+********************************************************
+
+
+Jacobian (Sensitivity matrix):
+   56793.49746656953
+
+
+Inverse Jacobian:
+   1.760764954806018e-05
+
+
+New scaled variable estimates:
+   MOI.Element1 = -0.2
+   
+Iteration 2
+Running Nominal Pass
+Variables:
+   MOI.Element1 = -0.2
+   
+Goals and achieved values:
+   geoSat.Earth.SMA  Desired: 42166.9 Achieved: 52144.52347823226
+   Tolerance: 0.001
+   
+********************************************************
+
+
+Jacobian (Sensitivity matrix):
+   45762.86826188152
+
+
+Inverse Jacobian:
+   2.185177717177654e-05
+
+
+New scaled variable estimates:
+   MOI.Element1 = -0.3
+   
+Iteration 3
+Running Nominal Pass
+Variables:
+   MOI.Element1 = -0.3
+   
+Goals and achieved values:
+   geoSat.Earth.SMA  Desired: 42166.9 Achieved: 47995.57479532532
+   Tolerance: 0.001
+   
+********************************************************
+
+
+Jacobian (Sensitivity matrix):
+   37613.9299791248
+
+
+Inverse Jacobian:
+   2.658589518710184e-05
+
+
+New scaled variable estimates:
+   MOI.Element1 = -0.4
+   
+Iteration 4
+Running Nominal Pass
+Variables:
+   MOI.Element1 = -0.4
+   
+Goals and achieved values:
+   geoSat.Earth.SMA  Desired: 42166.9 Achieved: 44557.59409769344
+   Tolerance: 0.001
+   
+********************************************************
+
+
+Jacobian (Sensitivity matrix):
+   31421.76631161419
+
+
+Inverse Jacobian:
+   3.182507278817033e-05
+
+
+New scaled variable estimates:
+   MOI.Element1 = -0.4760840136733427
+   
+Iteration 5
+Running Nominal Pass
+Variables:
+   MOI.Element1 = -0.4760840136733427
+   
+Goals and achieved values:
+   geoSat.Earth.SMA  Desired: 42166.9 Achieved: 42314.81222474064
+   Tolerance: 0.001
+   
+********************************************************
+
+
+Jacobian (Sensitivity matrix):
+   27654.43932279595
+
+
+Inverse Jacobian:
+   3.616055955166973e-05
+
+
+New scaled variable estimates:
+   MOI.Element1 = -0.4814326024844967
+   
+Iteration 6
+Running Nominal Pass
+Variables:
+   MOI.Element1 = -0.4814326024844967
+   
+Goals and achieved values:
+   geoSat.Earth.SMA  Desired: 42166.9 Achieved: 42167.55482707718
+   Tolerance: 0.001
+   
+********************************************************
+
+
+Jacobian (Sensitivity matrix):
+   27414.56580057275
+
+
+Inverse Jacobian:
+   3.64769592659063e-05
+
+
+New scaled variable estimates:
+   MOI.Element1 = -0.4814564885851172
+   
+Iteration 7
+Running Nominal Pass
+Variables:
+   MOI.Element1 = -0.4814564885851172
+   
+Goals and achieved values:
+   geoSat.Earth.SMA  Desired: 42166.9 Achieved: 42166.9000659372
+   Tolerance: 0.001
+   
+********************************************************
+
+
+********************************************************
+*** Targeting Completed in 7 iterations
+********************************************************
+

--- a/tests/fixtures/solver_log/dc_maxiter_R2026a.data
+++ b/tests/fixtures/solver_log/dc_maxiter_R2026a.data
@@ -1,0 +1,34 @@
+********************************************************
+*** Targeter Text File
+*** 
+*** Using Differential Correction
+***
+*** 1 variables
+*** 1 goals
+***
+*** Variables:
+***    MOI.Element1
+***    
+*** Goals:
+***    geoSat.Earth.SMA
+***    
+*** SolverMode:  Solve
+***    
+********************************************************
+
+Iteration 1
+Running Nominal Pass
+Variables:
+   MOI.Element1 = -0.1
+   
+Goals and achieved values:
+   geoSat.Earth.SMA  Desired: 42166.9 Achieved: 8929.80725361425
+   Tolerance: 0.001
+   
+********************************************************
+
+
+********************************************************
+*** Targeting Completed in 1 iterations
+********************************************************
+

--- a/tests/fixtures/solver_log/yukon_converged_R2026a.data
+++ b/tests/fixtures/solver_log/yukon_converged_R2026a.data
@@ -1,0 +1,45 @@
+********************************************************
+*** Performing Yukon Optimization (using "Yukon1")
+*** 2 variables; 0 equality constraints; 1 inequality constraints
+   Variables:  X1, X2
+   Inequality Constraints:  G
+********************************************************
+Yukon1 Iteration 0; Function Evaluation 1; Nominal Pass
+   Variables:  X1 = 0, X2 = 0
+   Cost Function Value: 8
+   Yukon1 State: Optimization ready to start.
+
+
+
+   Inequality Constraint Variances:
+      Delta G = -8
+
+Yukon1 Iteration 1; Function Evaluation 2; Nominal Pass
+   Variables:  X1 = 3.99999990464, X2 = 3.99999990464
+   Cost Function Value: 7.99999923709
+   Yukon1 State: Optimization is proceeding as expected.
+
+
+
+   Inequality Constraint Variances:
+      Delta G = -1.90728314919e-07
+
+Yukon1 Iteration 1; Function Evaluation 3; Nominal Pass
+   Variables:  X1 = 2, X2 = 2
+   Cost Function Value: 1.57772181044e-30
+   Yukon1 State: Optimization is proceeding as expected.
+
+
+
+   Inequality Constraint Variances:
+      Delta G = -4
+
+
+*** Optimization Completed in 1 iterations and 3 function evaluations
+*** The Optimizer Converged!
+Final Variable values:
+   X1 = 2
+   X2 = 2
+Yukon1 converged to within target accuracy.
+
+

--- a/tests/integration/fixtures/Ex_GEOTransfer.script
+++ b/tests/integration/fixtures/Ex_GEOTransfer.script
@@ -1,0 +1,171 @@
+%
+%  Ex_GEOTransfer
+%
+%  Perform a transfer from a highly-elliptical inclined orbit to an equatorial
+%  geosynchronous orbit.
+%
+%  Trimmed copy of GMAT's stock Ex_GEOTransfer sample for the gmat-run
+%  integration suite: the OpenFramesInterface / OpenFramesView visualisation
+%  resources and the Spacecraft ModelFile reference are removed so the fixture
+%  runs headless without the OpenFrames plugin. The Spacecraft, ForceModel,
+%  Propagator, Burns, DifferentialCorrector, and mission sequence are
+%  unchanged, so the solver .data output is identical to the stock sample.
+%
+
+
+%----------------------------------------
+%---------- Spacecraft
+%----------------------------------------
+
+Create Spacecraft geoSat;
+
+geoSat.DateFormat                   = TAIModJulian;
+geoSat.Epoch                        = '21545';
+geoSat.CoordinateSystem             = EarthMJ2000Eq;
+geoSat.DisplayStateType             = Keplerian;
+geoSat.SMA                          = 6578.000000000003;
+geoSat.ECC                          = 0.001000000000001135;
+geoSat.INC                          = 28.49999999999999;
+geoSat.RAAN                         = 66.99999999999999;
+geoSat.AOP                          = 355.0000000000957;
+geoSat.TA                           = 249.9999999999781;
+geoSat.DryMass                      = 850;
+geoSat.Cd                           = 2.2;
+geoSat.Cr                           = 1.8;
+geoSat.DragArea                     = 15;
+geoSat.SRPArea                      = 1;
+geoSat.NAIFId                       = -123456789;
+geoSat.NAIFIdReferenceFrame         = -123456789;
+geoSat.Id                           = 'SatId';
+geoSat.Attitude                     = CoordinateSystemFixed;
+
+
+%----------------------------------------
+%---------- ForceModels
+%----------------------------------------
+
+Create ForceModel AllForces;
+
+AllForces.CentralBody                      = Earth;
+AllForces.PrimaryBodies                    = {Earth};
+AllForces.SRP                              = On;
+AllForces.RelativisticCorrection           = Off;
+AllForces.ErrorControl                     = RSSStep;
+AllForces.GravityField.Earth.Degree        = 20;
+AllForces.GravityField.Earth.Order         = 20;
+AllForces.GravityField.Earth.PotentialFile = 'JGM2.cof';
+AllForces.GravityField.Earth.TideModel     = 'None';
+AllForces.SRP.Flux                         = 1367;
+AllForces.SRP.Nominal_Sun                  = 149597870.691;
+AllForces.Drag.AtmosphereModel             = MSISE90;
+AllForces.Drag.F107                        = 150;
+AllForces.Drag.F107A                       = 150;
+AllForces.Drag.MagneticIndex               = 3;
+
+%----------------------------------------
+%---------- Propagators
+%----------------------------------------
+
+Create Propagator DefaultProp;
+
+DefaultProp.FM                       = AllForces;
+DefaultProp.Type                     = PrinceDormand78;
+DefaultProp.InitialStepSize          = 60;
+DefaultProp.Accuracy                 = 9.999999999999999e-012;
+DefaultProp.MinStep                  = 0.001;
+DefaultProp.MaxStep                  = 86400;
+DefaultProp.MaxStepAttempts          = 50;
+DefaultProp.StopIfAccuracyIsViolated = true;
+
+%----------------------------------------
+%---------- Burns
+%----------------------------------------
+
+Create ImpulsiveBurn TOI;
+
+TOI.CoordinateSystem   = Local;
+TOI.Origin             = Earth;
+TOI.Axes               = VNB;
+TOI.Element1           = 0;
+TOI.Element2           = 0;
+TOI.Element3           = 0;
+TOI.DecrementMass      = false;
+TOI.Isp                = 300;
+TOI.GravitationalAccel = 9.810000000000001;
+
+Create ImpulsiveBurn MCC;
+
+MCC.CoordinateSystem   = Local;
+MCC.Origin             = Earth;
+MCC.Axes               = VNB;
+MCC.Element1           = 0;
+MCC.Element2           = 0;
+MCC.Element3           = 0;
+MCC.DecrementMass      = false;
+MCC.Isp                = 300;
+MCC.GravitationalAccel = 9.810000000000001;
+
+Create ImpulsiveBurn MOI;
+
+MOI.CoordinateSystem   = Local;
+MOI.Origin             = Earth;
+MOI.Axes               = VNB;
+MOI.Element1           = 0;
+MOI.Element2           = 0;
+MOI.Element3           = 0;
+MOI.DecrementMass      = false;
+MOI.Isp                = 300;
+MOI.GravitationalAccel = 9.810000000000001;
+
+%----------------------------------------
+%---------- Arrays, Variables, Strings
+%----------------------------------------
+Create Variable I lowerBound upperBound;
+
+lowerBound = -119;
+upperBound = -117.5;
+
+%----------------------------------------
+%---------- Solvers
+%----------------------------------------
+
+Create DifferentialCorrector DC;
+
+DC.ShowProgress      = true;
+DC.ReportStyle       = Normal;
+DC.ReportFile        = 'DifferentialCorrectorDC1.data';
+DC.MaximumIterations = 25;
+DC.DerivativeMethod  = ForwardDifference;
+
+%----------------------------------------
+%---------- Mission Sequence
+%----------------------------------------
+BeginMissionSequence;
+Propagate 'Prop to Z Crossing' DefaultProp(geoSat) {geoSat.Z = 0, StopTolerance = 1e-005};
+
+Target 'Raise Apogee' DC {SolveMode  = Solve, ExitMode = DiscardAndContinue};
+   Vary 'Vary TOI.V' DC(TOI.Element1 = 1, {Perturbation = .0001, Lower = -9.999999e300, Upper = 9.999999e300, MaxStep = .5});
+   Maneuver 'Apply TOI' TOI(geoSat);
+   Propagate 'Prop To Apogee' DefaultProp(geoSat) {geoSat.Apoapsis};
+   Achieve 'Achieve RMAG' DC(geoSat.RMAG = 85000, {Tolerance = .1});
+EndTarget;  % For targeter DC
+
+Propagate 'Prop to Perigee' DefaultProp(geoSat) {geoSat.Earth.Periapsis};
+Propagate 'Prop to Plane Crossing' DefaultProp(geoSat) {geoSat.Z = 0, StopTolerance = 1e-5};
+
+Target 'Change Plane/Perigee' DC {SolveMode = Solve, ExitMode = DiscardAndContinue};
+   Vary 'Vary MCC.V' DC(MCC.Element1 = 0.1, {Perturbation = .0001, Lower = -9.999999e300, Upper = 9.999999e300, MaxStep = 0.5});
+   Vary 'Vary MCC.N' DC(MCC.Element2 = 0.1, {Perturbation = .0001, Lower = -9.999999e300, Upper = 9.999999e300, MaxStep = 0.5});
+   Maneuver 'Apply MCC' MCC(geoSat);
+   Propagate 'Prop to Perigee' DefaultProp(geoSat) {geoSat.Periapsis};
+   Achieve 'Apply INC' DC(geoSat.EarthMJ2000Eq.INC = 2, {Tolerance = .001});
+   Achieve 'Achieve RMAG' DC(geoSat.RMAG = 42195, {Tolerance = .001});
+EndTarget;  % For targeter DC
+
+Target 'Lower Apogee' DC {SolveMode  = Solve, ExitMode = DiscardAndContinue};
+   Vary 'Vary MOI.V' DC(MOI.Element1 = -0.1, {Perturbation = .0001, Lower = -9.999999e300, Upper = 9.999999e300, MaxStep = .1});
+   Maneuver 'Apply MOI' MOI(geoSat);
+   Achieve 'Achieve SMA' DC(geoSat.Earth.SMA = 42166.90, {Tolerance = .001});
+EndTarget;  % For targeter DC
+
+Propagate 'Prop 10 days' DefaultProp(geoSat) {geoSat.ElapsedDays = 10};

--- a/tests/integration/fixtures/Ex_Yukon_AlgebraicOptimization.script
+++ b/tests/integration/fixtures/Ex_Yukon_AlgebraicOptimization.script
@@ -1,0 +1,87 @@
+%
+%  Ex_Yukon_AlgebraicOptimization
+%
+%  Script Mission - Optimization Example
+%
+%  This script demonstrates how to use Yukon in an Optimize sequence
+%
+%  Released: R2018a
+%
+%  Verbatim copy of GMAT's stock Ex_Yukon_AlgebraicOptimization sample for the
+%  gmat-run integration suite. No visualisation resources to strip; the only
+%  plugin dependency is the stock Yukon optimizer.
+%
+
+
+%-----------------------------------------------------------------
+%-----------------Create and Setup the Optimizer------------------
+%-----------------------------------------------------------------
+
+Create Yukon Yukon1;
+
+Yukon1.ShowProgress          = true;
+Yukon1.ReportStyle           = Normal;
+Yukon1.ReportFile            = 'MinNLPadYukon1.data';
+Yukon1.MaximumIterations     = 500;
+Yukon1.UseCentralDifferences = false;
+Yukon1.FeasibilityTolerance  = 0.001;
+Yukon1.HessianUpdateMethod   = SelfScaledBFGS;
+Yukon1.MaximumFunctionEvals  = 1000;
+Yukon1.OptimalityTolerance   = 0.0001;
+Yukon1.FunctionTolerance     = 0.0001;
+Yukon1.MaximumElasticWeight  = 10000;
+
+%-----------------------------------------------------------------
+%------------------------------OutPut-----------------------------
+%-----------------------------------------------------------------
+
+Create ReportFile Data;
+
+Data.SolverIterations = Current;
+Data.UpperLeft        = [ 0 0 ];
+Data.Size             = [ 0 0 ];
+Data.RelativeZOrder   = 0;
+Data.Maximized        = false;
+Data.Filename         = 'Ex_AlgebraicOptimization.report';
+Data.Precision        = 16;
+Data.WriteHeaders     = false;
+Data.LeftJustify      = On;
+Data.ZeroFill         = Off;
+Data.FixedWidth       = true;
+Data.Delimiter        = ' ';
+Data.ColumnWidth      = 20;
+Data.WriteReport      = true;
+Data.Add              = {X1, X2};
+
+%----------------------------------------
+%---------- Arrays, Variables, Strings
+%----------------------------------------
+Create Variable X1 X2 J G;
+
+
+
+%----------------------------------------
+%---------- Mission Sequence
+%----------------------------------------
+BeginMissionSequence;
+
+Optimize Yukon1 {SolveMode = Solve, ExitMode = DiscardAndContinue, ShowProgressWindow = true};
+
+   %  Vary the independent variables
+   Vary 'Vary X1' Yukon1(X1 = 0, {Perturbation = 0.0000001, MaxStep = 9.999999e300, AdditiveScaleFactor = 0.0, MultiplicativeScaleFactor = 1.0});
+   Vary 'Vary X2' Yukon1(X2 = 0, {Perturbation = 0.0000001, MaxStep = 9.999999e300, AdditiveScaleFactor = 0.0, MultiplicativeScaleFactor = 1.0});
+
+   %  The cost function and Minimize command
+   'Compute Cost (J)' J = ( X1 - 2 )^2 + ( X2 - 2 )^2;
+   Minimize 'Minimize Cost J' Yukon1(J);
+
+   %  Calculate constraint and use NonLinearConstraint command
+   %   ( yes, the equation below is actually a linear constraint, were
+   %     testing functionality with this test)
+   %  The constraint is to require the solution to lie above the line defined by X2 = -X1 + 6
+   %  or X2 >= -X1 + 6;
+   'Compute Constraint (G)' G = X2 + X1;
+   NonlinearConstraint 'G = 8' Yukon1(G<=8);
+	Report Data X1 X2;
+
+EndOptimize;  % For optimizer SQPfmincon

--- a/tests/integration/test_solver_runs.py
+++ b/tests/integration/test_solver_runs.py
@@ -1,0 +1,103 @@
+"""Integration tests for :attr:`Results.solver_runs` against real GMAT runs.
+
+Drives the trimmed stock samples under ``tests/integration/fixtures/`` through
+a full ``Mission.load`` -> ``run`` -> ``solver_runs`` pipeline:
+
+* ``Ex_GEOTransfer.script`` — three ``Target`` blocks sharing one
+  ``DifferentialCorrector``. The shared solver overwrites its ``.data`` file
+  per block, so the surfaced DataFrame covers the last block only.
+* the same script with ``DC.MaximumIterations`` forced to 1 — a deliberately
+  non-converged run that must end ``"max_iter"`` rather than raise.
+* ``Ex_Yukon_AlgebraicOptimization.script`` — a ``Yukon`` optimizer run.
+* ``Ex_MinimalLEO.script`` — no solver at all, so the mapping stays empty.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from gmat_run import Mission
+
+pytestmark = pytest.mark.integration
+
+_FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _staged(fixture_name: str, tmp_path: Path) -> Path:
+    """Copy a fixture script into ``tmp_path`` and return the copy's path."""
+    dest = tmp_path / fixture_name
+    shutil.copyfile(_FIXTURES / fixture_name, dest)
+    return dest
+
+
+def test_geotransfer_differential_corrector_converges(gmat_available: None, tmp_path: Path) -> None:
+    mission = Mission.load(_staged("Ex_GEOTransfer.script", tmp_path))
+    result = mission.run()
+
+    assert list(result.solver_runs) == ["DC"]
+    df = result.solver_runs["DC"]
+    assert isinstance(df, pd.DataFrame)
+
+    # Three Target blocks share DC and overwrite the same .data file; the
+    # surfaced run is the last block ("Lower Apogee": vary MOI.Element1 to
+    # achieve geoSat.Earth.SMA).
+    assert df.attrs["solver_type"] == "DifferentialCorrector"
+    assert "MOI.Element1" in df.columns
+    for column in (
+        "geoSat.Earth.SMA",
+        "geoSat.Earth.SMA_desired",
+        "geoSat.Earth.SMA_residual",
+        "geoSat.Earth.SMA_tolerance",
+    ):
+        assert column in df.columns
+
+    # It converged: the final row is stamped, the attr agrees, and the
+    # convenience map agrees.
+    assert df["status"].iloc[-1] == "converged"
+    assert df.attrs["converged"] is True
+    assert result.converged == {"DC": True}
+
+    # The .data log was redirected into the run workspace, like every other
+    # output, and reading the field back yields that resolved path.
+    report_file = mission["DC.ReportFile"]
+    assert Path(report_file).parent == result.output_dir
+
+
+def test_geotransfer_max_iterations_one_ends_max_iter(gmat_available: None, tmp_path: Path) -> None:
+    """A deliberately non-converged run ends ``"max_iter"`` and does not raise."""
+    mission = Mission.load(_staged("Ex_GEOTransfer.script", tmp_path))
+    mission["DC.MaximumIterations"] = 1
+    result = mission.run()
+
+    df = result.solver_runs["DC"]
+    assert df["status"].iloc[-1] == "max_iter"
+    assert df.attrs["converged"] is False
+    assert result.converged["DC"] is False
+
+
+def test_yukon_optimization_converges(gmat_available: None, tmp_path: Path) -> None:
+    mission = Mission.load(_staged("Ex_Yukon_AlgebraicOptimization.script", tmp_path))
+    result = mission.run()
+
+    assert "Yukon1" in result.solver_runs
+    df = result.solver_runs["Yukon1"]
+    assert df.attrs["solver_type"] == "Yukon"
+    # Yukon's normalised frame: variables, the cost function, per-constraint
+    # residual — no goal quartet (the file carries none).
+    assert "cost" in df.columns
+    assert {"X1", "X2"}.issubset(df.columns)
+
+    assert df["status"].iloc[-1] == "converged"
+    assert result.converged["Yukon1"] is True
+
+
+def test_mission_without_solver_yields_empty_mapping(gmat_available: None, tmp_path: Path) -> None:
+    mission = Mission.load(_staged("Ex_MinimalLEO.script", tmp_path))
+    result = mission.run()
+
+    assert dict(result.solver_runs) == {}
+    assert result.converged == {}

--- a/tests/test_parsers_solver_log.py
+++ b/tests/test_parsers_solver_log.py
@@ -1,0 +1,445 @@
+"""Unit tests for :func:`gmat_run.parsers.solver_log.parse`.
+
+Fixture-backed tests pin the parser against real GMAT R2026a ``.data`` captures
+committed under ``tests/fixtures/solver_log/``; inline ``tmp_path`` fixtures
+cover the malformed-input and edge cases, mirroring
+:mod:`tests.test_parsers_contact`. No GMAT install is required.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from gmat_run.errors import GmatOutputParseError
+from gmat_run.parsers.solver_log import parse
+
+_FIXTURES = Path(__file__).parent / "fixtures" / "solver_log"
+
+
+# --- helpers -----------------------------------------------------------------
+
+
+def _write(path: Path, content: str, encoding: str = "utf-8", newline: str = "\n") -> Path:
+    """Write ``content`` verbatim with the requested encoding and line ending."""
+    path.write_bytes(content.replace("\n", newline).encode(encoding))
+    return path
+
+
+# A minimal but well-formed DifferentialCorrector file: one converged
+# iteration, one variable, one goal. Edge-case tests mutate copies of this.
+_DC_MINIMAL = """\
+********************************************************
+*** Targeter Text File
+*** Using Differential Correction
+*** 1 variables
+*** 1 goals
+*** SolverMode:  Solve
+********************************************************
+
+Iteration 1
+Running Nominal Pass
+Variables:
+   Burn.V = 0.5
+
+Goals and achieved values:
+   Sat.SMA  Desired: 7000 Achieved: 6999.9995
+   Tolerance: 0.001
+
+********************************************************
+*** Targeting Completed in 1 iterations
+********************************************************
+"""
+
+# A minimal Yukon file: one nominal pass, one variable, one constraint.
+_YUKON_MINIMAL = """\
+********************************************************
+*** Performing Yukon Optimization (using "Opt")
+*** 1 variables; 0 equality constraints; 1 inequality constraints
+   Variables:  X
+   Inequality Constraints:  C
+********************************************************
+Opt Iteration 0; Function Evaluation 1; Nominal Pass
+   Variables:  X = 1
+   Cost Function Value: 5
+   Inequality Constraint Variances:
+      Delta C = -2
+
+*** Optimization Completed in 0 iterations and 1 function evaluations
+*** The Optimizer Converged!
+"""
+
+
+# --- DifferentialCorrector: converged fixture --------------------------------
+
+
+def test_dc_converged_fixture_shape() -> None:
+    df = parse(_FIXTURES / "dc_converged_R2026a.data", max_iterations=25)
+    assert list(df.columns) == [
+        "iteration",
+        "MOI.Element1",
+        "geoSat.Earth.SMA",
+        "geoSat.Earth.SMA_desired",
+        "geoSat.Earth.SMA_residual",
+        "geoSat.Earth.SMA_tolerance",
+        "status",
+    ]
+    assert len(df) == 7
+    assert df["iteration"].tolist() == [1, 2, 3, 4, 5, 6, 7]
+
+
+def test_dc_converged_fixture_dtypes() -> None:
+    df = parse(_FIXTURES / "dc_converged_R2026a.data", max_iterations=25)
+    assert df["iteration"].dtype == "int64"
+    assert df["MOI.Element1"].dtype == "float64"
+    assert df["geoSat.Earth.SMA_residual"].dtype == "float64"
+    assert df["status"].dtype == "string"
+
+
+def test_dc_converged_fixture_status_progression() -> None:
+    df = parse(_FIXTURES / "dc_converged_R2026a.data", max_iterations=25)
+    assert df["status"].tolist() == ["running"] * 6 + ["converged"]
+
+
+def test_dc_converged_fixture_residual_is_achieved_minus_desired() -> None:
+    df = parse(_FIXTURES / "dc_converged_R2026a.data", max_iterations=25)
+    row = df.iloc[-1]
+    assert row["geoSat.Earth.SMA_desired"] == 42166.9
+    assert row["geoSat.Earth.SMA_residual"] == pytest.approx(
+        row["geoSat.Earth.SMA"] - row["geoSat.Earth.SMA_desired"]
+    )
+    # Final residual is inside tolerance — that is why the run converged.
+    assert abs(row["geoSat.Earth.SMA_residual"]) <= row["geoSat.Earth.SMA_tolerance"]
+
+
+def test_dc_converged_fixture_attrs() -> None:
+    df = parse(_FIXTURES / "dc_converged_R2026a.data", max_iterations=25)
+    assert df.attrs["solver_type"] == "DifferentialCorrector"
+    assert df.attrs["solver_mode"] == "Solve"
+    assert df.attrs["n_iterations"] == 7
+    assert df.attrs["n_variables"] == 1
+    assert df.attrs["n_goals"] == 1
+    assert df.attrs["converged"] is True
+    assert df.attrs["source_path"].endswith("dc_converged_R2026a.data")
+
+
+# --- DifferentialCorrector: max-iter fixture ---------------------------------
+
+
+def test_dc_maxiter_fixture_ends_max_iter() -> None:
+    df = parse(_FIXTURES / "dc_maxiter_R2026a.data", max_iterations=1)
+    assert len(df) == 1
+    assert df["status"].iloc[-1] == "max_iter"
+    assert df.attrs["converged"] is False
+    assert df.attrs["n_iterations"] == 1
+
+
+def test_dc_maxiter_without_max_iterations_falls_back_to_failed() -> None:
+    # Without the MaximumIterations hint a non-converged run cannot be told
+    # apart from a generic failure.
+    df = parse(_FIXTURES / "dc_maxiter_R2026a.data")
+    assert df["status"].iloc[-1] == "failed"
+
+
+def test_dc_non_converged_below_max_iterations_is_failed() -> None:
+    df = parse(_FIXTURES / "dc_maxiter_R2026a.data", max_iterations=25)
+    # One iteration, cap of 25 — it stopped early without converging.
+    assert df["status"].iloc[-1] == "failed"
+
+
+# --- Yukon: converged fixture ------------------------------------------------
+
+
+def test_yukon_converged_fixture_shape() -> None:
+    df = parse(_FIXTURES / "yukon_converged_R2026a.data", max_iterations=500)
+    assert list(df.columns) == ["iteration", "X1", "X2", "cost", "G_residual", "status"]
+    assert len(df) == 3
+    # The iteration column repeats — one row per nominal pass, not per iteration.
+    assert df["iteration"].tolist() == [0, 1, 1]
+
+
+def test_yukon_converged_fixture_values() -> None:
+    df = parse(_FIXTURES / "yukon_converged_R2026a.data", max_iterations=500)
+    last = df.iloc[-1]
+    assert last["X1"] == pytest.approx(2.0)
+    assert last["X2"] == pytest.approx(2.0)
+    assert last["cost"] == pytest.approx(0.0, abs=1e-20)
+    assert df["status"].tolist() == ["running", "running", "converged"]
+
+
+def test_yukon_converged_fixture_attrs() -> None:
+    df = parse(_FIXTURES / "yukon_converged_R2026a.data", max_iterations=500)
+    assert df.attrs["solver_type"] == "Yukon"
+    assert df.attrs["solver_mode"] == "unknown"
+    assert df.attrs["n_iterations"] == 1
+    assert df.attrs["n_variables"] == 2
+    assert df.attrs["n_goals"] == 1
+    assert df.attrs["converged"] is True
+    assert df.attrs["source_path"].endswith("yukon_converged_R2026a.data")
+
+
+# --- minimal-template happy paths --------------------------------------------
+
+
+def test_dc_minimal_template_parses(tmp_path: Path) -> None:
+    df = parse(_write(tmp_path / "dc.data", _DC_MINIMAL), max_iterations=25)
+    assert df["status"].iloc[-1] == "converged"
+    assert df["Burn.V"].iloc[0] == pytest.approx(0.5)
+
+
+def test_yukon_minimal_template_parses(tmp_path: Path) -> None:
+    df = parse(_write(tmp_path / "y.data", _YUKON_MINIMAL), max_iterations=500)
+    assert df["status"].iloc[-1] == "converged"
+    assert df["C_residual"].iloc[0] == pytest.approx(-2.0)
+
+
+def test_crlf_line_endings_parse_identically(tmp_path: Path) -> None:
+    lf = parse(_write(tmp_path / "lf.data", _DC_MINIMAL, newline="\n"), max_iterations=25)
+    crlf = parse(_write(tmp_path / "crlf.data", _DC_MINIMAL, newline="\r\n"), max_iterations=25)
+    pd.testing.assert_frame_equal(lf, crlf)
+
+
+def test_utf8_bom_is_tolerated(tmp_path: Path) -> None:
+    df = parse(_write(tmp_path / "bom.data", _DC_MINIMAL, encoding="utf-8-sig"))
+    assert df.attrs["solver_type"] == "DifferentialCorrector"
+
+
+# --- dispatch / file-level errors --------------------------------------------
+
+
+def test_empty_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(GmatOutputParseError, match="empty"):
+        parse(_write(tmp_path / "empty.data", "\n  \n\n"))
+
+
+def test_unrecognised_header_lists_supported_types(tmp_path: Path) -> None:
+    content = "*** Performing SNOPT Optimization\n*** 1 variables\n"
+    with pytest.raises(GmatOutputParseError, match="DifferentialCorrector, Yukon"):
+        parse(_write(tmp_path / "snopt.data", content))
+
+
+# --- DifferentialCorrector: malformed input ----------------------------------
+
+
+def test_dc_no_iterations_raises(tmp_path: Path) -> None:
+    header = "\n".join(_DC_MINIMAL.splitlines()[:7]) + "\n"
+    with pytest.raises(GmatOutputParseError, match="no iterations"):
+        parse(_write(tmp_path / "dc.data", header))
+
+
+def test_dc_missing_variables_section_raises(tmp_path: Path) -> None:
+    broken = _DC_MINIMAL.replace("Variables:\n   Burn.V = 0.5\n\n", "")
+    with pytest.raises(GmatOutputParseError, match="missing 'Variables:'"):
+        parse(_write(tmp_path / "dc.data", broken))
+
+
+def test_dc_missing_goals_section_raises(tmp_path: Path) -> None:
+    broken = _DC_MINIMAL.replace(
+        "Goals and achieved values:\n"
+        "   Sat.SMA  Desired: 7000 Achieved: 6999.9995\n"
+        "   Tolerance: 0.001\n\n",
+        "",
+    )
+    with pytest.raises(GmatOutputParseError, match="missing 'Goals"):
+        parse(_write(tmp_path / "dc.data", broken))
+
+
+def test_dc_goal_without_tolerance_raises(tmp_path: Path) -> None:
+    broken = _DC_MINIMAL.replace("   Tolerance: 0.001\n", "")
+    with pytest.raises(GmatOutputParseError, match="Tolerance"):
+        parse(_write(tmp_path / "dc.data", broken))
+
+
+def test_dc_non_numeric_variable_raises(tmp_path: Path) -> None:
+    broken = _DC_MINIMAL.replace("Burn.V = 0.5", "Burn.V = lots")
+    with pytest.raises(GmatOutputParseError, match="non-numeric"):
+        parse(_write(tmp_path / "dc.data", broken))
+
+
+def test_dc_header_variable_count_mismatch_raises(tmp_path: Path) -> None:
+    broken = _DC_MINIMAL.replace("*** 1 variables", "*** 4 variables")
+    with pytest.raises(GmatOutputParseError, match="declares 4 variables"):
+        parse(_write(tmp_path / "dc.data", broken))
+
+
+def test_dc_inconsistent_variable_set_across_iterations_raises(tmp_path: Path) -> None:
+    second = """
+Iteration 2
+Running Nominal Pass
+Variables:
+   Other.V = 0.6
+
+Goals and achieved values:
+   Sat.SMA  Desired: 7000 Achieved: 7000.0
+   Tolerance: 0.001
+"""
+    broken = _DC_MINIMAL.replace(
+        "********************************************************\n"
+        "*** Targeting Completed in 1 iterations",
+        second + "********************************************************\n"
+        "*** Targeting Completed in 2 iterations",
+    )
+    with pytest.raises(GmatOutputParseError, match="variable set"):
+        parse(_write(tmp_path / "dc.data", broken))
+
+
+# --- Yukon: malformed input --------------------------------------------------
+
+
+def test_yukon_no_records_raises(tmp_path: Path) -> None:
+    header = "\n".join(_YUKON_MINIMAL.splitlines()[:6]) + "\n"
+    with pytest.raises(GmatOutputParseError, match="no iteration records"):
+        parse(_write(tmp_path / "y.data", header))
+
+
+def test_yukon_missing_cost_raises(tmp_path: Path) -> None:
+    broken = _YUKON_MINIMAL.replace("   Cost Function Value: 5\n", "")
+    with pytest.raises(GmatOutputParseError, match="Cost Function Value"):
+        parse(_write(tmp_path / "y.data", broken))
+
+
+def test_yukon_malformed_assignment_raises(tmp_path: Path) -> None:
+    broken = _YUKON_MINIMAL.replace("   Variables:  X = 1", "   Variables:  X 1")
+    with pytest.raises(GmatOutputParseError, match="malformed assignment"):
+        parse(_write(tmp_path / "y.data", broken))
+
+
+def test_yukon_perturbation_passes_are_skipped(tmp_path: Path) -> None:
+    # A perturbation pass between two nominal passes must not become a row.
+    extra = """Opt Iteration 0; Function Evaluation 2; Perturbation Pass 1
+   Variables:  X = 1.0001
+   Cost Function Value: 5.1
+   Inequality Constraint Variances:
+      Delta C = -1.9
+
+"""
+    augmented = _YUKON_MINIMAL.replace(
+        "*** Optimization Completed", extra + "*** Optimization Completed"
+    )
+    df = parse(_write(tmp_path / "y.data", augmented), max_iterations=500)
+    assert len(df) == 1  # only the nominal pass survives
+
+
+def test_yukon_non_converged_without_max_iterations_is_failed(tmp_path: Path) -> None:
+    broken = _YUKON_MINIMAL.replace("*** The Optimizer Converged!\n", "")
+    df = parse(_write(tmp_path / "y.data", broken))
+    assert df["status"].iloc[-1] == "failed"
+    assert df.attrs["converged"] is False
+
+
+def test_yukon_iteration_count_falls_back_without_terminator(tmp_path: Path) -> None:
+    # Strip the "Optimization Completed" line — n_iterations falls back to the
+    # highest iteration number actually seen in the records.
+    broken = _YUKON_MINIMAL.replace(
+        "*** Optimization Completed in 0 iterations and 1 function evaluations\n", ""
+    )
+    df = parse(_write(tmp_path / "y.data", broken))
+    assert df.attrs["n_iterations"] == 0
+
+
+def test_dc_header_goal_count_mismatch_raises(tmp_path: Path) -> None:
+    broken = _DC_MINIMAL.replace("*** 1 goals", "*** 3 goals")
+    with pytest.raises(GmatOutputParseError, match="declares 3 goals"):
+        parse(_write(tmp_path / "dc.data", broken))
+
+
+def test_dc_variables_section_may_end_without_blank_line(tmp_path: Path) -> None:
+    # The variable list runs straight into the goals header with no blank
+    # separator — the parser ends the section on the first non-assignment line.
+    tight = _DC_MINIMAL.replace("   Burn.V = 0.5\n\nGoals", "   Burn.V = 0.5\nGoals")
+    df = parse(_write(tmp_path / "dc.data", tight), max_iterations=25)
+    assert df["Burn.V"].iloc[0] == pytest.approx(0.5)
+
+
+def test_dc_empty_variables_section_raises(tmp_path: Path) -> None:
+    broken = _DC_MINIMAL.replace("Variables:\n   Burn.V = 0.5\n", "Variables:\n")
+    with pytest.raises(GmatOutputParseError, match="no variables listed"):
+        parse(_write(tmp_path / "dc.data", broken))
+
+
+def test_dc_empty_goals_section_raises(tmp_path: Path) -> None:
+    broken = _DC_MINIMAL.replace(
+        "Goals and achieved values:\n"
+        "   Sat.SMA  Desired: 7000 Achieved: 6999.9995\n"
+        "   Tolerance: 0.001\n",
+        "Goals and achieved values:\n",
+    )
+    with pytest.raises(GmatOutputParseError, match="no goals listed"):
+        parse(_write(tmp_path / "dc.data", broken))
+
+
+def test_dc_without_solver_mode_line_is_unknown(tmp_path: Path) -> None:
+    broken = _DC_MINIMAL.replace("*** SolverMode:  Solve\n", "")
+    df = parse(_write(tmp_path / "dc.data", broken), max_iterations=25)
+    assert df.attrs["solver_mode"] == "unknown"
+
+
+def test_dc_inconsistent_goal_set_across_iterations_raises(tmp_path: Path) -> None:
+    second = """
+Iteration 2
+Running Nominal Pass
+Variables:
+   Burn.V = 0.6
+
+Goals and achieved values:
+   Sat.ECC  Desired: 0 Achieved: 0.0
+   Tolerance: 0.001
+"""
+    broken = _DC_MINIMAL.replace(
+        "********************************************************\n"
+        "*** Targeting Completed in 1 iterations",
+        second + "********************************************************\n"
+        "*** Targeting Completed in 2 iterations",
+    )
+    with pytest.raises(GmatOutputParseError, match="goal set"):
+        parse(_write(tmp_path / "dc.data", broken))
+
+
+def test_yukon_all_perturbation_passes_raises(tmp_path: Path) -> None:
+    broken = _YUKON_MINIMAL.replace("Nominal Pass", "Perturbation Pass 1")
+    with pytest.raises(GmatOutputParseError, match="no nominal-pass records"):
+        parse(_write(tmp_path / "y.data", broken))
+
+
+def test_yukon_header_variable_count_mismatch_raises(tmp_path: Path) -> None:
+    broken = _YUKON_MINIMAL.replace("*** 1 variables", "*** 5 variables")
+    with pytest.raises(GmatOutputParseError, match="declares 5 variables"):
+        parse(_write(tmp_path / "y.data", broken))
+
+
+def test_yukon_empty_variables_raises(tmp_path: Path) -> None:
+    broken = _YUKON_MINIMAL.replace("   Variables:  X = 1\n", "   Variables:  \n")
+    with pytest.raises(GmatOutputParseError, match="no variables listed"):
+        parse(_write(tmp_path / "y.data", broken))
+
+
+def test_yukon_inconsistent_variable_set_raises(tmp_path: Path) -> None:
+    second = """Opt Iteration 1; Function Evaluation 2; Nominal Pass
+   Variables:  Y = 2
+   Cost Function Value: 3
+   Inequality Constraint Variances:
+      Delta C = -1
+
+"""
+    broken = _YUKON_MINIMAL.replace(
+        "*** Optimization Completed", second + "*** Optimization Completed"
+    )
+    with pytest.raises(GmatOutputParseError, match="variable set"):
+        parse(_write(tmp_path / "y.data", broken))
+
+
+def test_yukon_inconsistent_constraint_set_raises(tmp_path: Path) -> None:
+    second = """Opt Iteration 1; Function Evaluation 2; Nominal Pass
+   Variables:  X = 2
+   Cost Function Value: 3
+   Inequality Constraint Variances:
+      Delta D = -1
+
+"""
+    broken = _YUKON_MINIMAL.replace(
+        "*** Optimization Completed", second + "*** Optimization Completed"
+    )
+    with pytest.raises(GmatOutputParseError, match="constraint set"):
+        parse(_write(tmp_path / "y.data", broken))

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -47,6 +47,9 @@ def test_default_mappings_are_empty(tmp_path: Path) -> None:
     assert len(result.ephemeris_paths) == 0
     assert len(result.contacts) == 0
     assert len(result.contact_paths) == 0
+    assert len(result.solver_runs) == 0
+    assert len(result.solver_paths) == 0
+    assert result.converged == {}
 
 
 def test_path_mappings_are_read_only(tmp_path: Path) -> None:
@@ -375,10 +378,139 @@ def test_contacts_unknown_key_raises_keyerror(tmp_path: Path) -> None:
         _ = result.contacts["nope"]
 
 
+# --- solver_runs (lazy) ------------------------------------------------------
+
+
+_SOLVER_DC_CONVERGED = """\
+********************************************************
+*** Targeter Text File
+*** Using Differential Correction
+*** 1 variables
+*** 1 goals
+*** SolverMode:  Solve
+********************************************************
+
+Iteration 1
+Running Nominal Pass
+Variables:
+   Burn.V = 0.5
+
+Goals and achieved values:
+   Sat.SMA  Desired: 7000 Achieved: 6999.9995
+   Tolerance: 0.001
+
+********************************************************
+*** Targeting Completed in 1 iterations
+********************************************************
+"""
+
+# Same file with the achieved value far from the goal — does not converge.
+_SOLVER_DC_DIVERGED = _SOLVER_DC_CONVERGED.replace("6999.9995", "5000.0")
+
+
+def _write_solver(path: Path, content: str = _SOLVER_DC_CONVERGED) -> Path:
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_solver_paths_round_trip(tmp_path: Path) -> None:
+    data = tmp_path / "DC.data"
+    result = Results(output_dir=tmp_path, log="", solver_paths={"DC": data})
+    assert result.solver_paths["DC"] == data
+    assert list(result.solver_runs) == ["DC"]
+    assert "DC" in result.solver_runs
+    assert len(result.solver_runs) == 1
+
+
+def test_solver_run_value_access_returns_dataframe(tmp_path: Path) -> None:
+    """``.solver_runs[k]`` lazily parses the ``.data`` file into a typed frame."""
+    data = _write_solver(tmp_path / "DC.data")
+    result = Results(output_dir=tmp_path, log="", solver_paths={"DC": data})
+    df = result.solver_runs["DC"]
+    assert isinstance(df, pd.DataFrame)
+    assert "iteration" in df.columns
+    assert "Burn.V" in df.columns
+    assert df.attrs["solver_type"] == "DifferentialCorrector"
+
+
+def test_solver_run_construction_does_not_read_files(tmp_path: Path) -> None:
+    """Pointing at a non-existent path must not raise — the parser is lazy."""
+    result = Results(output_dir=tmp_path, log="", solver_paths={"DC": tmp_path / "never.data"})
+    assert "DC" in result.solver_runs
+    assert list(result.solver_runs) == ["DC"]
+    assert len(result.solver_runs) == 1
+
+
+def test_solver_run_lazy_parse_caches(tmp_path: Path) -> None:
+    """Once parsed, the DataFrame is independent of the source file."""
+    data = _write_solver(tmp_path / "DC.data")
+    result = Results(output_dir=tmp_path, log="", solver_paths={"DC": data})
+    df = result.solver_runs["DC"]
+    data.unlink()
+    assert result.solver_runs["DC"] is df
+
+
+def test_solver_runs_unknown_key_raises_keyerror(tmp_path: Path) -> None:
+    result = _empty(tmp_path)
+    with pytest.raises(KeyError):
+        _ = result.solver_runs["nope"]
+
+
+def test_solver_paths_are_read_only(tmp_path: Path) -> None:
+    result = Results(output_dir=tmp_path, log="", solver_paths={"DC": tmp_path / "DC.data"})
+    with pytest.raises(TypeError):
+        result.solver_paths["DC2"] = tmp_path / "DC2.data"  # type: ignore[index]
+
+
+def test_solver_paths_defensively_copied(tmp_path: Path) -> None:
+    paths: dict[str, Path] = {"DC": tmp_path / "DC.data"}
+    result = Results(output_dir=tmp_path, log="", solver_paths=paths)
+    paths["DC2"] = tmp_path / "DC2.data"
+    assert list(result.solver_runs) == ["DC"]
+
+
+def test_converged_reflects_each_solver(tmp_path: Path) -> None:
+    ok = _write_solver(tmp_path / "DC.data", _SOLVER_DC_CONVERGED)
+    bad = _write_solver(tmp_path / "DC2.data", _SOLVER_DC_DIVERGED)
+    result = Results(output_dir=tmp_path, log="", solver_paths={"DC": ok, "DC2": bad})
+    assert result.converged == {"DC": True, "DC2": False}
+
+
+def test_solver_max_iterations_threaded_to_parser(tmp_path: Path) -> None:
+    """``solver_max_iterations`` reaches the parser — it distinguishes max_iter."""
+    data = _write_solver(tmp_path / "DC.data", _SOLVER_DC_DIVERGED)
+    capped = Results(
+        output_dir=tmp_path,
+        log="",
+        solver_paths={"DC": data},
+        solver_max_iterations={"DC": 1},
+    )
+    assert capped.solver_runs["DC"]["status"].iloc[-1] == "max_iter"
+    # Without the hint the same non-converged run cannot be told from a failure.
+    uncapped = Results(output_dir=tmp_path, log="", solver_paths={"DC": data})
+    assert uncapped.solver_runs["DC"]["status"].iloc[-1] == "failed"
+
+
+def test_solver_run_persist_rebases_paths(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    _write_solver(workspace / "DC.data")
+    result = Results(output_dir=workspace, log="", solver_paths={"DC": workspace / "DC.data"})
+    dest = tmp_path / "persisted"
+
+    result.persist(dest)
+
+    assert result.solver_paths["DC"] == dest / "DC.data"
+    # Lazy parse now resolves against the persisted copy.
+    for f in workspace.iterdir():
+        f.unlink()
+    assert result.solver_runs["DC"].attrs["solver_type"] == "DifferentialCorrector"
+
+
 # --- mapping protocol --------------------------------------------------------
 
 
-@pytest.mark.parametrize("attr", ["reports", "ephemerides", "contacts"])
+@pytest.mark.parametrize("attr", ["reports", "ephemerides", "contacts", "solver_runs"])
 def test_mapping_attrs_are_mappings(tmp_path: Path, attr: str) -> None:
     """The three keyed views must satisfy ``Mapping`` at runtime, not just typing."""
     result = _empty(tmp_path)
@@ -646,7 +778,7 @@ def test_repr_format_shows_per_mapping_counts(tmp_path: Path) -> None:
         report_paths={"RF1": tmp_path / "rf1.txt", "RF2": tmp_path / "rf2.txt"},
         ephemeris_paths={"Eph1": tmp_path / "e1.oem"},
     )
-    assert repr(result) == "Results(reports=2, ephemerides=1, contacts=0)"
+    assert repr(result) == "Results(reports=2, ephemerides=1, contacts=0, solver_runs=0)"
 
 
 def test_repr_html_returns_table_listing_mapping_names(tmp_path: Path) -> None:
@@ -661,9 +793,10 @@ def test_repr_html_returns_table_listing_mapping_names(tmp_path: Path) -> None:
     assert "<code>reports</code>" in html_str
     assert "<code>ephemerides</code>" in html_str
     assert "<code>contacts</code>" in html_str
+    assert "<code>solver_runs</code>" in html_str
     assert "RF1" in html_str
     assert "Eph1" in html_str
-    assert "<em>none</em>" in html_str  # contacts is empty
+    assert "<em>none</em>" in html_str  # contacts and solver_runs are empty
 
 
 def test_repr_html_does_not_materialise_dataframes(tmp_path: Path) -> None:

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -559,12 +559,15 @@ def test_format_results_html_lists_each_mapping() -> None:
         report_names=("RF1", "RF2"),
         ephemeris_names=("Eph1",),
         contact_names=(),
+        solver_run_names=("DC",),
     )
     assert "<code>reports</code>" in out
     assert "<code>ephemerides</code>" in out
     assert "<code>contacts</code>" in out
+    assert "<code>solver_runs</code>" in out
     assert "RF1, RF2" in out
     assert "Eph1" in out
+    assert "DC" in out
     assert "<em>none</em>" in out
 
 
@@ -573,6 +576,7 @@ def test_format_results_html_escapes_names() -> None:
         report_names=("<RF>",),
         ephemeris_names=(),
         contact_names=(),
+        solver_run_names=(),
     )
     assert "<RF>" not in out.replace("&lt;RF&gt;", "")
     assert "&lt;RF&gt;" in out
@@ -583,8 +587,9 @@ def test_format_results_html_when_all_mappings_empty() -> None:
         report_names=(),
         ephemeris_names=(),
         contact_names=(),
+        solver_run_names=(),
     )
-    assert out.count("<em>none</em>") == 3
+    assert out.count("<em>none</em>") == 4
 
 
 # --- dataclass shape sanity --------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `Results.solver_runs` — a lazy mapping keyed by `Solver` resource name, one DataFrame per `Target`/`Optimize` run, parsed from the per-solver `.data` iteration log GMAT writes. `Results.converged` is a derived `{solver: bool}` shortcut.
- New pure parser `gmat_run.parsers.solver_log` covers `DifferentialCorrector` (goal quartet: achieved / desired / residual / tolerance) and `Yukon` (cost + per-constraint residual), dispatching on the file header. No `gmatpy` import — unit-tested against committed R2026a fixtures.
- `Mission.run` discovers `Solver` resources, redirects each `ReportFile` into the run workspace (the same rewrite applied to other outputs), and threads `MaximumIterations` through so a max-iteration stop is classified as `max_iter` rather than `failed`.

## Notes

- Convergence is explicit for Yukon (its converged stamp) and **derived** for `DifferentialCorrector` (last-iteration residual vs. tolerance) — its log carries no converged/failed marker.
- A `Solver` no `Target`/`Optimize` block exercises writes nothing and is simply absent from the mapping; a mission with no solver yields `solver_runs == {}`.
- Yukon's `.data` file carries no achieved value, desired bound, or tolerance for a constraint, so its DataFrame surfaces `cost` and `<constraint>_residual` only — see the "Solver iteration logs" known-limitations section.

## Test plan

- [ ] Parser unit tests pass against the three committed fixtures with no GMAT install (99% coverage on the new module).
- [ ] `Results` / `Mission.run` unit tests pass.
- [ ] Integration tests pass on Ubuntu + Windows against R2025a and R2026a: `Ex_GEOTransfer` (DC converges), the same forced to `MaximumIterations=1` (ends `max_iter`, no raise), `Ex_Yukon_AlgebraicOptimization`, and a no-solver mission.
- [ ] `mypy --strict`, `ruff check`, `ruff format --check`, and both coverage gates (overall ≥90%, parsers ≥95%) pass.

Closes #106