### PR TITLE
Fix Mission.summary() crash on missions with branch commands

### DIFF
--- a/src/gmat_run/summary.py
+++ b/src/gmat_run/summary.py
@@ -17,7 +17,7 @@ values — ``mission["Sat.SMA"]`` already serves that need.
 from __future__ import annotations
 
 import html
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
@@ -102,6 +102,16 @@ _RESOURCE_ENUM_ATTRS: Final = (
 # ``GetGeneratingString`` for a Propagate can run hundreds of characters;
 # truncating keeps notebook reprs readable without dropping the leading text.
 _COMMAND_SUMMARY_WIDTH: Final = 100
+
+# Backstops for the command-tree walk. GMAT wires every ``BranchEnd``'s
+# ``GetNext()`` back to the owning branch command, so a naive walk cycles
+# forever. The walkers below break that cycle at the ``BranchEnd``; these caps
+# only matter if a branch command ever fails to report its ``BranchEnd`` (an
+# exotic plugin), in which case the summary degrades to a truncated outline
+# instead of a native stack overflow. Real missions nest a handful of levels
+# deep and no branch command exposes more than a couple of branches.
+_MAX_BRANCH_DEPTH: Final = 64
+_MAX_BRANCH_COUNT: Final = 64
 
 
 # --- dataclasses --------------------------------------------------------------
@@ -343,9 +353,9 @@ def _walk_commands(gmat: ModuleType) -> list[CommandOutline]:
 
     Returns an empty list when the gmat module exposes no ``Moderator`` or
     when ``GetFirstCommand`` raises (fakes that don't model the command
-    graph). ``BeginMissionSequence`` / ``NoOp`` is treated as the sentinel
-    head of the linked list and skipped — real GMAT prepends one even for an
-    empty mission.
+    graph). Real GMAT heads every sequence with a ``NoOp -> BeginMissionSequence``
+    sentinel prefix — every leading ``NoOp`` / ``BeginMissionSequence`` node is
+    skipped, since neither is a user command.
     """
     moderator_proxy = getattr(gmat, "Moderator", None)
     if moderator_proxy is None:
@@ -356,20 +366,13 @@ def _walk_commands(gmat: ModuleType) -> list[CommandOutline]:
         return []
     if first is None:
         return []
-    node = first
-    head_type = _safe_type_name(first)
-    if head_type in {"NoOp", "BeginMissionSequence"}:
-        try:
-            node = first.GetNext()
-        except Exception:
-            return []
+    node: Any = first
+    while node is not None and _safe_type_name(node) in {"NoOp", "BeginMissionSequence"}:
+        node = _safe_next(node)
     outlines: list[CommandOutline] = []
     while node is not None:
         outlines.append(_outline_command(node, depth=0))
-        try:
-            node = node.GetNext()
-        except Exception:
-            break
+        node = _safe_next(node)
     return outlines
 
 
@@ -385,16 +388,11 @@ def _outline_command(node: Any, *, depth: int) -> CommandOutline:
     children: tuple[CommandOutline, ...] = ()
     nested_count = 0
     if depth == 0 and _is_branch(node):
-        child = _safe_child_command(node)
         child_outlines: list[CommandOutline] = []
         nested = 0
-        while child is not None:
+        for child in _iter_branch_children(node):
             child_outlines.append(_outline_command(child, depth=1))
-            nested += _count_descendants(child)
-            try:
-                child = child.GetNext()
-            except Exception:
-                break
+            nested += _count_descendants(child, depth=1)
         children = tuple(child_outlines)
         nested_count = nested
     return CommandOutline(
@@ -405,20 +403,53 @@ def _outline_command(node: Any, *, depth: int) -> CommandOutline:
     )
 
 
-def _count_descendants(node: Any) -> int:
-    """Total nodes nested under ``node`` (depth >= 2 from the top-level)."""
-    if not _is_branch(node):
+def _count_descendants(node: Any, depth: int) -> int:
+    """Total commands nested under ``node`` (depth >= 2 from the top level).
+
+    Recurses through branch bodies via :func:`_iter_branch_children`, which
+    stops at each ``BranchEnd``. ``depth`` is bounded by
+    :data:`_MAX_BRANCH_DEPTH` purely as a backstop: if a branch command ever
+    fails to expose its ``BranchEnd`` the count is silently truncated rather
+    than overflowing the native stack (issue #114).
+    """
+    if depth >= _MAX_BRANCH_DEPTH or not _is_branch(node):
         return 0
     count = 0
-    child = _safe_child_command(node)
-    while child is not None:
+    for child in _iter_branch_children(node):
         count += 1
-        count += _count_descendants(child)
-        try:
-            child = child.GetNext()
-        except Exception:
-            break
+        count += _count_descendants(child, depth + 1)
     return count
+
+
+def _iter_branch_children(node: Any) -> Iterator[Any]:
+    """Yield the body commands of every branch of a branch command.
+
+    GMAT terminates each branch with a ``BranchEnd`` marker (``EndTarget`` /
+    ``EndIf`` / ...) whose ``GetNext()`` points *back* at the owning branch
+    command. The walk therefore stops at the first ``BranchEnd`` — that node is
+    neither yielded nor followed — which keeps it inside the branch instead of
+    looping back and running off into the rest of the mission sequence
+    (issue #114).
+
+    Every branch is enumerated: ``GetChildCommand(0)``, ``GetChildCommand(1)``,
+    ... until the engine returns ``None``, so an ``If``/``Else`` contributes
+    both arms.
+
+    There is deliberately no ``id()``-based cycle guard. gmatpy hands out a
+    fresh SWIG proxy per call, so proxy identity tracks neither the underlying
+    C++ command (false negatives) nor — once a proxy is freed and CPython
+    recycles its address — distinct commands (false positives that silently
+    truncate a valid walk). The ``BranchEnd`` stop here and the depth cap in
+    :func:`_count_descendants` bound the walk without relying on identity;
+    following ``GetNext()`` alone always terminates at the end of the sequence.
+    """
+    for index in range(_MAX_BRANCH_COUNT):
+        child = _safe_child_command(node, index)
+        if child is None:
+            break
+        while child is not None and not _is_branch_end(child):
+            yield child
+            child = _safe_next(child)
 
 
 def _command_summary(node: Any) -> str:
@@ -447,15 +478,45 @@ def _is_branch(node: Any) -> bool:
         return False
 
 
-def _safe_child_command(node: Any) -> Any:
-    """``GetChildCommand()`` tolerant of nullary vs. indexed signatures."""
+def _is_branch_end(node: Any) -> bool:
+    """True if ``node`` is a branch terminator (``EndTarget`` / ``EndIf`` / …).
+
+    GMAT wires every ``BranchEnd``'s ``GetNext()`` back to the owning branch
+    command, so a child walk must stop at one rather than follow it — see
+    :func:`_iter_branch_children`.
+    """
     try:
-        return node.GetChildCommand()
+        return bool(node.IsOfType("BranchEnd"))
+    except Exception:
+        return False
+
+
+def _safe_child_command(node: Any, index: int) -> Any:
+    """``GetChildCommand(index)`` tolerant of fakes and plugin commands.
+
+    Real gmatpy exposes ``GetChildCommand(Integer whichOne=0)`` and returns
+    ``None`` for an out-of-range index — that is how
+    :func:`_iter_branch_children` discovers a branch command's branch count.
+    The nullary fallback covers a hypothetical binding that omits the
+    parameter entirely.
+    """
+    try:
+        return node.GetChildCommand(index)
     except TypeError:
+        if index != 0:
+            return None
         try:
-            return node.GetChildCommand(0)
+            return node.GetChildCommand()
         except Exception:
             return None
+    except Exception:
+        return None
+
+
+def _safe_next(node: Any) -> Any:
+    """``GetNext()`` tolerant of fakes and plugin commands that raise."""
+    try:
+        return node.GetNext()
     except Exception:
         return None
 

--- a/tests/integration/test_summary.py
+++ b/tests/integration/test_summary.py
@@ -6,6 +6,11 @@ resources, and command sequence as gmatpy reports them. Also locks in the
 contract that both :class:`Mission` and :class:`Results` have non-default
 ``__repr__`` and ``_repr_html_`` methods — the issue's acceptance criterion
 that the address-style repr is gone.
+
+The ``Ex_GEOTransfer`` fixture additionally exercises a mission built from
+``Target`` blocks: GMAT loops each ``EndTarget`` back to its owning ``Target``,
+which used to send ``summary()`` into unbounded recursion and a SIGSEGV
+(issue #114). These tests are the regression guard for that crash.
 """
 
 from __future__ import annotations
@@ -19,11 +24,18 @@ from gmat_run import Mission
 pytestmark = pytest.mark.integration
 
 _FIXTURE = Path(__file__).parent / "fixtures" / "Ex_LEOEphemeris.script"
+_GEO_FIXTURE = Path(__file__).parent / "fixtures" / "Ex_GEOTransfer.script"
 
 
 @pytest.fixture(scope="module")
 def loaded_mission(gmat_available: None) -> Mission:
     return Mission.load(_FIXTURE)
+
+
+@pytest.fixture(scope="module")
+def geo_mission(gmat_available: None) -> Mission:
+    """A mission whose sequence contains three ``Target`` branch blocks."""
+    return Mission.load(_GEO_FIXTURE)
 
 
 def test_summary_lists_named_resources(loaded_mission: Mission) -> None:
@@ -87,3 +99,57 @@ def test_results_repr_and_repr_html_are_not_default(loaded_mission: Mission) -> 
         # module-scoped Mission fixture goes out of scope (Windows file
         # handles get cranky otherwise).
         del result
+
+
+# --- branch-bearing mission (issue #114 regression) --------------------------
+
+
+def test_summary_returns_on_branch_mission(geo_mission: Mission) -> None:
+    # The core regression: summary() used to recurse through each Target's
+    # EndTarget loopback and crash the process with SIGSEGV. Reaching this
+    # assertion at all means the walk terminated.
+    summary = geo_mission.summary()
+    assert summary.script_name == "Ex_GEOTransfer.script"
+    assert summary.command_count >= 1
+
+
+def test_summary_outlines_top_level_branch_sequence(geo_mission: Mission) -> None:
+    summary = geo_mission.summary()
+    types = [c.type_name for c in summary.commands]
+    # NoOp / BeginMissionSequence sentinels are dropped; three Target blocks
+    # sit between the Propagate commands of the transfer.
+    assert types == [
+        "Propagate",
+        "Target",
+        "Propagate",
+        "Propagate",
+        "Target",
+        "Target",
+        "Propagate",
+    ]
+
+
+def test_target_block_children_are_summarised_one_level_deep(
+    geo_mission: Mission,
+) -> None:
+    summary = geo_mission.summary()
+    targets = [c for c in summary.commands if c.type_name == "Target"]
+    assert len(targets) == 3
+    # The 'Raise Apogee' Target body, with the EndTarget marker excluded.
+    assert [c.type_name for c in targets[0].children] == [
+        "Vary",
+        "Maneuver",
+        "Propagate",
+        "Achieve",
+    ]
+    # The targeter bodies are flat — no commands nested below depth one.
+    assert all(t.nested_count == 0 for t in targets)
+
+
+def test_branch_mission_repr_and_repr_html_render(geo_mission: Mission) -> None:
+    text = repr(geo_mission)
+    assert text.startswith("Mission(")
+    assert "<gmat_run.mission.Mission object" not in text
+    html_str = geo_mission._repr_html_()
+    assert "<table" in html_str
+    assert "Target" in html_str

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -14,9 +14,9 @@ from __future__ import annotations
 from itertools import pairwise
 from pathlib import Path
 from types import ModuleType
-from typing import Any
 
 from gmat_run.summary import (
+    _MAX_BRANCH_DEPTH,
     CommandOutline,
     MissionSummary,
     ResourceGroup,
@@ -57,7 +57,14 @@ class _FakeBase:
 
 
 class _FakeCommand:
-    """Stand-in for a GmatCommand node in the mission sequence."""
+    """Stand-in for a GmatCommand node in the mission sequence.
+
+    ``children`` holds one linked-list head per branch, so ``GetChildCommand``
+    is indexed: ``If``/``Else`` exposes two branches, every other branch
+    command exposes one. ``is_branch_end`` models a ``BranchEnd`` terminator
+    (``EndTarget`` / ``EndIf`` / ...); see :func:`_make_branch` for how GMAT
+    wires one back to its owning branch command.
+    """
 
     def __init__(
         self,
@@ -66,11 +73,13 @@ class _FakeCommand:
         generating: str = "",
         children: list[_FakeCommand] | None = None,
         is_branch: bool = False,
+        is_branch_end: bool = False,
     ) -> None:
         self._type = type_name
         self._generating = generating
         self._children = children or []
         self._is_branch = is_branch
+        self._is_branch_end = is_branch_end
         self._next: _FakeCommand | None = None
 
     def GetTypeName(self) -> str:
@@ -82,13 +91,17 @@ class _FakeCommand:
     def IsOfType(self, type_name: str) -> bool:
         if type_name == "BranchCommand":
             return self._is_branch
+        if type_name == "BranchEnd":
+            return self._is_branch_end
         return type_name == self._type
 
     def GetNext(self) -> _FakeCommand | None:
         return self._next
 
-    def GetChildCommand(self, *_args: Any) -> _FakeCommand | None:
-        return self._children[0] if self._children else None
+    def GetChildCommand(self, index: int = 0) -> _FakeCommand | None:
+        if 0 <= index < len(self._children):
+            return self._children[index]
+        return None
 
 
 def _link(*commands: _FakeCommand) -> _FakeCommand:
@@ -96,6 +109,45 @@ def _link(*commands: _FakeCommand) -> _FakeCommand:
     for prev, nxt in pairwise(commands):
         prev._next = nxt
     return commands[0]
+
+
+def _make_branch(
+    branch_cmd: _FakeCommand,
+    *body: _FakeCommand,
+    end_type: str = "EndTarget",
+) -> _FakeCommand:
+    """Wire ``body`` as ``branch_cmd``'s single branch, GMAT-style.
+
+    The branch body ends with a ``BranchEnd`` marker whose ``GetNext()`` loops
+    *back* to the owning branch command — the exact shape that sent the old
+    walker into unbounded recursion (issue #114). Returns ``branch_cmd``.
+    """
+    end = _FakeCommand(end_type, is_branch_end=True)
+    head = _link(*body, end)
+    end._next = branch_cmd
+    branch_cmd._children = [head]
+    return branch_cmd
+
+
+def _make_if_else(
+    if_cmd: _FakeCommand,
+    true_body: list[_FakeCommand],
+    else_body: list[_FakeCommand],
+) -> _FakeCommand:
+    """Wire ``if_cmd`` as a two-branch command (true arm + else arm).
+
+    Each arm is its own linked list terminated by an ``EndIf`` ``BranchEnd``
+    that loops back to ``if_cmd``, so the walker must enumerate both
+    ``GetChildCommand(0)`` and ``GetChildCommand(1)``. Returns ``if_cmd``.
+    """
+    branches: list[_FakeCommand] = []
+    for body in (true_body, else_body):
+        end = _FakeCommand("EndIf", is_branch_end=True)
+        head = _link(*body, end)
+        end._next = if_cmd
+        branches.append(head)
+    if_cmd._children = branches
+    return if_cmd
 
 
 def _make_gmat(
@@ -312,6 +364,19 @@ def test_command_walk_skips_no_op_head() -> None:
     assert [c.type_name for c in summary.commands] == ["Propagate"]
 
 
+def test_command_walk_skips_noop_and_begin_mission_sequence_prefix() -> None:
+    # Real GMAT heads every sequence with a two-node NoOp -> BeginMissionSequence
+    # sentinel prefix; both are dropped so the first user command leads.
+    head = _link(
+        _FakeCommand("NoOp"),
+        _FakeCommand("BeginMissionSequence"),
+        _FakeCommand("Propagate", generating="Propagate Prop(Sat);"),
+        _FakeCommand("Maneuver", generating="Maneuver TOI(Sat);"),
+    )
+    summary = build_mission_summary(_make_gmat(first_command=head), Path("seq.script"))
+    assert [c.type_name for c in summary.commands] == ["Propagate", "Maneuver"]
+
+
 def test_branch_command_renders_children_one_level_deep() -> None:
     vary1 = _FakeCommand("Vary", generating="Vary DC(TOI.Element1 = 0.5);")
     vary2 = _FakeCommand("Vary", generating="Vary DC(TOI.Element2 = 0.5);")
@@ -376,6 +441,72 @@ def test_branch_with_no_children_renders_empty() -> None:
     (cmd,) = summary.commands
     assert cmd.children == ()
     assert cmd.nested_count == 0
+
+
+def test_branch_walk_stops_at_branch_end_and_does_not_loop() -> None:
+    # Regression for issue #114: GMAT wires a Target's EndTarget so its
+    # GetNext() points back at the Target. The walk must stop at the EndTarget
+    # rather than follow it into unbounded recursion / off into the trailing
+    # mission sequence.
+    target = _FakeCommand("Target", generating="Target DC;", is_branch=True)
+    _make_branch(
+        target,
+        _FakeCommand("Vary", generating="Vary DC(TOI.Element1 = 0.5);"),
+        _FakeCommand("Maneuver", generating="Maneuver TOI(geoSat);"),
+        _FakeCommand("Propagate", generating="Propagate Prop(geoSat);"),
+        _FakeCommand("Achieve", generating="Achieve DC(geoSat.RMAG = 85000);"),
+    )
+    trailing = _FakeCommand("Propagate", generating="Propagate Prop(geoSat);")
+    target._next = trailing
+    summary = build_mission_summary(
+        _make_gmat(first_command=_link(_FakeCommand("BeginMissionSequence"), target)),
+        Path("geo.script"),
+    )
+    assert [c.type_name for c in summary.commands] == ["Target", "Propagate"]
+    outline = summary.commands[0]
+    # EndTarget is excluded; the walk never loops back or swallows `trailing`.
+    assert [c.type_name for c in outline.children] == [
+        "Vary",
+        "Maneuver",
+        "Propagate",
+        "Achieve",
+    ]
+    assert outline.nested_count == 0
+
+
+def test_branch_walk_enumerates_both_arms_of_if_else() -> None:
+    # If/Else exposes two branches; GetChildCommand(0) and GetChildCommand(1)
+    # must both be walked so the else arm is not dropped.
+    if_cmd = _FakeCommand("If", generating="If geoSat.SMA > 7000;", is_branch=True)
+    _make_if_else(
+        if_cmd,
+        true_body=[_FakeCommand("Propagate", generating="Propagate Prop(geoSat);")],
+        else_body=[_FakeCommand("Maneuver", generating="Maneuver TOI(geoSat);")],
+    )
+    summary = build_mission_summary(
+        _make_gmat(first_command=_link(_FakeCommand("BeginMissionSequence"), if_cmd)),
+        Path("ifelse.script"),
+    )
+    (cmd,) = summary.commands
+    assert cmd.type_name == "If"
+    assert [c.type_name for c in cmd.children] == ["Propagate", "Maneuver"]
+
+
+def test_count_descendants_saturates_at_max_branch_depth() -> None:
+    # Defence in depth: a pathologically deep nest is summarised with a
+    # truncated nested_count rather than overflowing the recursion backstop.
+    node = _FakeCommand("Propagate", generating="Propagate Prop(geoSat);")
+    for _ in range(_MAX_BRANCH_DEPTH + 20):
+        branch = _FakeCommand("For", generating="For I = 1:1;", is_branch=True)
+        node = _make_branch(branch, node, end_type="EndFor")
+    summary = build_mission_summary(
+        _make_gmat(first_command=_link(_FakeCommand("BeginMissionSequence"), node)),
+        Path("deep.script"),
+    )
+    (cmd,) = summary.commands
+    assert cmd.type_name == "For"
+    # The depth-1 child plus every level the backstop still recurses through.
+    assert cmd.nested_count == _MAX_BRANCH_DEPTH - 1
 
 
 def test_command_summary_truncated_to_width() -> None:


### PR DESCRIPTION
## Summary

- `Mission.summary()` (and `repr` / `_repr_html_`) crashed the process with a SIGSEGV on any mission containing a branch command. GMAT wires each `BranchEnd` (`EndTarget`, `EndIf`, …) so its `GetNext()` loops back to the owning branch command; the command-tree walk followed that link and recursed until the native stack overflowed. The walk now stops at each `BranchEnd`, enumerates every branch via `GetChildCommand(i)` (so `If`/`Else` contributes both arms), and bounds the descendant-count recursion with a depth cap. No `id()`-based cycle guard — gmatpy hands out a fresh SWIG proxy per call, so recycled proxy addresses produce false positives that truncate a valid walk (this surfaced only against real gmatpy, not the unit fakes).
- Adjacent fix: `_walk_commands` skipped only one sentinel head, but real GMAT heads every sequence with `NoOp -> BeginMissionSequence`, so `BeginMissionSequence` leaked in as the first command of every mission. The skip now consumes the whole sentinel prefix.
- Regression coverage added at both layers: unit tests model the `BranchEnd` loopback in the fakes, and a new `Ex_GEOTransfer.script` integration test exercises `summary()` against a real three-`Target` mission.

## Test plan

- [x] `uv run pytest` — 798 passed (unit + integration)
- [x] `uv run pytest -m integration tests/integration/test_summary.py` — 10 passed against GMAT R2026a
- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run mypy` — clean
- [x] Coverage gates: overall 95% (≥90), `parsers/` 98% (≥95)

Closes #114
