### PR TITLE
Fix repeated Mission.run() writing into the first run's directory

### DIFF
--- a/src/gmat_run/mission.py
+++ b/src/gmat_run/mission.py
@@ -86,6 +86,13 @@ _SPACECRAFT_TYPE_ENUM_ATTR: Final = "SPACECRAFT"
 # iteration logs. Probed with the same defensive ``getattr`` as the others.
 _SOLVER_TYPE_ENUM_ATTR: Final = "SOLVER"
 
+# One engine path field rewritten for the duration of a single run(): the
+# resource name, the field name (``"Filename"`` / ``"ReportFile"``), and the
+# value the field held before the rewrite. run() rolls each of these back in a
+# finally so the engine field reflects the loaded script between runs — see
+# Mission._restore_output_paths and issue #115.
+_OutputPathRestore = tuple[str, str, str]
+
 
 class _LazyAttitudeInputs(Mapping[str, pd.DataFrame]):
     """Mapping view over CCSDS-AEM files referenced by Spacecraft resources.
@@ -353,8 +360,13 @@ class Mission:
         and the run honours it. The rewrite is the only mechanism GMAT
         actually consults at write time; ``FileManager.OUTPUT_PATH`` is
         cached per-subscriber at Initialize time and ignored thereafter.
-        After :meth:`run` returns, reading ``mission["RF.Filename"]`` yields
-        the resolved absolute path, which points at the file on disk.
+        The rewrite is reverted once the run is over — reading
+        ``mission["RF.Filename"]`` afterwards yields the script's declared
+        value again, not the workspace path. ``Mission`` stays a view of the
+        loaded script (as with :attr:`attitude_inputs`); the resolved output
+        locations live on the returned :class:`Results`. Each :meth:`run`
+        therefore redirects independently of any earlier run on the same
+        ``Mission``.
 
         **Solver logs.** Every ``Target`` / ``Optimize`` run writes a
         per-``Solver`` ``.data`` iteration log. Its ``<Solver>.ReportFile``
@@ -427,82 +439,101 @@ class Mission:
         # has been parsed: the resolved absolute path is cached on each
         # subscriber, and overriding the Filename field is the only setting
         # the engine consults at write time.
-        report_paths, ephemeris_paths, contact_paths = self._rewrite_output_paths(workspace_path)
+        report_paths, ephemeris_paths, contact_paths, sub_restores = self._rewrite_output_paths(
+            workspace_path
+        )
         # Solver .data logs are redirected the same way. The returned paths are
         # *expected* locations — a Solver no Target/Optimize block exercises
         # writes nothing, so existence is rechecked after the run below.
-        solver_expected, solver_max_iterations = self._discover_solver_outputs(workspace_path)
+        solver_expected, solver_max_iterations, solver_restores = self._discover_solver_outputs(
+            workspace_path
+        )
         all_paths = (
             *report_paths.values(),
             *ephemeris_paths.values(),
             *contact_paths.values(),
             *solver_expected.values(),
         )
-        # Pre-run gate: pre-existing artefacts inside working_dir. Bounded to
-        # *resolved* output paths that live under workspace_path — absolute
-        # filenames pinned by the script outside the workspace are the user's
-        # destination and we honour them. Default raises; overwrite=True
-        # unlinks the colliding files first.
-        _check_inside_workspace_collisions(workspace_path, all_paths, overwrite=overwrite)
-        log_path = workspace_path / "GmatLog.txt"
-
-        self._gmat.UseLogFile(str(log_path))
-
-        api_exception = _get_api_exception(self._gmat)
+        # Both helpers pinned relative engine path fields into workspace_path.
+        # Roll them back once the run is over — success or failure — so the
+        # next run() on this Mission redirects from the script's declared
+        # Filename instead of this run's workspace (issue #115).
+        restores = [*sub_restores, *solver_restores]
         try:
-            status = int(self._gmat.RunScript())
-        except api_exception as exc:
+            # Pre-run gate: pre-existing artefacts inside working_dir. Bounded
+            # to *resolved* output paths that live under workspace_path —
+            # absolute filenames pinned by the script outside the workspace are
+            # the user's destination and we honour them. Default raises;
+            # overwrite=True unlinks the colliding files first.
+            _check_inside_workspace_collisions(workspace_path, all_paths, overwrite=overwrite)
+            log_path = workspace_path / "GmatLog.txt"
+
+            self._gmat.UseLogFile(str(log_path))
+
+            api_exception = _get_api_exception(self._gmat)
+            try:
+                status = int(self._gmat.RunScript())
+            except api_exception as exc:
+                log = _safe_read(log_path)
+                self._release_log_handle()
+                raise GmatRunError(
+                    f"GMAT raised {type(exc).__name__} during RunScript: {exc}",
+                    log=log,
+                ) from exc
+
             log = _safe_read(log_path)
+            # Repoint UseLogFile away from the workspace before yielding
+            # control. GMAT's MessageInterface holds the log file open for the
+            # lifetime of the gmatpy module, so on Windows any later attempt to
+            # delete the temp workspace (Results.persist, GC of the
+            # TemporaryDirectory) hits WinError 32 on GmatLog.txt. Redirecting
+            # to os.devnull closes the workspace handle; the log content has
+            # already been captured into ``log`` above. Subsequent GMAT
+            # operations log to the null sink until the next mission.run()
+            # repoints the handle again — accepted, since gmat-run's public
+            # surface ends at Results.
             self._release_log_handle()
-            raise GmatRunError(
-                f"GMAT raised {type(exc).__name__} during RunScript: {exc}",
-                log=log,
-            ) from exc
+            if status != _RUNSCRIPT_OK:
+                raise GmatRunError(
+                    f"GMAT RunScript returned status {status}; expected {_RUNSCRIPT_OK}",
+                    log=log,
+                )
 
-        log = _safe_read(log_path)
-        # Repoint UseLogFile away from the workspace before yielding control.
-        # GMAT's MessageInterface holds the log file open for the lifetime of
-        # the gmatpy module, so on Windows any later attempt to delete the
-        # temp workspace (Results.persist, GC of the TemporaryDirectory) hits
-        # WinError 32 on GmatLog.txt. Redirecting to os.devnull closes the
-        # workspace handle; the log content has already been captured into
-        # ``log`` above. Subsequent GMAT operations log to the null sink
-        # until the next mission.run() repoints the handle again — accepted,
-        # since gmat-run's public surface ends at Results.
-        self._release_log_handle()
-        if status != _RUNSCRIPT_OK:
-            raise GmatRunError(
-                f"GMAT RunScript returned status {status}; expected {_RUNSCRIPT_OK}",
+            # Out-of-workspace notice: any output the script pinned at an
+            # absolute path outside workspace_path gets a one-line summary at
+            # the top of the captured log so callers see the trail without
+            # having to re-walk the path mappings themselves.
+            notice = _format_outside_workspace_notice(workspace_path, all_paths)
+            if notice:
+                log = notice + log
+
+            # Keep only the solver logs GMAT actually wrote — a declared-but-
+            # unused Solver leaves the no-solver mapping empty rather than
+            # raising.
+            solver_paths = {n: p for n, p in solver_expected.items() if p.exists()}
+            results = Results(
+                output_dir=workspace_path,
                 log=log,
+                report_paths=report_paths,
+                ephemeris_paths=ephemeris_paths,
+                contact_paths=contact_paths,
+                solver_paths=solver_paths,
+                solver_max_iterations={
+                    n: solver_max_iterations[n] for n in solver_paths if n in solver_max_iterations
+                },
             )
-
-        # Out-of-workspace notice: any output the script pinned at an absolute
-        # path outside workspace_path gets a one-line summary at the top of
-        # the captured log so callers see the trail without having to re-walk
-        # the path mappings themselves.
-        notice = _format_outside_workspace_notice(workspace_path, all_paths)
-        if notice:
-            log = notice + log
-
-        # Keep only the solver logs GMAT actually wrote — a declared-but-unused
-        # Solver leaves the no-solver mapping empty rather than raising.
-        solver_paths = {n: p for n, p in solver_expected.items() if p.exists()}
-        results = Results(
-            output_dir=workspace_path,
-            log=log,
-            report_paths=report_paths,
-            ephemeris_paths=ephemeris_paths,
-            contact_paths=contact_paths,
-            solver_paths=solver_paths,
-            solver_max_iterations={
-                n: solver_max_iterations[n] for n in solver_paths if n in solver_max_iterations
-            },
-        )
-        # See project memory `gmat-run Mission.run temp-dir lifetime ties to
-        # Results`: the temp dir must outlive Mission.run so lazy report
-        # parsing on `result.reports[name]` still finds the file on disk.
-        results._workspace = tempdir
-        return results
+            # See project memory `gmat-run Mission.run temp-dir lifetime ties
+            # to Results`: the temp dir must outlive Mission.run so lazy report
+            # parsing on `result.reports[name]` still finds the file on disk.
+            results._workspace = tempdir
+            return results
+        finally:
+            # Engine path fields are pinned only for the duration of the run.
+            # Restoring them here — on the success return, on a GmatRunError,
+            # and on the pre-run collision gate — keeps the subscriber and
+            # solver fields reflecting the loaded script, so the next run()
+            # resolves its outputs afresh. Resolved paths live on Results.
+            self._restore_output_paths(restores)
 
     def _warn_if_workspace_is_script_dir(self, workspace_path: Path) -> None:
         """Emit a UserWarning if ``workspace_path`` resolves to the script's directory.
@@ -590,7 +621,7 @@ class Mission:
 
     def _rewrite_output_paths(
         self, workspace_path: Path
-    ) -> tuple[dict[str, Path], dict[str, Path], dict[str, Path]]:
+    ) -> tuple[dict[str, Path], dict[str, Path], dict[str, Path], list[_OutputPathRestore]]:
         """Bucket subscriber output paths and pin each one to ``workspace_path``.
 
         Walks every ``ReportFile`` / ``EphemerisFile`` / ``ContactLocator`` in
@@ -601,14 +632,25 @@ class Mission:
         return bucket. Resilient to missing type-enum attributes and broken
         objects — skips quietly rather than aborting the whole run.
 
+        Every relative ``Filename`` that gets rewritten also yields a restore
+        entry — ``(resource_name, "Filename", declared_value)`` — so
+        :meth:`run` can return the engine field to its script-declared state
+        once the run is over (see :meth:`_restore_output_paths`). Without that
+        rollback the rewritten absolute path would survive into the next
+        ``run()``, where the ``is_absolute()`` check below would mistake it for
+        a user-pinned destination and skip the redirect (issue #115). An
+        absolute ``Filename`` is left untouched and produces no restore entry.
+
         Returns:
-            ``(report_paths, ephemeris_paths, contact_paths)`` keyed by
-            resource name.
+            ``(report_paths, ephemeris_paths, contact_paths, restores)``. The
+            three path maps are keyed by resource name; ``restores`` is the
+            list of rewritten fields :meth:`run` must roll back afterwards.
         """
         moderator = self._gmat.Moderator.Instance()
         reports: dict[str, Path] = {}
         ephemerides: dict[str, Path] = {}
         contacts: dict[str, Path] = {}
+        restores: list[_OutputPathRestore] = []
         bucket = {
             "ReportFile": reports,
             "EphemerisFile": ephemerides,
@@ -648,12 +690,15 @@ class Mission:
                     resolved = workspace_path / path.name
                     with suppress(Exception):
                         obj.SetField("Filename", str(resolved))
+                        # Only recorded once SetField has actually landed —
+                        # a suppressed failure leaves nothing to restore.
+                        restores.append((name, "Filename", declared))
                 bucket[type_name][name] = resolved
-        return reports, ephemerides, contacts
+        return reports, ephemerides, contacts, restores
 
     def _discover_solver_outputs(
         self, workspace_path: Path
-    ) -> tuple[dict[str, Path], dict[str, int]]:
+    ) -> tuple[dict[str, Path], dict[str, int], list[_OutputPathRestore]]:
         """Enumerate ``Solver`` resources and pin each ``.data`` log to the workspace.
 
         Walks every ``Solver`` resource via ``Moderator.GetListOfObjects``. For
@@ -669,21 +714,27 @@ class Mission:
         Resilient to a missing ``SOLVER`` enum and to broken objects — skips
         quietly rather than aborting the run.
 
+        Each rewritten ``ReportFile`` yields a restore entry, exactly as in
+        :meth:`_rewrite_output_paths`, so :meth:`run` can roll the engine
+        field back to its declared value once the run is over (issue #115).
+
         Returns:
-            ``(paths, max_iterations)`` keyed by solver resource name. The
-            paths are *expected* locations; :meth:`run` rechecks existence
-            after the run, since an unexercised ``Solver`` writes nothing.
+            ``(paths, max_iterations, restores)`` keyed by solver resource
+            name (``restores`` is a flat list). The paths are *expected*
+            locations; :meth:`run` rechecks existence after the run, since an
+            unexercised ``Solver`` writes nothing.
         """
         type_id = getattr(self._gmat, _SOLVER_TYPE_ENUM_ATTR, None)
         if type_id is None:
-            return {}, {}
+            return {}, {}, []
         moderator = self._gmat.Moderator.Instance()
         try:
             names = list(moderator.GetListOfObjects(type_id))
         except Exception:
-            return {}, {}
+            return {}, {}, []
         paths: dict[str, Path] = {}
         max_iterations: dict[str, int] = {}
+        restores: list[_OutputPathRestore] = []
         for name in names:
             obj = self._gmat.GetObject(name)
             if obj is None:
@@ -702,10 +753,35 @@ class Mission:
                 resolved = workspace_path / path.name
                 with suppress(Exception):
                     obj.SetField("ReportFile", str(resolved))
+                    # Recorded only after SetField lands — see the matching
+                    # note in _rewrite_output_paths.
+                    restores.append((name, "ReportFile", declared))
             paths[name] = resolved
             with suppress(Exception):
                 max_iterations[name] = int(float(str(obj.GetField("MaximumIterations"))))
-        return paths, max_iterations
+        return paths, max_iterations, restores
+
+    def _restore_output_paths(self, restores: Iterable[_OutputPathRestore]) -> None:
+        """Roll back the engine path fields rewritten for one :meth:`run` call.
+
+        Each entry pairs a resource name with the field it owns and the value
+        that field held before :meth:`_rewrite_output_paths` /
+        :meth:`_discover_solver_outputs` pinned it into the run's workspace.
+        Restoring them leaves every subscriber and solver reflecting the
+        *loaded script* once the run is over, so a second :meth:`run` on the
+        same :class:`Mission` redirects from the originally declared
+        ``Filename`` rather than the previous run's workspace (issue #115).
+
+        The resource is re-fetched by name rather than carried as a live SWIG
+        proxy — gmatpy hands back a fresh proxy per call, so the name is the
+        stable handle. Each ``SetField`` is best-effort: a failure to roll
+        back must not mask the run's real outcome, so it is suppressed.
+        """
+        for name, field, original in restores:
+            with suppress(Exception):
+                obj = self._gmat.GetObject(name)
+                if obj is not None:
+                    obj.SetField(field, original)
 
     # --- internal helpers -----------------------------------------------------
 

--- a/tests/integration/test_rerun.py
+++ b/tests/integration/test_rerun.py
@@ -1,0 +1,91 @@
+"""End-to-end regression for re-running one :class:`Mission` (issue #115).
+
+Loading a ``Mission`` once and calling :meth:`Mission.run` more than once must
+keep the runs independent: each run redirects its outputs into that run's own
+workspace. The first run rewrites every relative subscriber ``Filename`` to an
+absolute path in its workspace; the regression was that this rewrite survived
+into the next run, where it was mistaken for a user-pinned destination and the
+redirect was skipped — so the second run's report landed in the first run's
+directory.
+
+The script is written inline so the test does not depend on which stock
+samples ship with a given GMAT release.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gmat_run import Mission
+
+pytestmark = pytest.mark.integration
+
+
+_SCRIPT = """\
+Create Spacecraft Sat
+Sat.DateFormat = UTCGregorian
+Sat.Epoch = '01 Jan 2026 12:00:00.000'
+Sat.CoordinateSystem = EarthMJ2000Eq
+Sat.DisplayStateType = Keplerian
+Sat.SMA = 7000
+Sat.ECC = 0.001
+Sat.INC = 28.5
+Sat.RAAN = 75
+Sat.AOP = 90
+Sat.TA = 0
+
+Create ForceModel FM
+FM.CentralBody = Earth
+FM.PrimaryBodies = {Earth}
+
+Create Propagator Prop
+Prop.FM = FM
+Prop.Type = PrinceDormand78
+Prop.InitialStepSize = 60
+Prop.Accuracy = 1e-9
+
+Create ReportFile RF
+RF.Filename = 'leo_state.txt'
+RF.Add = {Sat.UTCGregorian, Sat.X, Sat.Y, Sat.Z, Sat.SMA}
+RF.WriteHeaders = True
+
+BeginMissionSequence
+Propagate Prop(Sat) {Sat.ElapsedSecs = 600}
+"""
+
+
+@pytest.fixture
+def rerun_script(tmp_path: Path) -> Path:
+    """Write the inline mission script into ``tmp_path`` and return its path."""
+    script_path = tmp_path / "rerun_leo.script"
+    script_path.write_text(_SCRIPT, encoding="utf-8")
+    return script_path
+
+
+def test_rerun_redirects_each_run_into_its_own_workspace(
+    gmat_available: None,
+    rerun_script: Path,
+) -> None:
+    mission = Mission.load(rerun_script)
+
+    first = mission.run()
+    second = mission.run()
+
+    # Distinct temp workspaces — both stay alive while their Results are held.
+    assert first.output_dir != second.output_dir
+
+    first_report = first.reports._paths["RF"]  # type: ignore[attr-defined]
+    second_report = second.reports._paths["RF"]  # type: ignore[attr-defined]
+
+    # Each run's report landed under that run's own workspace, on disk —
+    # before the fix the second run's report lived under first.output_dir.
+    assert first_report.parent == first.output_dir
+    assert first_report.is_file()
+    assert second_report.parent == second.output_dir
+    assert second_report.is_file()
+
+    # Between runs the engine field reflects the script's declared value, not
+    # a workspace path — that is what keeps the redirect working a second time.
+    assert mission["RF.Filename"] == "leo_state.txt"

--- a/tests/integration/test_solver_runs.py
+++ b/tests/integration/test_solver_runs.py
@@ -62,9 +62,12 @@ def test_geotransfer_differential_corrector_converges(gmat_available: None, tmp_
     assert result.converged == {"DC": True}
 
     # The .data log was redirected into the run workspace, like every other
-    # output, and reading the field back yields that resolved path.
-    report_file = mission["DC.ReportFile"]
-    assert Path(report_file).parent == result.output_dir
+    # output — Results.solver_paths carries the resolved location.
+    assert result.solver_paths["DC"].parent == result.output_dir
+    # The rewrite is reverted once the run is over, so the engine field
+    # reflects the loaded script again and a second run() redirects afresh
+    # (issue #115).
+    assert mission["DC.ReportFile"] == "DifferentialCorrectorDC1.data"
 
 
 def test_geotransfer_max_iterations_one_ends_max_iter(gmat_available: None, tmp_path: Path) -> None:

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -1090,12 +1090,62 @@ class TestMissionRun:
         rf = _report_file("RF", "rel.txt")
         mission, _ = _run_mission(tmp_path, objects={"RF": rf})
         result = mission.run()
-        # Filename was rewritten on the underlying object…
+        # Filename was rewritten on the underlying object for the run…
         assert ("Filename", str(result.output_dir / "rel.txt")) in rf.set_calls
         # …and Results captures the same resolved path.
         assert result.reports._paths == {  # type: ignore[attr-defined]
             "RF": result.output_dir / "rel.txt"
         }
+        # …but the rewrite is reverted once the run is over, so the engine
+        # field reflects the loaded script again rather than the workspace.
+        assert mission["RF.Filename"] == "rel.txt"
+
+    def test_second_run_redirects_into_its_own_workspace(self, tmp_path: Path) -> None:
+        # Issue #115: a second run() on the same Mission must send its output
+        # into the second run's workspace, not the first's. Before the fix the
+        # first run left an absolute Filename on the subscriber, which the
+        # second run mistook for a user-pinned destination and never
+        # redirected — so run #2's report landed back in run #1's directory.
+        rf = _report_file("RF", "rel.txt")
+        mission, _ = _run_mission(tmp_path, objects={"RF": rf})
+
+        first = mission.run()
+        second = mission.run()
+
+        assert first.output_dir != second.output_dir
+        # Each run's report is bucketed under that run's own workspace.
+        assert first.reports._paths == {  # type: ignore[attr-defined]
+            "RF": first.output_dir / "rel.txt"
+        }
+        assert second.reports._paths == {  # type: ignore[attr-defined]
+            "RF": second.output_dir / "rel.txt"
+        }
+
+    def test_run_restores_filename_after_failed_run(self, tmp_path: Path) -> None:
+        # A run that fails its status check must still revert the Filename
+        # rewrite, or the next run() inherits the stale absolute path.
+        rf = _report_file("RF", "rel.txt")
+        mission, _ = _run_mission(tmp_path, objects={"RF": rf}, run_script_status=-5)
+
+        with pytest.raises(GmatRunError):
+            mission.run()
+
+        assert mission["RF.Filename"] == "rel.txt"
+
+    def test_run_restores_filename_when_collision_gate_raises(self, tmp_path: Path) -> None:
+        # The pre-run collision gate raises *after* the Filename rewrite, so
+        # the finally-restore is the only thing keeping a gated run from
+        # poisoning the next one.
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        (workspace / "rel.txt").write_text("stale artefact", encoding="utf-8")
+        rf = _report_file("RF", "rel.txt")
+        mission, _ = _run_mission(tmp_path, objects={"RF": rf})
+
+        with pytest.raises(GmatRunError):
+            mission.run(working_dir=workspace)
+
+        assert mission["RF.Filename"] == "rel.txt"
 
     def test_run_redirects_log(self, tmp_path: Path) -> None:
         mission, gmat = _run_mission(tmp_path)


### PR DESCRIPTION
## Summary

- `_rewrite_output_paths` / `_discover_solver_outputs` pin each relative subscriber `Filename` / solver `ReportFile` to an absolute path inside the run's workspace via `SetField` — the only field GMAT consults at write time. That rewrite **persisted** on the engine object after the run, so a second `run()` on the same `Mission` read the now-absolute `Filename`, hit the `is_absolute()` branch that treats a path as user-pinned, and skipped the redirect — the second run's output landed in (or overwrote) the first run's workspace. The mutation also survived a failed run.
- Both helpers now return the pre-rewrite value of every field they pinned; `run()` rolls them back in a `finally` covering the success return, a `GmatRunError`, and the pre-run collision gate alike. Between runs every subscriber/solver field reflects the loaded script again, so each `run()` resolves its outputs afresh. The `is_absolute()` check is unchanged — it stops misfiring because the field is no longer poisoned.
- `Mission` now stays a view of the loaded script (matching `attitude_inputs`): reading `mission["RF.Filename"]` after a run yields the *declared* value, not the workspace path. Resolved output locations live on the returned `Results`. Docstrings and one solver integration test that asserted the old post-run behaviour are updated accordingly.

The bug dates to the original `Mission.run` implementation (#27); `_discover_solver_outputs` replicated the pattern in #112. The recent absolute-path normalisation (#110) did not introduce it and downstream consumers are unaffected — they load a fresh `Mission` per run.

## Test plan

- [x] `pytest -m "not integration"` — 768 unit tests pass, including new `Mission.run()` re-run, failed-run, and collision-gate restore coverage
- [x] `pytest -m integration` — 34 integration tests pass against GMAT R2026a, including the new `test_rerun.py` end-to-end repro and the updated solver-path assertions
- [x] `ruff check`, `ruff format --check`, `mypy` — clean

Closes #115