### PR TITLE
Expose Results.report_paths for parser-free ReportFile path access

### DIFF
--- a/src/gmat_run/results.py
+++ b/src/gmat_run/results.py
@@ -251,6 +251,7 @@ class Results:
     output_dir: Path
     log: str
     reports: Mapping[str, pd.DataFrame]
+    report_paths: Mapping[str, Path]
     ephemerides: Mapping[str, pd.DataFrame]
     ephemeris_paths: Mapping[str, Path]
     contacts: Mapping[str, pd.DataFrame]
@@ -279,11 +280,13 @@ class Results:
         self.log = log
         self._workspace = None
 
+        rep_paths: dict[str, Path] = dict(report_paths or {})
         eph_paths: dict[str, Path] = dict(ephemeris_paths or {})
         con_paths: dict[str, Path] = dict(contact_paths or {})
         slv_paths: dict[str, Path] = dict(solver_paths or {})
 
-        self.reports = _LazyReports(report_paths or {})
+        self.reports = _LazyReports(rep_paths)
+        self.report_paths = MappingProxyType(rep_paths)
         self.ephemeris_paths = MappingProxyType(eph_paths)
         self.contact_paths = MappingProxyType(con_paths)
         self.solver_paths = MappingProxyType(slv_paths)
@@ -369,7 +372,7 @@ class Results:
                 return p
             return dest / rel
 
-        new_reports = {n: _migrate(p) for n, p in self.reports._paths.items()}  # type: ignore[attr-defined]
+        new_reports = {n: _migrate(p) for n, p in self.report_paths.items()}
         new_eph = {n: _migrate(p) for n, p in self.ephemeris_paths.items()}
         new_con = {n: _migrate(p) for n, p in self.contact_paths.items()}
         new_slv = {n: _migrate(p) for n, p in self.solver_paths.items()}
@@ -378,6 +381,7 @@ class Results:
         self.ephemerides._rebase(new_eph)  # type: ignore[attr-defined]
         self.contacts._rebase(new_con)  # type: ignore[attr-defined]
         self.solver_runs._rebase(new_slv)  # type: ignore[attr-defined]
+        self.report_paths = MappingProxyType(new_reports)
         self.ephemeris_paths = MappingProxyType(new_eph)
         self.contact_paths = MappingProxyType(new_con)
         self.solver_paths = MappingProxyType(new_slv)

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -1012,13 +1012,10 @@ class TestMissionRun:
         )
         result = mission.run()
         assert list(result.reports) == ["R1"]
-        # Relative filenames join the workspace dir.
-        assert result.reports.keys() == {"R1"}
-        # The path mapping itself is internal; reach through ephemeris_paths-style
-        # behaviour by verifying the workspace dir owns it.
-        # Use the parser-free path check on the lazy view's underlying mapping.
-        # (We expose the path via output_dir + basename.)
-        assert (result.output_dir / "r1.txt").parent == result.output_dir
+        # report_paths locates the ReportFile output without a parse; a relative
+        # Filename joins the run workspace.
+        assert list(result.report_paths) == ["R1"]
+        assert result.report_paths["R1"] == result.output_dir / "r1.txt"
 
     def test_run_buckets_outputs_by_subscriber_type(self, tmp_path: Path) -> None:
         mission, _ = _run_mission(

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -43,6 +43,7 @@ def test_output_dir_and_log_round_trip(tmp_path: Path) -> None:
 def test_default_mappings_are_empty(tmp_path: Path) -> None:
     result = _empty(tmp_path)
     assert len(result.reports) == 0
+    assert len(result.report_paths) == 0
     assert len(result.ephemerides) == 0
     assert len(result.ephemeris_paths) == 0
     assert len(result.contacts) == 0
@@ -57,9 +58,12 @@ def test_path_mappings_are_read_only(tmp_path: Path) -> None:
     result = Results(
         output_dir=tmp_path,
         log="",
+        report_paths={"R1": tmp_path / "R1.txt"},
         ephemeris_paths={"E1": tmp_path / "E1.eph"},
         contact_paths={"C1": tmp_path / "C1.txt"},
     )
+    with pytest.raises(TypeError):
+        result.report_paths["R2"] = tmp_path / "R2.txt"  # type: ignore[index]
     with pytest.raises(TypeError):
         result.ephemeris_paths["E2"] = tmp_path / "E2.eph"  # type: ignore[index]
     with pytest.raises(TypeError):
@@ -100,6 +104,18 @@ def test_reports_keyed_by_resource_name(tmp_path: Path) -> None:
     assert list(result.reports) == ["ReportFile1"]
     assert "ReportFile1" in result.reports
     assert len(result.reports) == 1
+
+
+def test_report_paths_round_trip(tmp_path: Path) -> None:
+    """``report_paths`` exposes the ReportFile location without parsing —
+    parity with ephemeris_paths / contact_paths / solver_paths."""
+    rpt = tmp_path / "never_written.txt"
+    result = Results(output_dir=tmp_path, log="", report_paths={"R1": rpt})
+    # Reachable even though the file does not exist: the path view never parses.
+    assert result.report_paths["R1"] == rpt
+    assert list(result.report_paths) == ["R1"]
+    assert "R1" in result.report_paths
+    assert len(result.report_paths) == 1
 
 
 def test_report_access_returns_dataframe(tmp_path: Path) -> None:
@@ -580,10 +596,9 @@ class TestPersist:
         result.persist(dest)
 
         assert result.output_dir == dest
+        assert result.report_paths["R1"] == dest / "r1.txt"
         assert result.ephemeris_paths["E1"] == dest / "e1.eph"
         assert result.contact_paths["C1"] == dest / "c1.txt"
-        # Reports' underlying path mapping is rebased too.
-        assert result.reports._paths["R1"] == dest / "r1.txt"  # type: ignore[attr-defined]
 
     def test_returns_self_for_chaining(self, tmp_path: Path) -> None:
         result, _ = _result_with_workspace(tmp_path)


### PR DESCRIPTION
## Summary

- `Results` exposed `ephemeris_paths` / `contact_paths` / `solver_paths` as read-only `MappingProxyType` views but consumed `report_paths` straight into the lazy `_LazyReports` and never re-exposed it — so callers had no parser-free way to locate `ReportFile` outputs, despite `cli.py` already telling them to reach `result.report_paths`.
- `Results.__init__` now builds a shared `rep_paths` dict, feeds it to `_LazyReports`, and exposes `self.report_paths = MappingProxyType(...)`; the attribute is declared in the class block and `persist()` rebases it alongside the other three.
- `persist()`'s report-path migration now reads the public `report_paths` instead of reaching into `_LazyReports._paths`, dropping a `type: ignore`.

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/integration` — 769 passed
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] `uv run mypy src/gmat_run/results.py` — clean
- [x] New `test_report_paths_round_trip`; `report_paths` added to the empty-mappings, read-only, and persist-rebase tests; `test_run_populates_report_paths` rewritten to assert on the real attribute

Closes #117