### PR TITLE
Make promote_epochs idempotent on a converted epoch column

### DIFF
--- a/src/gmat_run/parsers/epoch.py
+++ b/src/gmat_run/parsers/epoch.py
@@ -109,11 +109,14 @@ def promote_epochs(df: pd.DataFrame, *, convert_to: str | None = None) -> pd.Dat
     for column in df.columns:
         suffix = _suffix(str(column))
         if pd.api.types.is_datetime64_any_dtype(df[column]):
-            # Already promoted (idempotence) — but still tag the scale if we
-            # can, so a caller that constructed the frame by hand gets
-            # consistent attrs.
+            # Already promoted (idempotence). Tag the name-derived scale only
+            # when nothing recorded one yet — a caller that built the frame by
+            # hand still gets consistent attrs — but never overwrite a scale an
+            # earlier pass or convert_column already recorded: the column name
+            # keeps its original suffix after a conversion, so re-deriving from
+            # it would silently mislabel converted data.
             scale = _GREGORIAN_SUFFIXES.get(suffix) or _MODJULIAN_SUFFIXES.get(suffix)
-            if scale is not None:
+            if scale is not None and column not in df.attrs.get("epoch_scales", {}):
                 _tag_scale(df, column, scale)
             continue
         if suffix in _GREGORIAN_SUFFIXES:

--- a/tests/test_parsers_epoch.py
+++ b/tests/test_parsers_epoch.py
@@ -14,6 +14,7 @@ import pytest
 
 from gmat_run.errors import GmatOutputParseError
 from gmat_run.parsers.epoch import promote_epochs
+from gmat_run.time import convert_column
 
 # Scale suffixes the parser recognises. Parametrising over these catches any
 # table-entry-missing or typo regression in one place.
@@ -205,6 +206,39 @@ def test_promote_is_idempotent() -> None:
     promote_epochs(df)
     pd.testing.assert_frame_equal(df, snapshot)
     assert df.attrs["epoch_scales"] == attrs_snapshot
+
+
+def test_promote_does_not_clobber_a_converted_scale() -> None:
+    """Re-promoting after convert_column must not re-tag the original scale.
+
+    The column keeps its ``TAIModJulian`` suffix after the conversion, so the
+    idempotence branch must not re-derive ``"TAI"`` from the name and overwrite
+    the ``"UTC"`` that convert_column recorded.
+    """
+    df = pd.DataFrame({"Sat.TAIModJulian": [30000.0, 30001.0]})
+    promote_epochs(df)
+    convert_column(df, "Sat.TAIModJulian", "UTC")
+    converted = df["Sat.TAIModJulian"].copy(deep=True)
+
+    promote_epochs(df)
+
+    assert df.attrs["epoch_scales"]["Sat.TAIModJulian"] == "UTC"
+    # The re-promote leaves the already-converted data untouched too.
+    pd.testing.assert_series_equal(df["Sat.TAIModJulian"], converted)
+
+
+def test_promote_tags_hand_built_datetime64_frame() -> None:
+    """A datetime64 column with no recorded scale still gets a name-derived tag.
+
+    This is the case the idempotence branch exists to serve: promote_epochs
+    never ran on the frame, so there is no recorded scale to clobber.
+    """
+    df = pd.DataFrame({"Sat.TAIModJulian": pd.to_datetime(["2000-01-01 12:00:00"])})
+    assert "epoch_scales" not in df.attrs
+
+    promote_epochs(df)
+
+    assert df.attrs["epoch_scales"] == {"Sat.TAIModJulian": "TAI"}
 
 
 def test_returns_same_frame_for_chaining() -> None:


### PR DESCRIPTION
## Summary

- `promote_epochs()`'s already-`datetime64` branch re-derived the time scale from the column name's suffix (`TAIModJulian` → `TAI`) and unconditionally re-tagged `df.attrs["epoch_scales"]`. After `convert_column` changed the recorded scale, a second `promote_epochs` flipped the label back to the name-derived scale while the data stayed converted — so a later `convert_column` would apply a bogus offset.
- The idempotence branch now tags the name-derived scale only when the column has no entry in `epoch_scales` yet: a hand-built `datetime64` frame still gets consistent attrs, but a scale recorded by an earlier pass or by `convert_column` is never overwritten.

## Test plan

- [x] `uv run pytest tests/ --ignore=tests/integration` — 771 passed
- [x] `uv run ruff check` / `ruff format --check` / `uv run mypy` — clean
- [x] New `test_promote_does_not_clobber_a_converted_scale` (the issue's promote → convert → re-promote repro) and `test_promote_tags_hand_built_datetime64_frame` (locks the preserved hand-built-frame tagging)

Closes #118