### PR TITLE
Preserve relative subdirectory structure in rewritten output paths

### DIFF
--- a/src/gmat_run/mission.py
+++ b/src/gmat_run/mission.py
@@ -445,9 +445,17 @@ class Mission:
         # Solver .data logs are redirected the same way. The returned paths are
         # *expected* locations — a Solver no Target/Optimize block exercises
         # writes nothing, so existence is rechecked after the run below.
-        solver_expected, solver_max_iterations, solver_restores = self._discover_solver_outputs(
-            workspace_path
-        )
+        try:
+            solver_expected, solver_max_iterations, solver_restores = self._discover_solver_outputs(
+                workspace_path
+            )
+        except Exception:
+            # _rewrite_output_paths already pinned subscriber Filenames into
+            # the workspace; if solver discovery then rejects a path, roll
+            # those back before propagating so a refused run leaves the engine
+            # reflecting the loaded script (issue #115).
+            self._restore_output_paths(sub_restores)
+            raise
         all_paths = (
             *report_paths.values(),
             *ephemeris_paths.values(),
@@ -466,6 +474,11 @@ class Mission:
             # the user's destination and we honour them. Default raises;
             # overwrite=True unlinks the colliding files first.
             _check_inside_workspace_collisions(workspace_path, all_paths, overwrite=overwrite)
+            # Create parent directories for nested output paths now the gate
+            # has passed — GMAT does not create them itself, and a relative
+            # Filename with subdirectories (issue #119) resolves to a nested
+            # path that would otherwise fail to write.
+            _create_output_dirs(workspace_path, all_paths)
             log_path = workspace_path / "GmatLog.txt"
 
             self._gmat.UseLogFile(str(log_path))
@@ -625,20 +638,28 @@ class Mission:
         """Bucket subscriber output paths and pin each one to ``workspace_path``.
 
         Walks every ``ReportFile`` / ``EphemerisFile`` / ``ContactLocator`` in
-        the configuration. For each: reads its declared ``Filename``, resolves
-        a relative filename against ``workspace_path`` (preserving an absolute
-        path as-is), writes the resolved absolute path back to the engine via
-        ``SetField("Filename", ...)``, and records the path in the appropriate
-        return bucket. Resilient to missing type-enum attributes and broken
-        objects — skips quietly rather than aborting the whole run.
+        the configuration. For each: reads its declared ``Filename`` and
+        resolves it against ``workspace_path`` via :func:`_resolve_output_path`
+        — a relative filename keeps its subdirectory structure under the
+        workspace (issue #119), an absolute path is left as-is — then writes
+        the resolved path back to the engine via ``SetField("Filename", ...)``
+        and records it in the appropriate return bucket. Resilient to missing
+        type-enum attributes and broken objects — skips quietly rather than
+        aborting the whole run.
+
+        Done in two phases: phase one discovers and resolves every output
+        path, phase two writes them back. The split means a relative
+        ``Filename`` that would escape the workspace (a ``..`` component)
+        raises in phase one — before any ``SetField`` — so a refused run
+        leaves every engine field untouched.
 
         Every relative ``Filename`` that gets rewritten also yields a restore
         entry — ``(resource_name, "Filename", declared_value)`` — so
         :meth:`run` can return the engine field to its script-declared state
         once the run is over (see :meth:`_restore_output_paths`). Without that
         rollback the rewritten absolute path would survive into the next
-        ``run()``, where the ``is_absolute()`` check below would mistake it for
-        a user-pinned destination and skip the redirect (issue #115). An
+        ``run()``, where the ``is_absolute()`` check would mistake it for a
+        user-pinned destination and skip the redirect (issue #115). An
         absolute ``Filename`` is left untouched and produces no restore entry.
 
         Returns:
@@ -657,6 +678,10 @@ class Mission:
             "ContactLocator": contacts,
         }
         seen: set[str] = set()
+        # Phase one — discover every output subscriber and resolve its declared
+        # Filename. _resolve_output_path raises here, before any field is
+        # mutated, if a relative path would escape the workspace.
+        pending: list[tuple[str, Any, str, str, Path]] = []
         for enum_attr in _OUTPUT_TYPE_ENUM_ATTRS:
             type_id = getattr(self._gmat, enum_attr, None)
             if type_id is None:
@@ -683,17 +708,19 @@ class Mission:
                     declared = str(obj.GetField("Filename"))
                 except Exception:
                     continue
-                path = Path(declared)
-                if path.is_absolute():
-                    resolved = path
-                else:
-                    resolved = workspace_path / path.name
-                    with suppress(Exception):
-                        obj.SetField("Filename", str(resolved))
-                        # Only recorded once SetField has actually landed —
-                        # a suppressed failure leaves nothing to restore.
-                        restores.append((name, "Filename", declared))
-                bucket[type_name][name] = resolved
+                resolved = _resolve_output_path(name, declared, workspace_path)
+                pending.append((name, obj, type_name, declared, resolved))
+        # Phase two — pin each relative Filename into the workspace. Deferred
+        # to its own pass so a workspace-escape error above aborts the run
+        # before any engine field has been touched.
+        for name, obj, type_name, declared, resolved in pending:
+            if not Path(declared).is_absolute():
+                with suppress(Exception):
+                    obj.SetField("Filename", str(resolved))
+                    # Only recorded once SetField has actually landed —
+                    # a suppressed failure leaves nothing to restore.
+                    restores.append((name, "Filename", declared))
+            bucket[type_name][name] = resolved
         return reports, ephemerides, contacts, restores
 
     def _discover_solver_outputs(
@@ -706,13 +733,19 @@ class Mission:
         when set, otherwise the default ``<TypeName><SolverName>.data`` — and,
         for a relative or unset value, rewrites ``ReportFile`` to an absolute
         path inside ``workspace_path`` via ``SetField`` so GMAT writes where we
-        expect. An absolute ``ReportFile`` is the user's chosen destination and
-        is left alone, mirroring :meth:`_rewrite_output_paths`. The solver's
-        ``MaximumIterations`` is read alongside — the ``.data`` file does not
-        record it, but the parser needs it to classify a max-iteration stop.
+        expect. Resolution goes through :func:`_resolve_output_path`, so a
+        relative value keeps its subdirectory structure under the workspace
+        (issue #119) and an absolute ``ReportFile`` — the user's chosen
+        destination — is left alone, mirroring :meth:`_rewrite_output_paths`.
+        The solver's ``MaximumIterations`` is read alongside — the ``.data``
+        file does not record it, but the parser needs it to classify a
+        max-iteration stop.
 
         Resilient to a missing ``SOLVER`` enum and to broken objects — skips
-        quietly rather than aborting the run.
+        quietly rather than aborting the run. Done in two phases like
+        :meth:`_rewrite_output_paths`: a relative value that would escape the
+        workspace (a ``..`` component) raises during phase one, before any
+        ``SetField``.
 
         Each rewritten ``ReportFile`` yields a restore entry, exactly as in
         :meth:`_rewrite_output_paths`, so :meth:`run` can roll the engine
@@ -735,6 +768,10 @@ class Mission:
         paths: dict[str, Path] = {}
         max_iterations: dict[str, int] = {}
         restores: list[_OutputPathRestore] = []
+        # Phase one — resolve every solver .data path. _resolve_output_path
+        # raises here, before any field is mutated, if a relative ReportFile
+        # would escape the workspace.
+        pending: list[tuple[str, Any, str, str, Path]] = []
         for name in names:
             obj = self._gmat.GetObject(name)
             if obj is None:
@@ -746,19 +783,21 @@ class Mission:
             declared = ""
             with suppress(Exception):
                 declared = str(obj.GetField("ReportFile"))
-            path = Path(declared) if declared else Path(f"{type_name}{name}.data")
-            if path.is_absolute():
-                resolved = path
-            else:
-                resolved = workspace_path / path.name
+            effective = declared if declared else f"{type_name}{name}.data"
+            resolved = _resolve_output_path(name, effective, workspace_path)
+            pending.append((name, obj, declared, effective, resolved))
+            with suppress(Exception):
+                max_iterations[name] = int(float(str(obj.GetField("MaximumIterations"))))
+        # Phase two — pin each relative ReportFile into the workspace, deferred
+        # so a phase-one escape error aborts before any field is mutated.
+        for name, obj, declared, effective, resolved in pending:
+            paths[name] = resolved
+            if not Path(effective).is_absolute():
                 with suppress(Exception):
                     obj.SetField("ReportFile", str(resolved))
                     # Recorded only after SetField lands — see the matching
                     # note in _rewrite_output_paths.
                     restores.append((name, "ReportFile", declared))
-            paths[name] = resolved
-            with suppress(Exception):
-                max_iterations[name] = int(float(str(obj.GetField("MaximumIterations"))))
         return paths, max_iterations, restores
 
     def _restore_output_paths(self, restores: Iterable[_OutputPathRestore]) -> None:
@@ -1061,20 +1100,84 @@ def _probe_writable(path: Path) -> None:
         os.unlink(probe)
 
 
+def _resolve_output_path(name: str, declared: str, workspace_path: Path) -> Path:
+    """Resolve a subscriber / solver output path against ``workspace_path``.
+
+    An absolute ``declared`` path is the user's chosen destination and is
+    returned unchanged. A relative path is pinned under ``workspace_path``
+    with its subdirectory structure preserved, so two outputs declared with
+    distinct relative paths that share a basename — ``runs/a/out.txt`` and
+    ``runs/b/out.txt`` — resolve to distinct files instead of both collapsing
+    onto ``workspace/out.txt`` (issue #119).
+
+    A relative path containing a ``..`` component is rejected with
+    :class:`~gmat_run.errors.GmatRunError`: it could resolve outside
+    ``workspace_path``, and gmat-run will not write beyond the workspace it
+    manages. Callers resolve every output path before mutating any engine
+    field, so a raised error leaves the run un-started and the workspace
+    untouched.
+    """
+    path = Path(declared)
+    if path.is_absolute():
+        return path
+    if ".." in path.parts:
+        raise GmatRunError(
+            f"resource '{name}' declares a relative output path '{declared}' "
+            f"with a '..' component that could escape working_dir "
+            f"'{workspace_path}'; use a path inside the workspace or an "
+            f"absolute path",
+            log="",
+            path=workspace_path,
+        )
+    return workspace_path / path
+
+
+def _create_output_dirs(workspace_path: Path, paths: Iterable[Path]) -> None:
+    """Pre-create parent directories for output paths inside the workspace.
+
+    Preserving a relative ``Filename``'s subdirectory structure under
+    ``workspace_path`` (issue #119) means a ``ReportFile`` declared as
+    ``runs/a/out.txt`` resolves to a nested path — but GMAT does not create
+    output directories itself, so the write would fail unless ``runs/a/``
+    exists first. This walks the resolved output set and creates every parent
+    that lives under the workspace. Absolute paths the script pinned outside
+    the workspace are the user's destination and are left alone.
+
+    Runs after the collision gate so a refused run still leaves the workspace
+    untouched. A path directly in the workspace has the (already-created)
+    workspace as its parent, so ``mkdir`` is a no-op there.
+    """
+    try:
+        workspace_resolved = workspace_path.resolve()
+    except OSError:
+        return
+    for p in paths:
+        if not _is_inside(p, workspace_resolved):
+            continue
+        with suppress(OSError):
+            p.parent.mkdir(parents=True, exist_ok=True)
+
+
 def _check_inside_workspace_collisions(
     workspace_path: Path,
     paths: Iterable[Path],
     *,
     overwrite: bool,
 ) -> None:
-    """Gate or clear pre-existing output files inside the workspace.
+    """Gate two output-path collision classes inside the workspace.
 
     Walks every resolved output path; only those that live under
     ``workspace_path`` (i.e. relative ``Filename`` rewrites, not user-pinned
-    absolute paths) participate in the gate. With ``overwrite=False`` (the
-    default), any pre-existing file raises
-    :class:`~gmat_run.errors.GmatRunError` listing the collisions; with
-    ``overwrite=True`` they are unlinked instead.
+    absolute paths) participate. Two classes are caught:
+
+    * **Intra-run** — two outputs of *this* run resolved to the same path. It
+      raises regardless of ``overwrite``: ``overwrite`` governs pre-existing
+      files, not two writers racing onto one path within a single run, and
+      letting the run proceed would silently clobber one output.
+    * **Pre-existing** — a file already on disk at a resolved output path.
+      With ``overwrite=False`` (the default) this raises
+      :class:`~gmat_run.errors.GmatRunError` listing the collisions; with
+      ``overwrite=True`` the files are unlinked instead.
 
     The check runs before ``RunScript`` so a refused run leaves the workspace
     untouched (the error message tells the caller exactly what to clear, or
@@ -1088,12 +1191,30 @@ def _check_inside_workspace_collisions(
         # the gate rather than raise a confusing collision error. Writability
         # would have already failed if this path were genuinely broken.
         return
-    collisions: list[Path] = []
-    for p in paths:
-        if not _is_inside(p, workspace_resolved):
-            continue
-        if p.exists():
-            collisions.append(p)
+    inside = [p for p in paths if _is_inside(p, workspace_resolved)]
+    # Intra-run collision: two resolved output paths are identical. With
+    # relative subdirectory structure preserved (issue #119) this only
+    # happens when two resources declare the same relative Filename — a
+    # collision the script itself carries, which gmat-run surfaces rather
+    # than letting the second writer silently clobber the first.
+    seen: set[Path] = set()
+    duplicates: list[Path] = []
+    for p in inside:
+        if p in seen and p not in duplicates:
+            duplicates.append(p)
+        seen.add(p)
+    if duplicates:
+        listing = ", ".join(str(p) for p in duplicates)
+        raise GmatRunError(
+            (
+                f"working_dir '{workspace_path}': multiple outputs resolve to "
+                f"the same path: {listing}; give the colliding subscribers "
+                f"distinct Filename values"
+            ),
+            log="",
+            path=workspace_path,
+        )
+    collisions = [p for p in inside if p.exists()]
     if not collisions:
         return
     if overwrite:

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -161,17 +161,19 @@ class _FakeObject:
 # ``Moderator.GetListOfObjects`` uses as bucket IDs. The real gmat module
 # defines these as opaque ints from the C++ engine; the production code reads
 # them via ``getattr(self._gmat, "SUBSCRIBER", None)`` so any unique values work.
-_OBJECT_TYPE_IDS = {"SUBSCRIBER": 100, "EVENT_LOCATOR": 200, "SPACECRAFT": 300}
+_OBJECT_TYPE_IDS = {"SUBSCRIBER": 100, "EVENT_LOCATOR": 200, "SPACECRAFT": 300, "SOLVER": 400}
 
 # Which object-type bucket each top-level type lives in. ReportFile and
 # EphemerisFile are Subscribers; ContactLocator is an EventLocator; Spacecraft
 # resources land in the dedicated SPACECRAFT bucket that
-# Mission.attitude_inputs probes.
+# Mission.attitude_inputs probes; DifferentialCorrector is a Solver, walked by
+# Mission._discover_solver_outputs.
 _OBJECT_TYPE_OF_CLASS = {
     "ReportFile": "SUBSCRIBER",
     "EphemerisFile": "SUBSCRIBER",
     "ContactLocator": "EVENT_LOCATOR",
     "Spacecraft": "SPACECRAFT",
+    "DifferentialCorrector": "SOLVER",
 }
 
 
@@ -381,6 +383,17 @@ def _contact_locator(name: str = "Contacts", filename: str = "contacts.txt") -> 
         "Filename": (_TYPE_CODES["FILENAME_TYPE"], filename, False),
     }
     return _FakeObject("ContactLocator", name, fields)
+
+
+def _diff_corrector(
+    name: str = "DC", report_file: str = "DifferentialCorrectorDC.data"
+) -> _FakeObject:
+    """DifferentialCorrector Solver — exercises Mission._discover_solver_outputs."""
+    fields: dict[str, tuple[int, Any, bool]] = {
+        "ReportFile": (_TYPE_CODES["FILENAME_TYPE"], report_file, False),
+        "MaximumIterations": (_TYPE_CODES["INTEGER_TYPE"], 25, False),
+    }
+    return _FakeObject("DifferentialCorrector", name, fields)
 
 
 def _force_model(name: str = "FM") -> _FakeObject:
@@ -1472,16 +1485,17 @@ class TestMissionRunWorkingDir:
 
     def test_forward_slash_relative_filename_resolves_under_workspace(self, tmp_path: Path) -> None:
         # Regression for Windows-authored scripts that use forward slashes in
-        # a relative ``Filename``. ``Path.name`` strips any leading directory
-        # portion regardless of the platform, so the resolved path lives
-        # directly under the workspace on every OS.
+        # a relative ``Filename``. The subdirectory structure is preserved
+        # under the workspace (issue #119), and ``Path`` parses a forward
+        # slash as a separator on every OS, so the resolved path is the same
+        # nested location anywhere.
         rf = _report_file("R1", "outputs/r1.txt")
         mission, _ = _run_mission(tmp_path, objects={"R1": rf})
 
         result = mission.run()
 
         assert result.reports._paths == {  # type: ignore[attr-defined]
-            "R1": result.output_dir / "r1.txt"
+            "R1": result.output_dir / "outputs" / "r1.txt"
         }
 
     def test_overwrite_is_a_noop_for_default_workspace(self, tmp_path: Path) -> None:
@@ -1527,6 +1541,167 @@ class TestMissionRunWorkingDir:
         result = mission.run(working_dir="~/run_home")
 
         assert result.output_dir == (tmp_path / "run_home").resolve()
+
+
+class TestMissionRunRelativeOutputPaths:
+    """Relative output paths keep their subdirectory structure (issue #119)."""
+
+    def test_nested_paths_with_shared_basename_stay_distinct(self, tmp_path: Path) -> None:
+        # The issue #119 repro: two subscribers declared with distinct
+        # relative paths that share a basename must not collapse onto one
+        # file. Preserving the subdirectory structure keeps them distinct.
+        mission, _ = _run_mission(
+            tmp_path,
+            objects={
+                "R_A": _report_file("R_A", "runs/a/out.txt"),
+                "R_B": _report_file("R_B", "runs/b/out.txt"),
+            },
+        )
+
+        result = mission.run()
+
+        assert result.report_paths["R_A"] == result.output_dir / "runs" / "a" / "out.txt"
+        assert result.report_paths["R_B"] == result.output_dir / "runs" / "b" / "out.txt"
+        assert result.report_paths["R_A"] != result.report_paths["R_B"]
+
+    def test_relative_subdirectory_structure_is_preserved(self, tmp_path: Path) -> None:
+        # A single relative Filename with subdirectories resolves to a nested
+        # path under the workspace — not flattened to the basename — and that
+        # nested path is what gets written back to the engine.
+        rf = _report_file("RF", "reports/run_0/r1.txt")
+        mission, _ = _run_mission(tmp_path, objects={"RF": rf})
+
+        result = mission.run()
+
+        nested = result.output_dir / "reports" / "run_0" / "r1.txt"
+        assert result.report_paths["RF"] == nested
+        assert ("Filename", str(nested)) in rf.set_calls
+
+    def test_parent_directories_created_for_nested_output(self, tmp_path: Path) -> None:
+        # GMAT does not create output directories itself, so gmat-run
+        # pre-creates the parents of every nested inside-workspace path.
+        rf = _report_file("RF", "runs/a/out.txt")
+        mission, _ = _run_mission(tmp_path, objects={"RF": rf})
+
+        result = mission.run()
+
+        assert (result.output_dir / "runs" / "a").is_dir()
+
+    @pytest.mark.parametrize(
+        "declared",
+        ["../escape.txt", "../../escape.txt", "sub/../../escape.txt"],
+    )
+    def test_relative_filename_that_escapes_workspace_raises(
+        self, tmp_path: Path, declared: str
+    ) -> None:
+        # A relative Filename with a `..` component could resolve outside the
+        # workspace; gmat-run refuses it rather than write beyond the
+        # workspace it manages.
+        rf = _report_file("RF", declared)
+        mission, _ = _run_mission(tmp_path, objects={"RF": rf})
+
+        with pytest.raises(GmatRunError) as excinfo:
+            mission.run()
+
+        msg = str(excinfo.value)
+        assert "RF" in msg
+        assert ".." in msg
+        assert "escape working_dir" in msg
+
+    def test_internal_parent_component_is_also_rejected(self, tmp_path: Path) -> None:
+        # The guard rejects any `..` component, even one that would normalise
+        # back inside the workspace — `..` in an output Filename is almost
+        # always a script mistake, and rejecting it outright is unambiguous.
+        rf = _report_file("RF", "sub/../r1.txt")
+        mission, _ = _run_mission(tmp_path, objects={"RF": rf})
+
+        with pytest.raises(GmatRunError, match="escape working_dir"):
+            mission.run()
+
+    def test_escape_raises_before_runscript_without_mutating_fields(self, tmp_path: Path) -> None:
+        # The escape check runs in phase one of _rewrite_output_paths, before
+        # any SetField and before RunScript — so a refused run leaves the
+        # engine field and the workspace untouched.
+        rf = _report_file("RF", "../escape.txt")
+        mission, gmat = _run_mission(tmp_path, objects={"RF": rf})
+
+        with pytest.raises(GmatRunError):
+            mission.run()
+
+        # Filename was never rewritten, and RunScript / UseLogFile never ran.
+        assert all(name != "Filename" for name, _ in rf.set_calls)
+        assert gmat._log_paths == []
+        assert mission["RF.Filename"] == "../escape.txt"
+
+    def test_identical_relative_paths_raise_intra_run_collision(self, tmp_path: Path) -> None:
+        # Two subscribers declaring the *same* relative Filename resolve to
+        # one path — a collision the script itself carries. The hardened gate
+        # surfaces it instead of letting the second writer clobber the first.
+        mission, _ = _run_mission(
+            tmp_path,
+            objects={
+                "R1": _report_file("R1", "out.txt"),
+                "R2": _report_file("R2", "out.txt"),
+            },
+        )
+
+        with pytest.raises(GmatRunError) as excinfo:
+            mission.run()
+
+        assert "multiple outputs resolve to the same path" in str(excinfo.value)
+
+    def test_intra_run_collision_raises_even_with_overwrite(self, tmp_path: Path) -> None:
+        # overwrite= governs pre-existing files, not two outputs of one run
+        # racing onto a single path — so the intra-run gate raises regardless.
+        mission, _ = _run_mission(
+            tmp_path,
+            objects={
+                "R1": _report_file("R1", "out.txt"),
+                "R2": _report_file("R2", "out.txt"),
+            },
+        )
+
+        with pytest.raises(GmatRunError, match="multiple outputs resolve"):
+            mission.run(overwrite=True)
+
+    def test_solver_relative_report_file_subdirectory_preserved(self, tmp_path: Path) -> None:
+        # The solver .data twin of _rewrite_output_paths: a relative
+        # ReportFile keeps its subdirectory structure under the workspace.
+        dc = _diff_corrector("DC", "logs/dc.data")
+        mission, _ = _run_mission(tmp_path, objects={"DC": dc})
+
+        result = mission.run()
+
+        nested = result.output_dir / "logs" / "dc.data"
+        assert ("ReportFile", str(nested)) in dc.set_calls
+        assert (result.output_dir / "logs").is_dir()
+
+    def test_solver_relative_report_file_escape_raises(self, tmp_path: Path) -> None:
+        # A solver ReportFile with a `..` component is rejected the same way
+        # a subscriber Filename is.
+        dc = _diff_corrector("DC", "../escape/dc.data")
+        mission, gmat = _run_mission(tmp_path, objects={"DC": dc})
+
+        with pytest.raises(GmatRunError) as excinfo:
+            mission.run()
+
+        assert "DC" in str(excinfo.value)
+        assert "escape working_dir" in str(excinfo.value)
+        assert gmat._log_paths == []
+
+    def test_solver_escape_rolls_back_subscriber_rewrite(self, tmp_path: Path) -> None:
+        # _rewrite_output_paths runs before _discover_solver_outputs. If a
+        # solver path is rejected, the subscriber Filenames already pinned
+        # must be rolled back so a refused run leaves the engine reflecting
+        # the loaded script (issue #115).
+        rf = _report_file("RF", "rel.txt")
+        dc = _diff_corrector("DC", "../escape/dc.data")
+        mission, _ = _run_mission(tmp_path, objects={"RF": rf, "DC": dc})
+
+        with pytest.raises(GmatRunError):
+            mission.run()
+
+        assert mission["RF.Filename"] == "rel.txt"
 
 
 # --- Mission.attitude_inputs --------------------------------------------------


### PR DESCRIPTION
## Summary

- `_rewrite_output_paths` / `_discover_solver_outputs` resolved a relative output path with `workspace_path / path.name`, discarding directory components — so two subscribers declared with distinct relative paths sharing a basename (`runs/a/out.txt`, `runs/b/out.txt`) both collapsed onto `workspace/out.txt`. Resolution now preserves the subdirectory structure under the workspace, and `run()` pre-creates the nested parent directories (GMAT does not create them itself).
- A relative `Filename` with a `..` component is now rejected with `GmatRunError` before `RunScript` — it could resolve outside the workspace gmat-run manages. Resolution is two-phase (resolve + validate all, then mutate), so a refused run leaves every engine field untouched.
- `_check_inside_workspace_collisions` now also catches two outputs of one run resolving to the same path (two resources declaring an identical relative `Filename`), raising regardless of `overwrite`.

## Test plan

- [ ] `uv run pytest` — full unit suite (784 passing locally; 12 new tests for nested-path preservation, the `..` escape guard, the intra-run collision gate, and the solver `.data` twin)
- [ ] `uv run ruff check` / `uv run ruff format --check`
- [ ] CI integration cell against real GMAT (exercises `_discover_solver_outputs` and the live run path)

Closes #119