### PR TITLE
Normalise write_oem_all and GmatInstall paths; fix persist docstring

### DIFF
--- a/src/gmat_run/install.py
+++ b/src/gmat_run/install.py
@@ -113,6 +113,12 @@ def _validate_install(root: Path) -> GmatInstall | str:
     if not root.is_dir():
         return "not a directory"
 
+    # Canonicalise once so every GmatInstall for a given physical install
+    # compares equal regardless of how the path was spelled (argument, env
+    # var, glob, PATH discovery, or via a symlink). bootstrap()'s "second
+    # install" guard relies on that field-wise equality.
+    root = root.resolve()
+
     bin_dir = root / "bin"
     if not bin_dir.is_dir():
         return "missing bin/ directory"

--- a/src/gmat_run/results.py
+++ b/src/gmat_run/results.py
@@ -343,7 +343,7 @@ class Results:
         user chose that destination and we honour it. Already-parsed
         DataFrames stay cached; they are independent of the on-disk files.
 
-        Calling ``persist`` again later moves the artefacts to the new
+        Calling ``persist`` again later copies the artefacts to the new
         destination. A no-op fast path applies when the destination already
         equals the current ``output_dir``.
 

--- a/src/gmat_run/results.py
+++ b/src/gmat_run/results.py
@@ -448,7 +448,7 @@ class Results:
         Returns:
             ``dirpath`` as a resolved :class:`pathlib.Path`.
         """
-        dest_dir = Path(dirpath)
+        dest_dir = resolve_user_path(dirpath)
         dest_dir.mkdir(parents=True, exist_ok=True)
         for name in self.ephemerides:
             self.write_oem(name, dest_dir / f"{name}.oem", originator=originator)

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -296,6 +296,27 @@ def test_validate_install_rejects_file(tmp_path: Path) -> None:
     assert excinfo.value.attempts[0][2] == "not a directory"
 
 
+# --- path canonicalisation ----------------------------------------------------
+
+
+def test_validate_install_canonicalises_root(tmp_path: Path) -> None:
+    """Regression for issue #122: the same physical install reached via two
+    different path spellings yields equal GmatInstall objects, so bootstrap()'s
+    "second install" guard does not misfire."""
+    root = _make_install(tmp_path / "gmat-R2026a")
+    # A non-normalised spelling of the very same directory.
+    detour = tmp_path / "gmat-R2026a" / ".." / "gmat-R2026a"
+
+    canonical = locate_gmat(gmat_root=root)
+    via_detour = locate_gmat(gmat_root=detour)
+
+    assert via_detour == canonical
+    assert via_detour.root == root.resolve()
+    assert via_detour.bin_dir == (root / "bin").resolve()
+    assert via_detour.api_dir == (root / "api").resolve()
+    assert via_detour.output_dir == (root / "output").resolve()
+
+
 # --- error reporting ----------------------------------------------------------
 
 

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -778,6 +778,24 @@ def test_write_oem_all_with_no_ephemerides_creates_empty_dir(tmp_path: Path) -> 
     assert list(dest.iterdir()) == []
 
 
+def test_write_oem_all_returns_resolved_expanded_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Regression for issue #120: the return value must honour the docstring's
+    # "resolved Path" contract, matching write_oem and resolve_user_path. Both
+    # HOME (POSIX) and USERPROFILE (Windows) are stubbed because Python's
+    # expanduser reads USERPROFILE on Windows, not HOME.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    result = Results(output_dir=tmp_path, log="")
+
+    dest = result.write_oem_all("~/oem_out")
+
+    assert dest == (tmp_path / "oem_out").resolve()
+    assert dest.is_absolute()
+    assert dest.is_dir()
+
+
 # --- __repr__ / _repr_html_ --------------------------------------------------
 
 


### PR DESCRIPTION
## Summary
- `Results.write_oem_all` built its destination with `Path(dirpath)`, returning a non-`~`-expanded, non-resolved path that contradicted its docstring's "resolved `Path`" promise and the sibling `write_oem`. It now routes through `resolve_user_path`, matching the workspace-wide path contract. (#120)
- `Results.persist`'s docstring contradicted itself — "`persist` is a copy, never a move", then "Calling `persist` again later moves the artefacts". The implementation only ever `copytree`s; the second sentence is reworded to "copies". (#121)
- `install._validate_install` now `.resolve()`s `root` before deriving `bin_dir`/`api_dir`/`output_dir`, so every `GmatInstall` for one physical install is canonical regardless of discovery route. Two loads reaching the same install via different routes (or a symlink) no longer trip `bootstrap()`'s "second install" guard. (#122)

## Test plan
- [x] `uv run pytest` — 786 passed, 34 deselected
- [x] `uv run ruff check` / `uv run ruff format --check` — clean
- [x] `uv run mypy` — clean
- [x] New regression tests: `test_write_oem_all_returns_resolved_expanded_path`, `test_validate_install_canonicalises_root`

Closes #120
Closes #121
Closes #122