### PR TITLE
Cut v0.5.0: version bump, CHANGELOG, full docs + notebook review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,10 @@ jobs:
           uv sync --all-groups --extra examples
           uv run jupyter execute docs/examples/01_load_run_plot.ipynb
           uv run jupyter execute docs/examples/02_parameter_sweep.ipynb
+          uv run jupyter execute docs/examples/03_ground_track.ipynb
           uv run jupyter execute docs/examples/04_export_oem.ipynb
           uv run jupyter execute docs/examples/05_time_scales.ipynb
+          uv run jupyter execute docs/examples/06_solver_iterations.ipynb
 
   lint:
     name: lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,75 @@ All notable changes to gmat-run are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] — 2026-05-20
+
+### Added
+
+- Solver/targeter introspection — [`Results.solver_runs`][gmat_run.Results]
+  exposes a lazy mapping keyed by `Solver` resource name, one
+  `pandas.DataFrame` per `Target` / `Optimize` run. Each frame carries one row
+  per iteration with a column for every `Vary` variable, the goal/constraint
+  residuals, and a terminal `status`; [`Results.converged`][gmat_run.Results]
+  is the derived `{solver: bool}` shortcut. A new pure parser,
+  `gmat_run.parsers.solver_log`, reads the per-`Solver` `.data` file for
+  `DifferentialCorrector` and `Yukon` with no `gmatpy` import (#106, #112).
+- Extended `mission[...]` override grammar — multi-dot sub-resource paths
+  (`mission["FM.Drag.CSSISpaceWeatherFile"] = ...`) and script `Variable`
+  values (`mission["elapsed_seconds.Value"] = ...`), alongside the existing
+  `Resource.Field` form (#103, #104, #111).
+- `Results.report_paths` — a read-only mapping of `ReportFile` resource name
+  to its output path, completing the parser-free path accessors next to
+  `ephemeris_paths`, `contact_paths`, and `solver_paths` (#117, #125).
+- Example notebook *Target a Hohmann transfer and inspect solver iterations*
+  — runs a two-burn transfer and reads the `DifferentialCorrector` history
+  back through `Results.solver_runs`, including a `MaximumIterations`-capped
+  run that ends non-converged without raising (#107, #113).
+
+### Changed
+
+- Every public path-shaped argument — [`Mission.load`][gmat_run.Mission.load],
+  the `working_dir` of [`Mission.run`][gmat_run.Mission.run],
+  [`Results.persist`][gmat_run.Results.persist], and `Results.write_oem` /
+  `write_oem_all` — now expands `~` and resolves a relative path against the
+  caller's working directory when the call is made. Stored path attributes
+  (`Mission.script_path`, `Results.output_dir`) are always absolute. Callers
+  already passing absolute paths are unaffected (#105, #110, #120).
+
+### Fixed
+
+- [`Mission.summary`][gmat_run.Mission.summary] (and the `Mission` / `Results`
+  notebook reprs) crashed the interpreter on any mission containing a branch
+  command — `Target`, `If`, `For`, and the like — and listed
+  `BeginMissionSequence` as a spurious first command. The command-tree walk
+  now stops at each `BranchEnd`, enumerates branches explicitly, and consumes
+  GMAT's full `NoOp -> BeginMissionSequence` sentinel prefix (#114, #116, #123).
+- Running the same `Mission` twice wrote the second run's output into the
+  first run's directory: the output-path rewrite leaked onto the engine object
+  between runs. [`Mission.run`][gmat_run.Mission.run] now restores every
+  rewritten field after the run (including after a failure), so each run
+  resolves its outputs afresh and a `Mission` stays a view of the loaded
+  script — reading a subscriber's `Filename` back yields the value declared in
+  the script, not the resolved workspace path (#115, #124).
+- Relative subscriber and solver output paths were flattened to a bare
+  filename, so two outputs declared with distinct relative paths that shared a
+  basename collided onto one file. Resolution now preserves the subdirectory
+  structure under the run workspace (nested parents are pre-created), rejects a
+  relative `Filename` containing a `..` component, and raises when two outputs
+  of one run resolve to the same path (#119, #127).
+- `promote_epochs` re-tagged an already-converted epoch column with the scale
+  derived from its name, so a promote → convert → promote sequence could
+  silently mislabel the time scale. A scale recorded by an earlier pass or by
+  `convert_column` is now preserved (#118, #126).
+- [`bootstrap`][gmat_run.bootstrap] rejected a second load of the same GMAT
+  install when it was reached through a different discovery route or a
+  symlink; the install root is now canonicalised before the comparison.
+  Separately, the [`Results.persist`][gmat_run.Results.persist] docstring no
+  longer claims the method can "move" artefacts — it only ever copies
+  (#121, #122, #128).
+- `CONTRIBUTING.md` linked to a per-repo Discussions board that does not
+  exist; it now points at the org-wide `astro-tools` Discussions space
+  (#102, #109).
+
 ## [0.4.0] — 2026-05-03
 
 ### Added
@@ -138,6 +207,7 @@ Initial public release.
 - Release workflow: build, PyPI trusted publishing, and
   `gh release create --generate-notes` on `v*` tags (#31).
 
+[0.5.0]: https://github.com/astro-tools/gmat-run/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/astro-tools/gmat-run/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/astro-tools/gmat-run/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/astro-tools/gmat-run/compare/v0.1.1...v0.2.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ existing issues to make sure the work belongs here and not in a future repo.
 
 - **Building missions in Python →** [`gmatpyplus`](https://github.com/weasdown/gmatpyplus).
 - **Generating `.script` text from Python →** [`pygmat`](https://pypi.org/project/pygmat/).
-- **Parallel sweeps / Monte Carlo →** a future `astro-tools/gmat-sweep`.
+- **Parallel sweeps / Monte Carlo →** [`astro-tools/gmat-sweep`](https://github.com/astro-tools/gmat-sweep).
 
 ## Questions
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ gmat-run loads it, lets you override fields from Python, runs the mission headle
 - **Not** a way to build GMAT missions from scratch in Python — see
   [`gmatpyplus`](https://github.com/weasdown/gmatpyplus) for that.
 - **Not** a `.script` text generator — see [`pygmat`](https://pypi.org/project/pygmat/).
-- **Not** a parallel sweep runner — that's a future astro-tools project (`gmat-sweep`) built on top.
+- **Not** a parallel sweep runner — see [`gmat-sweep`](https://github.com/astro-tools/gmat-sweep),
+  an astro-tools project built on top.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ gmat-run loads it, lets you override fields from Python, runs the mission headle
 |---|---|---|
 | R2026a | Primary development target | Exercised on every PR (Ubuntu + Windows + macOS, Python 3.10/3.11/3.12) |
 | R2025a | Supported | Exercised on every PR (Ubuntu + Windows + macOS, Python 3.10/3.11/3.12) |
-| R2024a | Expected to work | Not exercised in CI |
-| R2023a | Expected to work | Not exercised in CI |
 | R2022a | Expected to work | Not exercised in CI (Python 3.9 ABI floor; see [known limitations](https://astro-tools.github.io/gmat-run/known-limitations/)) |
 
 Report any version-specific breakage as an issue and we'll add a CI cell for it.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ and sample output.
 
 ## Outputs
 
-`Results` exposes three mappings, each keyed by the GMAT resource name as declared in the
+`Results` exposes four mappings, each keyed by the GMAT resource name as declared in the
 `.script`:
 
 - **`ReportFile`** → DataFrame, with `UTCGregorian` and `*ModJulian` epoch columns promoted
@@ -129,6 +129,10 @@ and sample output.
   variable, the goal/constraint residuals, and a `status` column; `df.attrs["converged"]`
   and the `Results.converged` shortcut answer the yes/no. `DifferentialCorrector` and
   `Yukon` are covered.
+
+Each mapping has a sibling path accessor — `report_paths`, `ephemeris_paths`,
+`contact_paths`, and `solver_paths` — mapping each resource name to the file GMAT wrote,
+so you can locate an output without parsing it.
 
 ## Documentation
 
@@ -148,8 +152,8 @@ Runnable example notebooks:
   vary `Sat.SMA` across a range, run the same script for each, and overlay the resulting
   orbits.
 - [Ground track](https://astro-tools.github.io/gmat-run/examples/03_ground_track/) — read an
-  `EphemerisFile` from `Results.ephemerides` and plot the spacecraft's ground track on a
-  Cartopy world map.
+  `EphemerisFile` from `Results.ephemerides` and plot the spacecraft's ground track on an
+  equirectangular world map.
 - [Export to CCSDS-OEM](https://astro-tools.github.io/gmat-run/examples/04_export_oem/) —
   run a stock GMAT sample that emits an STK ephemeris, convert it to a CCSDS-OEM file
   with `Results.write_oem`, re-parse the result, and visualise the trajectory in 3D.

--- a/docs/ci-with-setup-gmat.md
+++ b/docs/ci-with-setup-gmat.md
@@ -3,7 +3,7 @@
 [`astro-tools/setup-gmat`](https://github.com/astro-tools/setup-gmat) installs
 GMAT on the runner, caches it across runs, and exports `GMAT_ROOT` to the
 workflow environment. With it, a complete CI workflow for a project that uses
-gmat-run is four steps.
+gmat-run is five steps.
 
 ## Minimal workflow
 
@@ -18,7 +18,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
@@ -86,7 +86,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
         gmat-version: [R2025a, R2026a]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'

--- a/docs/examples/01_load_run_plot.ipynb
+++ b/docs/examples/01_load_run_plot.ipynb
@@ -293,11 +293,7 @@
    "cell_type": "markdown",
    "id": "b708869f",
    "metadata": {},
-   "source": [
-    "### Inspect the Results\n",
-    "\n",
-    "`Results` has the same notebook treatment: bare-evaluating it lists the reports, ephemerides, and contacts the run produced (by name only — the DataFrames are not materialised, so this stays cheap)."
-   ]
+   "source": "### Inspect the Results\n\n`Results` has the same notebook treatment: bare-evaluating it lists the reports, ephemerides, contacts, and solver runs the run produced (by name only — the DataFrames are not materialised, so this stays cheap)."
   },
   {
    "cell_type": "code",
@@ -432,13 +428,7 @@
    "cell_type": "markdown",
    "id": "6d0c67a9",
    "metadata": {},
-   "source": [
-    "## Where to next\n",
-    "\n",
-    "- **Override script fields from Python.** The [Getting started guide](https://astro-tools.github.io/gmat-run/getting-started/) shows how to write to fields via subscript access (e.g. `mission['Sat.SMA'] = 7000`) before running.\n",
-    "- **Read other output types.** `Results` also exposes `.ephemerides` (CCSDS-OEM and STK-TimePosVel formats) and `.contacts` (`ContactLocator`) as DataFrames — see the [API reference](https://astro-tools.github.io/gmat-run/reference/).\n",
-    "- **Run from the shell.** The [`gmat-run` CLI](https://astro-tools.github.io/gmat-run/cli/) wraps the same load → run → write loop for shell scripts and smoke tests."
-   ]
+   "source": "## Where to next\n\n- **Override script fields from Python.** The [Getting started guide](https://astro-tools.github.io/gmat-run/getting-started/) shows how to write to fields via subscript access (e.g. `mission['Sat.SMA'] = 7000`) before running.\n- **Read other output types.** `Results` also exposes `.ephemerides` (CCSDS-OEM and STK-TimePosVel formats), `.contacts` (`ContactLocator`), and `.solver_runs` (`Target` / `Optimize` iteration history) as DataFrames — see the [API reference](https://astro-tools.github.io/gmat-run/reference/) and [notebook 6](06_solver_iterations.ipynb).\n- **Run from the shell.** The [`gmat-run` CLI](https://astro-tools.github.io/gmat-run/cli/) wraps the same load → run → write loop for shell scripts and smoke tests."
   }
  ],
  "metadata": {

--- a/docs/examples/01_load_run_plot.ipynb
+++ b/docs/examples/01_load_run_plot.ipynb
@@ -35,10 +35,10 @@
    "id": "069b67f5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T17:33:08.457293Z",
-     "iopub.status.busy": "2026-05-20T17:33:08.457143Z",
-     "iopub.status.idle": "2026-05-20T17:33:13.857408Z",
-     "shell.execute_reply": "2026-05-20T17:33:13.856348Z"
+     "iopub.execute_input": "2026-05-20T17:55:02.432316Z",
+     "iopub.status.busy": "2026-05-20T17:55:02.432165Z",
+     "iopub.status.idle": "2026-05-20T17:55:06.287959Z",
+     "shell.execute_reply": "2026-05-20T17:55:06.286854Z"
     }
    },
    "outputs": [
@@ -84,10 +84,10 @@
    "id": "3311d486",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T17:33:13.859064Z",
-     "iopub.status.busy": "2026-05-20T17:33:13.858830Z",
-     "iopub.status.idle": "2026-05-20T17:33:14.227809Z",
-     "shell.execute_reply": "2026-05-20T17:33:14.226760Z"
+     "iopub.execute_input": "2026-05-20T17:55:06.289770Z",
+     "iopub.status.busy": "2026-05-20T17:55:06.289532Z",
+     "iopub.status.idle": "2026-05-20T17:55:06.673041Z",
+     "shell.execute_reply": "2026-05-20T17:55:06.671954Z"
     }
    },
    "outputs": [
@@ -127,17 +127,17 @@
    "id": "7baf7527",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T17:33:14.229593Z",
-     "iopub.status.busy": "2026-05-20T17:33:14.229418Z",
-     "iopub.status.idle": "2026-05-20T17:33:14.236832Z",
-     "shell.execute_reply": "2026-05-20T17:33:14.235796Z"
+     "iopub.execute_input": "2026-05-20T17:55:06.674605Z",
+     "iopub.status.busy": "2026-05-20T17:55:06.674388Z",
+     "iopub.status.idle": "2026-05-20T17:55:06.682163Z",
+     "shell.execute_reply": "2026-05-20T17:55:06.680994Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<div class=\"gmat-run-mission-summary\"><strong>Mission:</strong> <code>Ex_TLE_Propagation.script</code><table class=\"gmat-run-resources\"><thead><tr><th style=\"text-align:left\">Resource type</th><th style=\"text-align:right\">Count</th><th style=\"text-align:left\">Names</th></tr></thead><tbody><tr><td style=\"text-align:left\">Spacecraft</td><td style=\"text-align:right\">1</td><td style=\"text-align:left\">ExampleSat</td></tr><tr><td style=\"text-align:left\">Propagator</td><td style=\"text-align:right\">1</td><td style=\"text-align:left\">TLEProp</td></tr><tr><td style=\"text-align:left\">CoordinateSystem</td><td style=\"text-align:right\">4</td><td style=\"text-align:left\">EarthMJ2000Eq, EarthMJ2000Ec, EarthFixed, EarthICRF</td></tr><tr><td style=\"text-align:left\">ReportFile</td><td style=\"text-align:right\">1</td><td style=\"text-align:left\">RF</td></tr><tr><td style=\"text-align:left\">Other</td><td style=\"text-align:right\">9</td><td style=\"text-align:left\">SolarSystemBarycenter, ExampleSat.UTCGregorian, ExampleSat.X, ExampleSat.Y, ExampleSat.Z, ExampleSat.VX, ExampleSat.VY, ExampleSat.VZ, ExampleSat.ElapsedDays</td></tr></tbody></table><strong>Outputs</strong><table class=\"gmat-run-outputs\"><thead><tr><th style=\"text-align:left\">Resource type</th><th style=\"text-align:left\">Names</th></tr></thead><tbody><tr><td style=\"text-align:left\">ReportFile</td><td style=\"text-align:left\">RF</td></tr></tbody></table><strong>Mission sequence</strong> (1 commands)<ol><li><code>Propagate</code> — Propagate TLEProp(ExampleSat) {ExampleSat.ElapsedDays = 1.0};</li></ol></div>"
+       "<div class=\"gmat-run-mission-summary\"><strong>Mission:</strong> <code>Ex_TLE_Propagation.script</code><table class=\"gmat-run-resources\"><thead><tr><th style=\"text-align:left\">Resource type</th><th style=\"text-align:right\">Count</th><th style=\"text-align:left\">Names</th></tr></thead><tbody><tr><td style=\"text-align:left\">Spacecraft</td><td style=\"text-align:right\">1</td><td style=\"text-align:left\">ExampleSat</td></tr><tr><td style=\"text-align:left\">Propagator</td><td style=\"text-align:right\">1</td><td style=\"text-align:left\">TLEProp</td></tr><tr><td style=\"text-align:left\">CoordinateSystem</td><td style=\"text-align:right\">4</td><td style=\"text-align:left\">EarthMJ2000Eq, EarthMJ2000Ec, EarthFixed, EarthICRF</td></tr><tr><td style=\"text-align:left\">ReportFile</td><td style=\"text-align:right\">1</td><td style=\"text-align:left\">RF</td></tr><tr><td style=\"text-align:left\">Other</td><td style=\"text-align:right\">9</td><td style=\"text-align:left\">SolarSystemBarycenter, ExampleSat.UTCGregorian, ExampleSat.X, ExampleSat.Y, ExampleSat.Z, ExampleSat.VX, ExampleSat.VY, ExampleSat.VZ, ExampleSat.ElapsedDays</td></tr></tbody></table><strong>Outputs</strong><table class=\"gmat-run-outputs\"><thead><tr><th style=\"text-align:left\">Resource type</th><th style=\"text-align:left\">Names</th></tr></thead><tbody><tr><td style=\"text-align:left\">ReportFile</td><td style=\"text-align:left\">RF</td></tr></tbody></table><strong>Mission sequence</strong> (1 command)<ol><li><code>Propagate</code> — Propagate TLEProp(ExampleSat) {ExampleSat.ElapsedDays = 1.0};</li></ol></div>"
       ],
       "text/plain": [
        "Mission('Ex_TLE_Propagation.script', spacecraft=1, commands=1)"
@@ -170,10 +170,10 @@
    "id": "37a9eec8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T17:33:14.238361Z",
-     "iopub.status.busy": "2026-05-20T17:33:14.238209Z",
-     "iopub.status.idle": "2026-05-20T17:33:14.768657Z",
-     "shell.execute_reply": "2026-05-20T17:33:14.767624Z"
+     "iopub.execute_input": "2026-05-20T17:55:06.683928Z",
+     "iopub.status.busy": "2026-05-20T17:55:06.683755Z",
+     "iopub.status.idle": "2026-05-20T17:55:06.781721Z",
+     "shell.execute_reply": "2026-05-20T17:55:06.780610Z"
     }
    },
    "outputs": [
@@ -305,10 +305,10 @@
    "id": "f7132fb1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T17:33:14.770172Z",
-     "iopub.status.busy": "2026-05-20T17:33:14.770013Z",
-     "iopub.status.idle": "2026-05-20T17:33:14.773793Z",
-     "shell.execute_reply": "2026-05-20T17:33:14.772866Z"
+     "iopub.execute_input": "2026-05-20T17:55:06.783436Z",
+     "iopub.status.busy": "2026-05-20T17:55:06.783266Z",
+     "iopub.status.idle": "2026-05-20T17:55:06.787323Z",
+     "shell.execute_reply": "2026-05-20T17:55:06.786339Z"
     }
    },
    "outputs": [
@@ -344,10 +344,10 @@
    "id": "2ae2939c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T17:33:14.775293Z",
-     "iopub.status.busy": "2026-05-20T17:33:14.775147Z",
-     "iopub.status.idle": "2026-05-20T17:33:14.780120Z",
-     "shell.execute_reply": "2026-05-20T17:33:14.779038Z"
+     "iopub.execute_input": "2026-05-20T17:55:06.788889Z",
+     "iopub.status.busy": "2026-05-20T17:55:06.788738Z",
+     "iopub.status.idle": "2026-05-20T17:55:06.794208Z",
+     "shell.execute_reply": "2026-05-20T17:55:06.793150Z"
     }
    },
    "outputs": [
@@ -389,10 +389,10 @@
    "id": "346f1d57",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T17:33:14.781577Z",
-     "iopub.status.busy": "2026-05-20T17:33:14.781423Z",
-     "iopub.status.idle": "2026-05-20T17:33:15.931241Z",
-     "shell.execute_reply": "2026-05-20T17:33:15.930040Z"
+     "iopub.execute_input": "2026-05-20T17:55:06.795702Z",
+     "iopub.status.busy": "2026-05-20T17:55:06.795550Z",
+     "iopub.status.idle": "2026-05-20T17:55:07.212606Z",
+     "shell.execute_reply": "2026-05-20T17:55:07.211616Z"
     }
    },
    "outputs": [

--- a/docs/examples/01_load_run_plot.ipynb
+++ b/docs/examples/01_load_run_plot.ipynb
@@ -35,10 +35,10 @@
    "id": "069b67f5",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T16:35:08.886248Z",
-     "iopub.status.busy": "2026-05-03T16:35:08.886079Z",
-     "iopub.status.idle": "2026-05-03T16:35:12.400181Z",
-     "shell.execute_reply": "2026-05-03T16:35:12.399019Z"
+     "iopub.execute_input": "2026-05-20T17:33:08.457293Z",
+     "iopub.status.busy": "2026-05-20T17:33:08.457143Z",
+     "iopub.status.idle": "2026-05-20T17:33:13.857408Z",
+     "shell.execute_reply": "2026-05-20T17:33:13.856348Z"
     }
    },
    "outputs": [
@@ -84,10 +84,10 @@
    "id": "3311d486",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T16:35:12.402024Z",
-     "iopub.status.busy": "2026-05-03T16:35:12.401591Z",
-     "iopub.status.idle": "2026-05-03T16:35:12.644939Z",
-     "shell.execute_reply": "2026-05-03T16:35:12.643769Z"
+     "iopub.execute_input": "2026-05-20T17:33:13.859064Z",
+     "iopub.status.busy": "2026-05-20T17:33:13.858830Z",
+     "iopub.status.idle": "2026-05-20T17:33:14.227809Z",
+     "shell.execute_reply": "2026-05-20T17:33:14.226760Z"
     }
    },
    "outputs": [
@@ -127,20 +127,20 @@
    "id": "7baf7527",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T16:35:12.646398Z",
-     "iopub.status.busy": "2026-05-03T16:35:12.646242Z",
-     "iopub.status.idle": "2026-05-03T16:35:12.652299Z",
-     "shell.execute_reply": "2026-05-03T16:35:12.651271Z"
+     "iopub.execute_input": "2026-05-20T17:33:14.229593Z",
+     "iopub.status.busy": "2026-05-20T17:33:14.229418Z",
+     "iopub.status.idle": "2026-05-20T17:33:14.236832Z",
+     "shell.execute_reply": "2026-05-20T17:33:14.235796Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<div class=\"gmat-run-mission-summary\"><strong>Mission:</strong> <code>Ex_TLE_Propagation.script</code><table class=\"gmat-run-resources\"><thead><tr><th style=\"text-align:left\">Resource type</th><th style=\"text-align:right\">Count</th><th style=\"text-align:left\">Names</th></tr></thead><tbody><tr><td style=\"text-align:left\">Spacecraft</td><td style=\"text-align:right\">1</td><td style=\"text-align:left\">ExampleSat</td></tr><tr><td style=\"text-align:left\">Propagator</td><td style=\"text-align:right\">1</td><td style=\"text-align:left\">TLEProp</td></tr><tr><td style=\"text-align:left\">CoordinateSystem</td><td style=\"text-align:right\">4</td><td style=\"text-align:left\">EarthMJ2000Eq, EarthMJ2000Ec, EarthFixed, EarthICRF</td></tr><tr><td style=\"text-align:left\">ReportFile</td><td style=\"text-align:right\">1</td><td style=\"text-align:left\">RF</td></tr><tr><td style=\"text-align:left\">Other</td><td style=\"text-align:right\">9</td><td style=\"text-align:left\">SolarSystemBarycenter, ExampleSat.UTCGregorian, ExampleSat.X, ExampleSat.Y, ExampleSat.Z, ExampleSat.VX, ExampleSat.VY, ExampleSat.VZ, ExampleSat.ElapsedDays</td></tr></tbody></table><strong>Outputs</strong><table class=\"gmat-run-outputs\"><thead><tr><th style=\"text-align:left\">Resource type</th><th style=\"text-align:left\">Names</th></tr></thead><tbody><tr><td style=\"text-align:left\">ReportFile</td><td style=\"text-align:left\">RF</td></tr></tbody></table><strong>Mission sequence</strong> (2 commands)<ol><li><code>BeginMissionSequence</code> — %----------------------------------------</li><li><code>Propagate</code> — Propagate TLEProp(ExampleSat) {ExampleSat.ElapsedDays = 1.0};</li></ol></div>"
+       "<div class=\"gmat-run-mission-summary\"><strong>Mission:</strong> <code>Ex_TLE_Propagation.script</code><table class=\"gmat-run-resources\"><thead><tr><th style=\"text-align:left\">Resource type</th><th style=\"text-align:right\">Count</th><th style=\"text-align:left\">Names</th></tr></thead><tbody><tr><td style=\"text-align:left\">Spacecraft</td><td style=\"text-align:right\">1</td><td style=\"text-align:left\">ExampleSat</td></tr><tr><td style=\"text-align:left\">Propagator</td><td style=\"text-align:right\">1</td><td style=\"text-align:left\">TLEProp</td></tr><tr><td style=\"text-align:left\">CoordinateSystem</td><td style=\"text-align:right\">4</td><td style=\"text-align:left\">EarthMJ2000Eq, EarthMJ2000Ec, EarthFixed, EarthICRF</td></tr><tr><td style=\"text-align:left\">ReportFile</td><td style=\"text-align:right\">1</td><td style=\"text-align:left\">RF</td></tr><tr><td style=\"text-align:left\">Other</td><td style=\"text-align:right\">9</td><td style=\"text-align:left\">SolarSystemBarycenter, ExampleSat.UTCGregorian, ExampleSat.X, ExampleSat.Y, ExampleSat.Z, ExampleSat.VX, ExampleSat.VY, ExampleSat.VZ, ExampleSat.ElapsedDays</td></tr></tbody></table><strong>Outputs</strong><table class=\"gmat-run-outputs\"><thead><tr><th style=\"text-align:left\">Resource type</th><th style=\"text-align:left\">Names</th></tr></thead><tbody><tr><td style=\"text-align:left\">ReportFile</td><td style=\"text-align:left\">RF</td></tr></tbody></table><strong>Mission sequence</strong> (1 commands)<ol><li><code>Propagate</code> — Propagate TLEProp(ExampleSat) {ExampleSat.ElapsedDays = 1.0};</li></ol></div>"
       ],
       "text/plain": [
-       "Mission('Ex_TLE_Propagation.script', spacecraft=1, commands=2)"
+       "Mission('Ex_TLE_Propagation.script', spacecraft=1, commands=1)"
       ]
      },
      "execution_count": 3,
@@ -170,10 +170,10 @@
    "id": "37a9eec8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T16:35:12.653816Z",
-     "iopub.status.busy": "2026-05-03T16:35:12.653660Z",
-     "iopub.status.idle": "2026-05-03T16:35:12.742886Z",
-     "shell.execute_reply": "2026-05-03T16:35:12.741827Z"
+     "iopub.execute_input": "2026-05-20T17:33:14.238361Z",
+     "iopub.status.busy": "2026-05-20T17:33:14.238209Z",
+     "iopub.status.idle": "2026-05-20T17:33:14.768657Z",
+     "shell.execute_reply": "2026-05-20T17:33:14.767624Z"
     }
    },
    "outputs": [
@@ -293,7 +293,11 @@
    "cell_type": "markdown",
    "id": "b708869f",
    "metadata": {},
-   "source": "### Inspect the Results\n\n`Results` has the same notebook treatment: bare-evaluating it lists the reports, ephemerides, contacts, and solver runs the run produced (by name only — the DataFrames are not materialised, so this stays cheap)."
+   "source": [
+    "### Inspect the Results\n",
+    "\n",
+    "`Results` has the same notebook treatment: bare-evaluating it lists the reports, ephemerides, contacts, and solver runs the run produced (by name only — the DataFrames are not materialised, so this stays cheap)."
+   ]
   },
   {
    "cell_type": "code",
@@ -301,20 +305,20 @@
    "id": "f7132fb1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T16:35:12.744364Z",
-     "iopub.status.busy": "2026-05-03T16:35:12.744199Z",
-     "iopub.status.idle": "2026-05-03T16:35:12.748101Z",
-     "shell.execute_reply": "2026-05-03T16:35:12.747134Z"
+     "iopub.execute_input": "2026-05-20T17:33:14.770172Z",
+     "iopub.status.busy": "2026-05-20T17:33:14.770013Z",
+     "iopub.status.idle": "2026-05-20T17:33:14.773793Z",
+     "shell.execute_reply": "2026-05-20T17:33:14.772866Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<div class=\"gmat-run-results\"><strong>Results</strong><table><thead><tr><th style=\"text-align:left\">Output</th><th style=\"text-align:right\">Count</th><th style=\"text-align:left\">Names</th></tr></thead><tbody><tr><td style=\"text-align:left\"><code>reports</code></td><td style=\"text-align:right\">1</td><td style=\"text-align:left\">RF</td></tr><tr><td style=\"text-align:left\"><code>ephemerides</code></td><td style=\"text-align:right\">0</td><td style=\"text-align:left\"><em>none</em></td></tr><tr><td style=\"text-align:left\"><code>contacts</code></td><td style=\"text-align:right\">0</td><td style=\"text-align:left\"><em>none</em></td></tr></tbody></table></div>"
+       "<div class=\"gmat-run-results\"><strong>Results</strong><table><thead><tr><th style=\"text-align:left\">Output</th><th style=\"text-align:right\">Count</th><th style=\"text-align:left\">Names</th></tr></thead><tbody><tr><td style=\"text-align:left\"><code>reports</code></td><td style=\"text-align:right\">1</td><td style=\"text-align:left\">RF</td></tr><tr><td style=\"text-align:left\"><code>ephemerides</code></td><td style=\"text-align:right\">0</td><td style=\"text-align:left\"><em>none</em></td></tr><tr><td style=\"text-align:left\"><code>contacts</code></td><td style=\"text-align:right\">0</td><td style=\"text-align:left\"><em>none</em></td></tr><tr><td style=\"text-align:left\"><code>solver_runs</code></td><td style=\"text-align:right\">0</td><td style=\"text-align:left\"><em>none</em></td></tr></tbody></table></div>"
       ],
       "text/plain": [
-       "Results(reports=1, ephemerides=0, contacts=0)"
+       "Results(reports=1, ephemerides=0, contacts=0, solver_runs=0)"
       ]
      },
      "execution_count": 5,
@@ -340,10 +344,10 @@
    "id": "2ae2939c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T16:35:12.749459Z",
-     "iopub.status.busy": "2026-05-03T16:35:12.749311Z",
-     "iopub.status.idle": "2026-05-03T16:35:12.754117Z",
-     "shell.execute_reply": "2026-05-03T16:35:12.753223Z"
+     "iopub.execute_input": "2026-05-20T17:33:14.775293Z",
+     "iopub.status.busy": "2026-05-20T17:33:14.775147Z",
+     "iopub.status.idle": "2026-05-20T17:33:14.780120Z",
+     "shell.execute_reply": "2026-05-20T17:33:14.779038Z"
     }
    },
    "outputs": [
@@ -385,10 +389,10 @@
    "id": "346f1d57",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-03T16:35:12.755655Z",
-     "iopub.status.busy": "2026-05-03T16:35:12.755466Z",
-     "iopub.status.idle": "2026-05-03T16:35:13.150591Z",
-     "shell.execute_reply": "2026-05-03T16:35:13.149653Z"
+     "iopub.execute_input": "2026-05-20T17:33:14.781577Z",
+     "iopub.status.busy": "2026-05-20T17:33:14.781423Z",
+     "iopub.status.idle": "2026-05-20T17:33:15.931241Z",
+     "shell.execute_reply": "2026-05-20T17:33:15.930040Z"
     }
    },
    "outputs": [
@@ -428,7 +432,13 @@
    "cell_type": "markdown",
    "id": "6d0c67a9",
    "metadata": {},
-   "source": "## Where to next\n\n- **Override script fields from Python.** The [Getting started guide](https://astro-tools.github.io/gmat-run/getting-started/) shows how to write to fields via subscript access (e.g. `mission['Sat.SMA'] = 7000`) before running.\n- **Read other output types.** `Results` also exposes `.ephemerides` (CCSDS-OEM and STK-TimePosVel formats), `.contacts` (`ContactLocator`), and `.solver_runs` (`Target` / `Optimize` iteration history) as DataFrames — see the [API reference](https://astro-tools.github.io/gmat-run/reference/) and [notebook 6](06_solver_iterations.ipynb).\n- **Run from the shell.** The [`gmat-run` CLI](https://astro-tools.github.io/gmat-run/cli/) wraps the same load → run → write loop for shell scripts and smoke tests."
+   "source": [
+    "## Where to next\n",
+    "\n",
+    "- **Override script fields from Python.** The [Getting started guide](https://astro-tools.github.io/gmat-run/getting-started/) shows how to write to fields via subscript access (e.g. `mission['Sat.SMA'] = 7000`) before running.\n",
+    "- **Read other output types.** `Results` also exposes `.ephemerides` (CCSDS-OEM and STK-TimePosVel formats), `.contacts` (`ContactLocator`), and `.solver_runs` (`Target` / `Optimize` iteration history) as DataFrames — see the [API reference](https://astro-tools.github.io/gmat-run/reference/) and [notebook 6](06_solver_iterations.ipynb).\n",
+    "- **Run from the shell.** The [`gmat-run` CLI](https://astro-tools.github.io/gmat-run/cli/) wraps the same load → run → write loop for shell scripts and smoke tests."
+   ]
   }
  ],
  "metadata": {

--- a/docs/examples/02_parameter_sweep.ipynb
+++ b/docs/examples/02_parameter_sweep.ipynb
@@ -446,11 +446,7 @@
    "cell_type": "markdown",
    "id": "45fdf39b",
    "metadata": {},
-   "source": [
-    "## Single-machine demo\n",
-    "\n",
-    "This loop runs the eight cases sequentially in the current Python process — fine for demos, prototyping, and small grids, but it scales linearly in wall-clock with the run count. Distributed sweeps (thousands of cases, Monte Carlo, parallel workers) are out of scope for `gmat-run` by design — that's the job of the future [`astro-tools/gmat-sweep`](https://github.com/astro-tools) library, which will reuse the same `Mission.load` + override pattern under the hood. The library boundary stays at *one process, one script*; everything above lives in tools that wrap it."
-   ]
+   "source": "## Single-machine demo\n\nThis loop runs the eight cases sequentially in the current Python process — fine for demos, prototyping, and small grids, but it scales linearly in wall-clock with the run count. Distributed sweeps (thousands of cases, Monte Carlo, parallel workers) are out of scope for `gmat-run` by design — that's the job of the [`astro-tools/gmat-sweep`](https://github.com/astro-tools/gmat-sweep) library, which reuses the same `Mission.load` + override pattern under the hood. The library boundary stays at *one process, one script*; everything above lives in tools that wrap it."
   },
   {
    "cell_type": "markdown",

--- a/docs/examples/02_parameter_sweep.ipynb
+++ b/docs/examples/02_parameter_sweep.ipynb
@@ -35,10 +35,10 @@
    "id": "26afc46b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-26T17:20:51.348426Z",
-     "iopub.status.busy": "2026-04-26T17:20:51.348262Z",
-     "iopub.status.idle": "2026-04-26T17:20:54.962430Z",
-     "shell.execute_reply": "2026-04-26T17:20:54.961332Z"
+     "iopub.execute_input": "2026-05-20T17:33:34.671494Z",
+     "iopub.status.busy": "2026-05-20T17:33:34.671331Z",
+     "iopub.status.idle": "2026-05-20T17:33:38.293063Z",
+     "shell.execute_reply": "2026-05-20T17:33:38.292039Z"
     }
    },
    "outputs": [
@@ -85,10 +85,10 @@
    "id": "712aaf64",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-26T17:20:54.964064Z",
-     "iopub.status.busy": "2026-04-26T17:20:54.963830Z",
-     "iopub.status.idle": "2026-04-26T17:20:54.970331Z",
-     "shell.execute_reply": "2026-04-26T17:20:54.969326Z"
+     "iopub.execute_input": "2026-05-20T17:33:38.294631Z",
+     "iopub.status.busy": "2026-05-20T17:33:38.294403Z",
+     "iopub.status.idle": "2026-05-20T17:33:38.300860Z",
+     "shell.execute_reply": "2026-05-20T17:33:38.299868Z"
     }
    },
    "outputs": [
@@ -126,10 +126,10 @@
    "id": "8db52fdd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-26T17:20:54.971767Z",
-     "iopub.status.busy": "2026-04-26T17:20:54.971609Z",
-     "iopub.status.idle": "2026-04-26T17:20:57.240825Z",
-     "shell.execute_reply": "2026-04-26T17:20:57.239723Z"
+     "iopub.execute_input": "2026-05-20T17:33:38.302304Z",
+     "iopub.status.busy": "2026-05-20T17:33:38.302156Z",
+     "iopub.status.idle": "2026-05-20T17:33:40.598354Z",
+     "shell.execute_reply": "2026-05-20T17:33:40.597238Z"
     }
    },
    "outputs": [
@@ -262,10 +262,10 @@
    "id": "ff657373",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-26T17:20:57.242368Z",
-     "iopub.status.busy": "2026-04-26T17:20:57.242177Z",
-     "iopub.status.idle": "2026-04-26T17:20:57.250837Z",
-     "shell.execute_reply": "2026-04-26T17:20:57.249839Z"
+     "iopub.execute_input": "2026-05-20T17:33:40.599990Z",
+     "iopub.status.busy": "2026-05-20T17:33:40.599799Z",
+     "iopub.status.idle": "2026-05-20T17:33:40.608584Z",
+     "shell.execute_reply": "2026-05-20T17:33:40.607579Z"
     }
    },
    "outputs": [
@@ -392,10 +392,10 @@
    "id": "0bf085ba",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-26T17:20:57.252277Z",
-     "iopub.status.busy": "2026-04-26T17:20:57.252115Z",
-     "iopub.status.idle": "2026-04-26T17:20:57.781044Z",
-     "shell.execute_reply": "2026-04-26T17:20:57.780082Z"
+     "iopub.execute_input": "2026-05-20T17:33:40.610239Z",
+     "iopub.status.busy": "2026-05-20T17:33:40.610085Z",
+     "iopub.status.idle": "2026-05-20T17:33:41.132567Z",
+     "shell.execute_reply": "2026-05-20T17:33:41.131610Z"
     }
    },
    "outputs": [

--- a/docs/examples/03_ground_track.ipynb
+++ b/docs/examples/03_ground_track.ipynb
@@ -4,7 +4,19 @@
    "cell_type": "markdown",
    "id": "f59f5e1e",
    "metadata": {},
-   "source": "# Plot a ground track from an Earth-fixed ephemeris\n\nThis notebook drives the `EphemerisFile` parser end-to-end:\n\n1. Load a small mission script that writes an `EphemerisFile` in an Earth-fixed frame.\n2. Run the mission and grab `result.ephemerides[\"EF\"]` as a DataFrame.\n3. Project the body-fixed state vector onto (lon, lat) and plot the ground track on an equirectangular world map.\n\nWe drive a minimal LEO mission script that ships next to this notebook (`ground_track_leo.script` — Keplerian initial state at ISS-like inclination, point-mass Earth, 24 hours of propagation, single `EphemerisFile` written in `CoordinateSystem = EarthFixed`). Because GMAT writes the ephemeris in the rotating Earth frame, the notebook never has to do a frame transform — only a spherical-coordinates projection.\n\n**Prerequisites.** A local GMAT install (R2026a is the primary development target) and `pip install gmat-run[examples]` for the matplotlib dependency."
+   "source": [
+    "# Plot a ground track from an Earth-fixed ephemeris\n",
+    "\n",
+    "This notebook drives the `EphemerisFile` parser end-to-end:\n",
+    "\n",
+    "1. Load a small mission script that writes an `EphemerisFile` in an Earth-fixed frame.\n",
+    "2. Run the mission and grab `result.ephemerides[\"EF\"]` as a DataFrame.\n",
+    "3. Project the body-fixed state vector onto (lon, lat) and plot the ground track on an equirectangular world map.\n",
+    "\n",
+    "We drive a minimal LEO mission script that ships next to this notebook (`ground_track_leo.script` — Keplerian initial state at ISS-like inclination, point-mass Earth, 24 hours of propagation, single `EphemerisFile` written in `CoordinateSystem = EarthFixed`). Because GMAT writes the ephemeris in the rotating Earth frame, the notebook never has to do a frame transform — only a spherical-coordinates projection.\n",
+    "\n",
+    "**Prerequisites.** A local GMAT install (R2026a is the primary development target) and `pip install gmat-run[examples]` for the matplotlib dependency."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -22,10 +34,10 @@
    "id": "28c1a785",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-26T17:46:19.686250Z",
-     "iopub.status.busy": "2026-04-26T17:46:19.686096Z",
-     "iopub.status.idle": "2026-04-26T17:46:22.376871Z",
-     "shell.execute_reply": "2026-04-26T17:46:22.375753Z"
+     "iopub.execute_input": "2026-05-20T17:33:59.792136Z",
+     "iopub.status.busy": "2026-05-20T17:33:59.791966Z",
+     "iopub.status.idle": "2026-05-20T17:34:03.397310Z",
+     "shell.execute_reply": "2026-05-20T17:34:03.396219Z"
     }
    },
    "outputs": [
@@ -75,10 +87,10 @@
    "id": "51a448f0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-26T17:46:22.378478Z",
-     "iopub.status.busy": "2026-04-26T17:46:22.378253Z",
-     "iopub.status.idle": "2026-04-26T17:46:22.981937Z",
-     "shell.execute_reply": "2026-04-26T17:46:22.980797Z"
+     "iopub.execute_input": "2026-05-20T17:34:03.399052Z",
+     "iopub.status.busy": "2026-05-20T17:34:03.398782Z",
+     "iopub.status.idle": "2026-05-20T17:34:04.023631Z",
+     "shell.execute_reply": "2026-05-20T17:34:04.022556Z"
     }
    },
    "outputs": [
@@ -232,10 +244,10 @@
    "id": "c458233e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-26T17:46:22.983416Z",
-     "iopub.status.busy": "2026-04-26T17:46:22.983255Z",
-     "iopub.status.idle": "2026-04-26T17:46:22.988792Z",
-     "shell.execute_reply": "2026-04-26T17:46:22.987833Z"
+     "iopub.execute_input": "2026-05-20T17:34:04.025226Z",
+     "iopub.status.busy": "2026-05-20T17:34:04.025066Z",
+     "iopub.status.idle": "2026-05-20T17:34:04.032415Z",
+     "shell.execute_reply": "2026-05-20T17:34:04.031409Z"
     }
    },
    "outputs": [
@@ -275,10 +287,10 @@
    "id": "8ae6fe7d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-26T17:46:22.990241Z",
-     "iopub.status.busy": "2026-04-26T17:46:22.990089Z",
-     "iopub.status.idle": "2026-04-26T17:46:23.156122Z",
-     "shell.execute_reply": "2026-04-26T17:46:23.155216Z"
+     "iopub.execute_input": "2026-05-20T17:34:04.034029Z",
+     "iopub.status.busy": "2026-05-20T17:34:04.033864Z",
+     "iopub.status.idle": "2026-05-20T17:34:04.394601Z",
+     "shell.execute_reply": "2026-05-20T17:34:04.393469Z"
     }
    },
    "outputs": [

--- a/docs/examples/03_ground_track.ipynb
+++ b/docs/examples/03_ground_track.ipynb
@@ -4,19 +4,7 @@
    "cell_type": "markdown",
    "id": "f59f5e1e",
    "metadata": {},
-   "source": [
-    "# Plot a ground track from an Earth-fixed ephemeris\n",
-    "\n",
-    "This notebook drives the new `EphemerisFile` parser end-to-end:\n",
-    "\n",
-    "1. Load a small mission script that writes an `EphemerisFile` in an Earth-fixed frame.\n",
-    "2. Run the mission and grab `result.ephemerides[\"EF\"]` as a DataFrame.\n",
-    "3. Project the body-fixed state vector onto (lon, lat) and plot the ground track on an equirectangular world map.\n",
-    "\n",
-    "We drive a minimal LEO mission script that ships next to this notebook (`ground_track_leo.script` — Keplerian initial state at ISS-like inclination, point-mass Earth, 24 hours of propagation, single `EphemerisFile` written in `CoordinateSystem = EarthFixed`). Because GMAT writes the ephemeris in the rotating Earth frame, the notebook never has to do a frame transform — only a spherical-coordinates projection.\n",
-    "\n",
-    "**Prerequisites.** A local GMAT install (R2026a is the primary development target) and `pip install gmat-run[examples]` for the matplotlib dependency."
-   ]
+   "source": "# Plot a ground track from an Earth-fixed ephemeris\n\nThis notebook drives the `EphemerisFile` parser end-to-end:\n\n1. Load a small mission script that writes an `EphemerisFile` in an Earth-fixed frame.\n2. Run the mission and grab `result.ephemerides[\"EF\"]` as a DataFrame.\n3. Project the body-fixed state vector onto (lon, lat) and plot the ground track on an equirectangular world map.\n\nWe drive a minimal LEO mission script that ships next to this notebook (`ground_track_leo.script` — Keplerian initial state at ISS-like inclination, point-mass Earth, 24 hours of propagation, single `EphemerisFile` written in `CoordinateSystem = EarthFixed`). Because GMAT writes the ephemeris in the rotating Earth frame, the notebook never has to do a frame transform — only a spherical-coordinates projection.\n\n**Prerequisites.** A local GMAT install (R2026a is the primary development target) and `pip install gmat-run[examples]` for the matplotlib dependency."
   },
   {
    "cell_type": "markdown",

--- a/docs/examples/04_export_oem.ipynb
+++ b/docs/examples/04_export_oem.ipynb
@@ -30,10 +30,10 @@
    "id": "800b327e",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T03:05:19.694309Z",
-     "iopub.status.busy": "2026-04-28T03:05:19.694123Z",
-     "iopub.status.idle": "2026-04-28T03:05:23.164673Z",
-     "shell.execute_reply": "2026-04-28T03:05:23.163656Z"
+     "iopub.execute_input": "2026-05-20T17:34:27.971239Z",
+     "iopub.status.busy": "2026-05-20T17:34:27.971085Z",
+     "iopub.status.idle": "2026-05-20T17:34:31.593401Z",
+     "shell.execute_reply": "2026-05-20T17:34:31.592311Z"
     }
    },
    "outputs": [
@@ -80,10 +80,10 @@
    "id": "1a7d5e20",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T03:05:23.166200Z",
-     "iopub.status.busy": "2026-04-28T03:05:23.165955Z",
-     "iopub.status.idle": "2026-04-28T03:05:23.453516Z",
-     "shell.execute_reply": "2026-04-28T03:05:23.452587Z"
+     "iopub.execute_input": "2026-05-20T17:34:31.595445Z",
+     "iopub.status.busy": "2026-05-20T17:34:31.595179Z",
+     "iopub.status.idle": "2026-05-20T17:34:31.897308Z",
+     "shell.execute_reply": "2026-05-20T17:34:31.896161Z"
     }
    },
    "outputs": [
@@ -125,10 +125,10 @@
    "id": "3ebb4334",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T03:05:23.454899Z",
-     "iopub.status.busy": "2026-04-28T03:05:23.454744Z",
-     "iopub.status.idle": "2026-04-28T03:05:23.496332Z",
-     "shell.execute_reply": "2026-04-28T03:05:23.495377Z"
+     "iopub.execute_input": "2026-05-20T17:34:31.899097Z",
+     "iopub.status.busy": "2026-05-20T17:34:31.898917Z",
+     "iopub.status.idle": "2026-05-20T17:34:31.943890Z",
+     "shell.execute_reply": "2026-05-20T17:34:31.942799Z"
     }
    },
    "outputs": [
@@ -283,10 +283,10 @@
    "id": "d3f704d4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T03:05:23.497889Z",
-     "iopub.status.busy": "2026-04-28T03:05:23.497734Z",
-     "iopub.status.idle": "2026-04-28T03:05:24.314170Z",
-     "shell.execute_reply": "2026-04-28T03:05:24.313109Z"
+     "iopub.execute_input": "2026-05-20T17:34:31.945468Z",
+     "iopub.status.busy": "2026-05-20T17:34:31.945282Z",
+     "iopub.status.idle": "2026-05-20T17:34:32.816009Z",
+     "shell.execute_reply": "2026-05-20T17:34:32.814896Z"
     }
    },
    "outputs": [
@@ -300,7 +300,7 @@
       "--- OEM header ---\n",
       "CCSDS_OEM_VERS           = 1.0\n",
       "\n",
-      "CREATION_DATE            = 2026-04-28T03:05:24.309\n",
+      "CREATION_DATE            = 2026-05-20T17:34:32.811\n",
       "ORIGINATOR               = astro-tools/gmat-run docs example\n",
       "\n",
       "META_START\n",
@@ -349,10 +349,10 @@
    "id": "a599ea5f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T03:05:24.315605Z",
-     "iopub.status.busy": "2026-04-28T03:05:24.315440Z",
-     "iopub.status.idle": "2026-04-28T03:05:24.328926Z",
-     "shell.execute_reply": "2026-04-28T03:05:24.327960Z"
+     "iopub.execute_input": "2026-05-20T17:34:32.817587Z",
+     "iopub.status.busy": "2026-05-20T17:34:32.817421Z",
+     "iopub.status.idle": "2026-05-20T17:34:32.831268Z",
+     "shell.execute_reply": "2026-05-20T17:34:32.830348Z"
     }
    },
    "outputs": [
@@ -498,10 +498,10 @@
    "id": "1f753280",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T03:05:24.330383Z",
-     "iopub.status.busy": "2026-04-28T03:05:24.330191Z",
-     "iopub.status.idle": "2026-04-28T03:05:24.685375Z",
-     "shell.execute_reply": "2026-04-28T03:05:24.684460Z"
+     "iopub.execute_input": "2026-05-20T17:34:32.832827Z",
+     "iopub.status.busy": "2026-05-20T17:34:32.832659Z",
+     "iopub.status.idle": "2026-05-20T17:34:33.610680Z",
+     "shell.execute_reply": "2026-05-20T17:34:33.609680Z"
     }
    },
    "outputs": [

--- a/docs/examples/05_time_scales.ipynb
+++ b/docs/examples/05_time_scales.ipynb
@@ -396,7 +396,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "f477627b",
    "metadata": {
     "execution": {
@@ -406,110 +406,8 @@
      "shell.execute_reply": "2026-04-28T17:06:48.725573Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "All scales after convert_to='UTC':\n",
-      "  Sat.UTCGregorian: UTC\n",
-      "  Sat.TAIGregorian: UTC\n",
-      "  Sat.TTGregorian: UTC\n",
-      "  Sat.TDBGregorian: UTC\n",
-      "  Sat.A1ModJulian: UTC\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Sat.UTCGregorian</th>\n",
-       "      <th>Sat.TAIGregorian</th>\n",
-       "      <th>Sat.TTGregorian</th>\n",
-       "      <th>Sat.TDBGregorian</th>\n",
-       "      <th>Sat.A1ModJulian</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>2016-12-31 23:55:00</td>\n",
-       "      <td>2016-12-31 23:55:00</td>\n",
-       "      <td>2016-12-31 23:55:00</td>\n",
-       "      <td>2016-12-31 23:55:00.000049599</td>\n",
-       "      <td>2016-12-31 23:54:59.999999923</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>2016-12-31 23:55:30</td>\n",
-       "      <td>2016-12-31 23:55:30</td>\n",
-       "      <td>2016-12-31 23:55:30</td>\n",
-       "      <td>2016-12-31 23:55:30.000049588</td>\n",
-       "      <td>2016-12-31 23:55:29.999999705</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>2016-12-31 23:56:00</td>\n",
-       "      <td>2016-12-31 23:56:00</td>\n",
-       "      <td>2016-12-31 23:56:00</td>\n",
-       "      <td>2016-12-31 23:56:00.000049578</td>\n",
-       "      <td>2016-12-31 23:55:59.999999487</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "     Sat.UTCGregorian    Sat.TAIGregorian     Sat.TTGregorian  \\\n",
-       "0 2016-12-31 23:55:00 2016-12-31 23:55:00 2016-12-31 23:55:00   \n",
-       "1 2016-12-31 23:55:30 2016-12-31 23:55:30 2016-12-31 23:55:30   \n",
-       "2 2016-12-31 23:56:00 2016-12-31 23:56:00 2016-12-31 23:56:00   \n",
-       "\n",
-       "               Sat.TDBGregorian               Sat.A1ModJulian  \n",
-       "0 2016-12-31 23:55:00.000049599 2016-12-31 23:54:59.999999923  \n",
-       "1 2016-12-31 23:55:30.000049588 2016-12-31 23:55:29.999999705  \n",
-       "2 2016-12-31 23:56:00.000049578 2016-12-31 23:55:59.999999487  "
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "report_path = result.output_dir / \"leap_second_demo_report.txt\"\n",
-    "df_utc = parse_report(report_path, convert_to=\"UTC\")\n",
-    "\n",
-    "print(\"All scales after convert_to='UTC':\")\n",
-    "for col, scale in df_utc.attrs[\"epoch_scales\"].items():\n",
-    "    print(f\"  {col}: {scale}\")\n",
-    "\n",
-    "epoch_cols = [\n",
-    "    \"Sat.UTCGregorian\",\n",
-    "    \"Sat.TAIGregorian\",\n",
-    "    \"Sat.TTGregorian\",\n",
-    "    \"Sat.TDBGregorian\",\n",
-    "    \"Sat.A1ModJulian\",\n",
-    "]\n",
-    "df_utc[epoch_cols].head(3)"
-   ]
+   "outputs": [],
+   "source": "report_path = result.report_paths[\"RF\"]\ndf_utc = parse_report(report_path, convert_to=\"UTC\")\n\nprint(\"All scales after convert_to='UTC':\")\nfor col, scale in df_utc.attrs[\"epoch_scales\"].items():\n    print(f\"  {col}: {scale}\")\n\nepoch_cols = [\n    \"Sat.UTCGregorian\",\n    \"Sat.TAIGregorian\",\n    \"Sat.TTGregorian\",\n    \"Sat.TDBGregorian\",\n    \"Sat.A1ModJulian\",\n]\ndf_utc[epoch_cols].head(3)"
   },
   {
    "cell_type": "markdown",

--- a/docs/examples/05_time_scales.ipynb
+++ b/docs/examples/05_time_scales.ipynb
@@ -36,10 +36,10 @@
    "id": "d2d9071d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T17:06:35.852440Z",
-     "iopub.status.busy": "2026-04-28T17:06:35.852291Z",
-     "iopub.status.idle": "2026-04-28T17:06:39.678988Z",
-     "shell.execute_reply": "2026-04-28T17:06:39.677896Z"
+     "iopub.execute_input": "2026-05-20T17:34:52.302268Z",
+     "iopub.status.busy": "2026-05-20T17:34:52.302112Z",
+     "iopub.status.idle": "2026-05-20T17:34:55.901179Z",
+     "shell.execute_reply": "2026-05-20T17:34:55.899912Z"
     }
    },
    "outputs": [
@@ -87,10 +87,10 @@
    "id": "af1a5290",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T17:06:39.680592Z",
-     "iopub.status.busy": "2026-04-28T17:06:39.680352Z",
-     "iopub.status.idle": "2026-04-28T17:06:40.254039Z",
-     "shell.execute_reply": "2026-04-28T17:06:40.252936Z"
+     "iopub.execute_input": "2026-05-20T17:34:55.902905Z",
+     "iopub.status.busy": "2026-05-20T17:34:55.902668Z",
+     "iopub.status.idle": "2026-05-20T17:34:56.443367Z",
+     "shell.execute_reply": "2026-05-20T17:34:56.442248Z"
     }
    },
    "outputs": [
@@ -151,10 +151,10 @@
    "id": "4da32df2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T17:06:40.255513Z",
-     "iopub.status.busy": "2026-04-28T17:06:40.255345Z",
-     "iopub.status.idle": "2026-04-28T17:06:40.281192Z",
-     "shell.execute_reply": "2026-04-28T17:06:40.280200Z"
+     "iopub.execute_input": "2026-05-20T17:34:56.444893Z",
+     "iopub.status.busy": "2026-05-20T17:34:56.444734Z",
+     "iopub.status.idle": "2026-05-20T17:34:56.469163Z",
+     "shell.execute_reply": "2026-05-20T17:34:56.468130Z"
     }
    },
    "outputs": [
@@ -351,10 +351,10 @@
    "id": "bc6c1f35",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T17:06:40.282711Z",
-     "iopub.status.busy": "2026-04-28T17:06:40.282551Z",
-     "iopub.status.idle": "2026-04-28T17:06:48.706218Z",
-     "shell.execute_reply": "2026-04-28T17:06:48.705185Z"
+     "iopub.execute_input": "2026-05-20T17:34:56.470734Z",
+     "iopub.status.busy": "2026-05-20T17:34:56.470581Z",
+     "iopub.status.idle": "2026-05-20T17:35:04.520288Z",
+     "shell.execute_reply": "2026-05-20T17:35:04.519187Z"
     }
    },
    "outputs": [
@@ -396,18 +396,120 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "f477627b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T17:06:48.708227Z",
-     "iopub.status.busy": "2026-04-28T17:06:48.708011Z",
-     "iopub.status.idle": "2026-04-28T17:06:48.726766Z",
-     "shell.execute_reply": "2026-04-28T17:06:48.725573Z"
+     "iopub.execute_input": "2026-05-20T17:35:04.521847Z",
+     "iopub.status.busy": "2026-05-20T17:35:04.521676Z",
+     "iopub.status.idle": "2026-05-20T17:35:04.539874Z",
+     "shell.execute_reply": "2026-05-20T17:35:04.538845Z"
     }
    },
-   "outputs": [],
-   "source": "report_path = result.report_paths[\"RF\"]\ndf_utc = parse_report(report_path, convert_to=\"UTC\")\n\nprint(\"All scales after convert_to='UTC':\")\nfor col, scale in df_utc.attrs[\"epoch_scales\"].items():\n    print(f\"  {col}: {scale}\")\n\nepoch_cols = [\n    \"Sat.UTCGregorian\",\n    \"Sat.TAIGregorian\",\n    \"Sat.TTGregorian\",\n    \"Sat.TDBGregorian\",\n    \"Sat.A1ModJulian\",\n]\ndf_utc[epoch_cols].head(3)"
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "All scales after convert_to='UTC':\n",
+      "  Sat.UTCGregorian: UTC\n",
+      "  Sat.TAIGregorian: UTC\n",
+      "  Sat.TTGregorian: UTC\n",
+      "  Sat.TDBGregorian: UTC\n",
+      "  Sat.A1ModJulian: UTC\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Sat.UTCGregorian</th>\n",
+       "      <th>Sat.TAIGregorian</th>\n",
+       "      <th>Sat.TTGregorian</th>\n",
+       "      <th>Sat.TDBGregorian</th>\n",
+       "      <th>Sat.A1ModJulian</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2016-12-31 23:55:00</td>\n",
+       "      <td>2016-12-31 23:55:00</td>\n",
+       "      <td>2016-12-31 23:55:00</td>\n",
+       "      <td>2016-12-31 23:55:00.000049599</td>\n",
+       "      <td>2016-12-31 23:54:59.999999923</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2016-12-31 23:55:30</td>\n",
+       "      <td>2016-12-31 23:55:30</td>\n",
+       "      <td>2016-12-31 23:55:30</td>\n",
+       "      <td>2016-12-31 23:55:30.000049588</td>\n",
+       "      <td>2016-12-31 23:55:29.999999705</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2016-12-31 23:56:00</td>\n",
+       "      <td>2016-12-31 23:56:00</td>\n",
+       "      <td>2016-12-31 23:56:00</td>\n",
+       "      <td>2016-12-31 23:56:00.000049578</td>\n",
+       "      <td>2016-12-31 23:55:59.999999487</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     Sat.UTCGregorian    Sat.TAIGregorian     Sat.TTGregorian  \\\n",
+       "0 2016-12-31 23:55:00 2016-12-31 23:55:00 2016-12-31 23:55:00   \n",
+       "1 2016-12-31 23:55:30 2016-12-31 23:55:30 2016-12-31 23:55:30   \n",
+       "2 2016-12-31 23:56:00 2016-12-31 23:56:00 2016-12-31 23:56:00   \n",
+       "\n",
+       "               Sat.TDBGregorian               Sat.A1ModJulian  \n",
+       "0 2016-12-31 23:55:00.000049599 2016-12-31 23:54:59.999999923  \n",
+       "1 2016-12-31 23:55:30.000049588 2016-12-31 23:55:29.999999705  \n",
+       "2 2016-12-31 23:56:00.000049578 2016-12-31 23:55:59.999999487  "
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "report_path = result.report_paths[\"RF\"]\n",
+    "df_utc = parse_report(report_path, convert_to=\"UTC\")\n",
+    "\n",
+    "print(\"All scales after convert_to='UTC':\")\n",
+    "for col, scale in df_utc.attrs[\"epoch_scales\"].items():\n",
+    "    print(f\"  {col}: {scale}\")\n",
+    "\n",
+    "epoch_cols = [\n",
+    "    \"Sat.UTCGregorian\",\n",
+    "    \"Sat.TAIGregorian\",\n",
+    "    \"Sat.TTGregorian\",\n",
+    "    \"Sat.TDBGregorian\",\n",
+    "    \"Sat.A1ModJulian\",\n",
+    "]\n",
+    "df_utc[epoch_cols].head(3)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -427,10 +529,10 @@
    "id": "a97794f8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T17:06:48.728417Z",
-     "iopub.status.busy": "2026-04-28T17:06:48.728241Z",
-     "iopub.status.idle": "2026-04-28T17:06:48.738316Z",
-     "shell.execute_reply": "2026-04-28T17:06:48.737136Z"
+     "iopub.execute_input": "2026-05-20T17:35:04.541347Z",
+     "iopub.status.busy": "2026-05-20T17:35:04.541188Z",
+     "iopub.status.idle": "2026-05-20T17:35:04.550273Z",
+     "shell.execute_reply": "2026-05-20T17:35:04.549203Z"
     }
    },
    "outputs": [
@@ -537,10 +639,10 @@
    "id": "14151a9b",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-28T17:06:48.739910Z",
-     "iopub.status.busy": "2026-04-28T17:06:48.739620Z",
-     "iopub.status.idle": "2026-04-28T17:06:49.062728Z",
-     "shell.execute_reply": "2026-04-28T17:06:49.061765Z"
+     "iopub.execute_input": "2026-05-20T17:35:04.551779Z",
+     "iopub.status.busy": "2026-05-20T17:35:04.551621Z",
+     "iopub.status.idle": "2026-05-20T17:35:04.865648Z",
+     "shell.execute_reply": "2026-05-20T17:35:04.864442Z"
     }
    },
    "outputs": [

--- a/docs/examples/06_solver_iterations.ipynb
+++ b/docs/examples/06_solver_iterations.ipynb
@@ -56,10 +56,10 @@
    "id": "37a11ad3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T03:02:41.487565Z",
-     "iopub.status.busy": "2026-05-20T03:02:41.487416Z",
-     "iopub.status.idle": "2026-05-20T03:02:45.683186Z",
-     "shell.execute_reply": "2026-05-20T03:02:45.682130Z"
+     "iopub.execute_input": "2026-05-20T17:35:23.492606Z",
+     "iopub.status.busy": "2026-05-20T17:35:23.492460Z",
+     "iopub.status.idle": "2026-05-20T17:35:27.106292Z",
+     "shell.execute_reply": "2026-05-20T17:35:27.105197Z"
     }
    },
    "outputs": [
@@ -114,10 +114,10 @@
    "id": "43261eb2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T03:02:45.684959Z",
-     "iopub.status.busy": "2026-05-20T03:02:45.684729Z",
-     "iopub.status.idle": "2026-05-20T03:02:46.682071Z",
-     "shell.execute_reply": "2026-05-20T03:02:46.681035Z"
+     "iopub.execute_input": "2026-05-20T17:35:27.108001Z",
+     "iopub.status.busy": "2026-05-20T17:35:27.107778Z",
+     "iopub.status.idle": "2026-05-20T17:35:27.940388Z",
+     "shell.execute_reply": "2026-05-20T17:35:27.939150Z"
     }
    },
    "outputs": [
@@ -170,10 +170,10 @@
    "id": "af4df79c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T03:02:46.683595Z",
-     "iopub.status.busy": "2026-05-20T03:02:46.683424Z",
-     "iopub.status.idle": "2026-05-20T03:02:46.846727Z",
-     "shell.execute_reply": "2026-05-20T03:02:46.845686Z"
+     "iopub.execute_input": "2026-05-20T17:35:27.942341Z",
+     "iopub.status.busy": "2026-05-20T17:35:27.942136Z",
+     "iopub.status.idle": "2026-05-20T17:35:27.979063Z",
+     "shell.execute_reply": "2026-05-20T17:35:27.977998Z"
     }
    },
    "outputs": [
@@ -505,10 +505,10 @@
    "id": "cb08aff2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T03:02:46.848241Z",
-     "iopub.status.busy": "2026-05-20T03:02:46.848081Z",
-     "iopub.status.idle": "2026-05-20T03:02:47.953410Z",
-     "shell.execute_reply": "2026-05-20T03:02:47.952366Z"
+     "iopub.execute_input": "2026-05-20T17:35:27.980647Z",
+     "iopub.status.busy": "2026-05-20T17:35:27.980486Z",
+     "iopub.status.idle": "2026-05-20T17:35:28.634474Z",
+     "shell.execute_reply": "2026-05-20T17:35:28.633622Z"
     }
    },
    "outputs": [
@@ -573,10 +573,10 @@
    "id": "a0d477f7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-05-20T03:02:47.954944Z",
-     "iopub.status.busy": "2026-05-20T03:02:47.954781Z",
-     "iopub.status.idle": "2026-05-20T03:02:48.557733Z",
-     "shell.execute_reply": "2026-05-20T03:02:48.556700Z"
+     "iopub.execute_input": "2026-05-20T17:35:28.636355Z",
+     "iopub.status.busy": "2026-05-20T17:35:28.636178Z",
+     "iopub.status.idle": "2026-05-20T17:35:29.249970Z",
+     "shell.execute_reply": "2026-05-20T17:35:29.249004Z"
     }
    },
    "outputs": [

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -3,7 +3,7 @@
 End-to-end Jupyter notebooks that exercise the `gmat-run` API on stock GMAT
 sample missions. Each notebook is committed with cell outputs so you can read
 through it on the docs site without running anything; you can also run them
-locally after `pip install gmat-run[examples]` and the matplotlib dependency.
+locally after `pip install gmat-run[examples]`.
 
 - [Load, run, and plot](01_load_run_plot.ipynb) — the canonical loop:
   [`Mission.load`][gmat_run.Mission.load] a stock sample, run it, pull the
@@ -12,7 +12,7 @@ locally after `pip install gmat-run[examples]` and the matplotlib dependency.
   of values, run the same script for each, and overlay the resulting orbits.
 - [Ground track](03_ground_track.ipynb) — read an `EphemerisFile` from
   [`Results.ephemerides`][gmat_run.Results] and plot the spacecraft's ground
-  track on a Cartopy world map.
+  track on an equirectangular world map.
 - [Export to CCSDS-OEM](04_export_oem.ipynb) — run a stock GMAT sample that emits
   an STK ephemeris, convert it to a CCSDS-OEM file with
   [`Results.write_oem`][gmat_run.Results], re-parse the result, and visualise the

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,8 +12,6 @@
 | ------------ | -------------------------- | --------------------------------------------------------------------------------- |
 | R2026a       | Primary development target | Exercised on every PR (Ubuntu + Windows + macOS, Python 3.10/3.11/3.12)           |
 | R2025a       | Supported                  | Exercised on every PR (Ubuntu + Windows + macOS, Python 3.10/3.11/3.12)           |
-| R2024a       | Expected to work           | Not exercised in CI                                                               |
-| R2023a       | Expected to work           | Not exercised in CI                                                               |
 | R2022a       | Expected to work           | Not exercised in CI (Python 3.9 ABI floor; see [known limitations][r2022a-floor]) |
 
 [r2022a-floor]: known-limitations.md#r2022a-is-not-exercised-in-ci

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,8 +23,8 @@ result.reports["ReportFile1"].plot(x="UTCGregorian", y="Sat.Earth.Altitude")
 - **Not** a way to build GMAT missions from scratch in Python — see
   [gmatpyplus](https://github.com/weasdown/gmatpyplus) for that.
 - **Not** a `.script` text generator — see [pygmat](https://pypi.org/project/pygmat/).
-- **Not** a parallel sweep runner — that's a future astro-tools project (`gmat-sweep`)
-  built on top of gmat-run.
+- **Not** a parallel sweep runner — see [gmat-sweep](https://github.com/astro-tools/gmat-sweep),
+  an astro-tools project built on top of gmat-run.
 
 ## Where to next
 

--- a/docs/install-gmat.md
+++ b/docs/install-gmat.md
@@ -14,7 +14,6 @@ handles the install for you.
 | --------------------- | ------------------------------------------------------------------------------------- |
 | R2026a                | Primary development target; exercised on every PR (Ubuntu + Windows + macOS, Python 3.10/3.11/3.12). |
 | R2025a                | Supported; exercised on every PR (Ubuntu + Windows + macOS, Python 3.10/3.11/3.12).   |
-| R2023a, R2024a        | Supported on a best-effort basis; not exercised in CI.                                |
 | R2022a                | Best-effort; not exercised in CI (Python 3.9 ABI floor; see [known limitations][r2022a-floor]). |
 | Earlier               | Not supported. gmatpy ships per-Python-minor shared libraries; older releases predate Python 3.10. |
 

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -112,7 +112,7 @@ but you cannot ask GMAT to *emit* an AEM trace of a propagated spacecraft.
 ## Parser format restrictions
 
 The parsers in [`gmat_run.parsers`](reference/parsers.md) cover the formats
-GMAT actually emits in v0.4; uncommon variants raise
+GMAT actually emits; uncommon variants raise
 [`GmatOutputParseError`][gmat_run.GmatOutputParseError].
 
 - **CCSDS-OEM ephemeris**: covariance blocks (`COVARIANCE_START` …

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -14,8 +14,8 @@ The reference splits into one page per module:
   ([`Mission.load`][gmat_run.Mission.load], dotted-path field access,
   [`Mission.run`][gmat_run.Mission.run]).
 - [Results](results.md) — the value returned by
-  [`Mission.run`][gmat_run.Mission.run]: `reports`, `ephemerides`, `contacts`
-  as lazy `Mapping[str, pandas.DataFrame]`, plus
+  [`Mission.run`][gmat_run.Mission.run]: `reports`, `ephemerides`, `contacts`,
+  and `solver_runs` as lazy `Mapping[str, pandas.DataFrame]`, plus
   [`Results.persist`][gmat_run.Results.persist].
 - [Mission summary](summary.md) — the dataclass schema returned by
   [`Mission.summary`][gmat_run.Mission.summary]
@@ -31,6 +31,6 @@ The reference splits into one page per module:
   leaf classes.
 - [Parsers](parsers.md) — `gmat_run.parsers`, the standalone functions for
   ReportFile, EphemerisFile (CCSDS-OEM / STK-TimePosVel / SPK), CCSDS-AEM
-  attitude, ContactLocator, and epoch-column promotion. You normally do not
-  call these directly — [`Mission.run`][gmat_run.Mission.run] dispatches to
-  the right one for you.
+  attitude, ContactLocator, solver-iteration logs, and epoch-column promotion.
+  You normally do not call these directly — [`Mission.run`][gmat_run.Mission.run]
+  dispatches to the right one for you.

--- a/docs/working-directories.md
+++ b/docs/working-directories.md
@@ -25,20 +25,36 @@ the cache by rewriting each subscriber's `Filename` field to an absolute path
 inside the workspace before invoking `RunScript`.
 
 - A **relative** `Filename` (e.g. `RF.Filename = 'leo_state.txt'`) is rewritten
-  to `<working_dir>/leo_state.txt`. Any leading directory component is dropped
-  — output files always land at the top of the workspace, on every OS, and
-  forward-slash and back-slash relative paths are treated identically.
+  to the matching path inside the workspace — `<working_dir>/leo_state.txt`. A
+  relative path that carries directory components
+  (`RF.Filename = 'reports/leo_state.txt'`) keeps its subdirectory structure:
+  it resolves to `<working_dir>/reports/leo_state.txt`, and
+  [`Mission.run`][gmat_run.Mission.run] pre-creates the nested parent
+  directories that GMAT itself will not. Forward-slash and back-slash relative
+  paths are treated identically on every OS. A relative `Filename` containing a
+  `..` component is refused with [`GmatRunError`][gmat_run.GmatRunError] before
+  the run — it could resolve outside the workspace gmat-run manages.
 - An **absolute** `Filename` (e.g. `RF.Filename = '/data/runs/leo.txt'`) is
   honoured as-is. The user picked that destination; gmat-run does not relocate
   it.
 
-Reading the field back from Python after the run yields the resolved absolute
-path:
+If two of a run's outputs resolve to the same path — two subscribers declaring
+an identical relative `Filename` — the run is refused with
+[`GmatRunError`][gmat_run.GmatRunError], regardless of `overwrite`.
+
+The rewrite does not persist on the `Mission`. A `Mission` stays a view of the
+loaded script: reading a subscriber's `Filename` back after the run yields the
+value declared in the script, not the resolved workspace path. The resolved
+output locations live on the returned [`Results`][gmat_run.Results] —
+`report_paths`, `ephemeris_paths`, `contact_paths`, and `solver_paths` each map
+a resource name to the absolute path GMAT actually wrote:
 
 ```python
 mission = Mission.load("flyby.script")
 result = mission.run(working_dir="out")
-mission["RF.Filename"]  # '/abs/.../out/leo_state.txt'
+
+mission["RF.Filename"]       # 'leo_state.txt' — the script's declared value
+result.report_paths["RF"]    # Path('/abs/.../out/leo_state.txt')
 ```
 
 ## Out-of-workspace notice

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gmat-run"
-version = "0.4.0"
+version = "0.5.0"
 description = "Run GMAT mission scripts from Python and get results as pandas DataFrames."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/gmat_run/__init__.py
+++ b/src/gmat_run/__init__.py
@@ -14,7 +14,7 @@ from gmat_run.results import Results
 from gmat_run.runtime import bootstrap
 from gmat_run.summary import CommandOutline, MissionSummary, ResourceGroup
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 __all__ = [
     "CommandOutline",

--- a/src/gmat_run/summary.py
+++ b/src/gmat_run/summary.py
@@ -204,7 +204,7 @@ class MissionSummary:
                 names = ", ".join(group.names)
                 lines.append(f"  {group.category}: {names}")
         lines.append("")
-        lines.append(f"Mission sequence ({self.command_count} commands)")
+        lines.append(f"Mission sequence ({_count(self.command_count, 'command')})")
         if not self.commands:
             lines.append("  (empty)")
         else:
@@ -213,7 +213,7 @@ class MissionSummary:
                 for sub in cmd.children:
                     lines.append(f"      - {_format_command_line(sub)}")
                 if cmd.nested_count:
-                    lines.append(f"      ({cmd.nested_count} nested commands)")
+                    lines.append(f"      ({_count(cmd.nested_count, 'nested command')})")
         return "\n".join(lines)
 
     def _repr_html_(self) -> str:
@@ -594,7 +594,7 @@ def _format_mission_html(summary: MissionSummary) -> str:
             )
         parts.append("</tbody></table>")
 
-    parts.append(f"<strong>Mission sequence</strong> ({summary.command_count} commands)")
+    parts.append(f"<strong>Mission sequence</strong> ({_count(summary.command_count, 'command')})")
     if summary.commands:
         parts.append("<ol>")
         for cmd in summary.commands:
@@ -605,7 +605,7 @@ def _format_mission_html(summary: MissionSummary) -> str:
                     parts.append("<li>" + _format_command_html(sub) + "</li>")
                 parts.append("</ul>")
             if cmd.nested_count:
-                parts.append(f"<div><em>({cmd.nested_count} nested commands)</em></div>")
+                parts.append(f"<div><em>({_count(cmd.nested_count, 'nested command')})</em></div>")
             parts.append("</li>")
         parts.append("</ol>")
     else:
@@ -626,3 +626,8 @@ def _format_command_line(cmd: CommandOutline) -> str:
     if cmd.summary:
         return f"{cmd.type_name} — {cmd.summary}"
     return cmd.type_name
+
+
+def _count(n: int, noun: str) -> str:
+    """Render a count with a naively pluralised noun — ``1 command`` / ``2 commands``."""
+    return f"{n} {noun}" if n == 1 else f"{n} {noun}s"

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -4,4 +4,4 @@ import gmat_run
 
 
 def test_import() -> None:
-    assert gmat_run.__version__ == "0.4.0"
+    assert gmat_run.__version__ == "0.5.0"

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -565,7 +565,7 @@ def test_text_repr_renders_resources_outputs_and_sequence() -> None:
     assert "Spacecraft (1): Sat" in text
     assert "ReportFile (1): RF" in text
     assert "Outputs" in text
-    assert "Mission sequence (1 commands)" in text
+    assert "Mission sequence (1 command)" in text
     assert "1. Propagate — Propagate Prop(Sat) {Sat.ElapsedDays = 1};" in text
 
 
@@ -599,7 +599,7 @@ def test_text_repr_marks_nested_count_in_branch() -> None:
         Path("nested.script"),
     )
     text = repr(summary)
-    assert "(1 nested commands)" in text
+    assert "(1 nested command)" in text
 
 
 # --- HTML repr ---------------------------------------------------------------
@@ -664,7 +664,7 @@ def test_html_repr_renders_branch_children_and_nested_count() -> None:
     # the descendants past depth 1.
     assert "<ul>" in html_str
     assert "Vary" in html_str
-    assert "(1 nested commands)" in html_str
+    assert "(1 nested command)" in html_str
 
 
 def test_html_repr_falls_back_to_type_only_when_summary_blank() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -861,7 +861,7 @@ wheels = [
 
 [[package]]
 name = "gmat-run"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

Cuts the v0.5.0 release and, per the issue's expanded scope, folds in a
complete review and update of every doc page and example notebook.

**Release mechanics**

- Bump `__version__` to `0.5.0` (`pyproject.toml`, package `__init__`, smoke
  test, the `gmat-run` editable entry in `uv.lock`).
- Add the `CHANGELOG.md` `[0.5.0]` section — all 11 merged PRs grouped
  Added / Changed / Fixed — and the compare link.

**Docs review**

- Drop the non-existent **R2023a / R2024a** rows from the supported-version
  tables (README, getting-started, install-gmat) — GMAT published no 2023 or
  2024 release.
- Rewrite `working-directories.md`: two sections described pre-0.5 path
  behaviour that #124 and #127 had already changed — relative output paths
  keep their subdirectory structure, and a `Mission` stays a view of the
  loaded script after a run.
- Fix `reference/index.md` (its Results summary and parser list omitted
  `solver_runs` and the solver-log parser), the README Outputs count plus the
  `*_paths` accessors, the notebook-03 "Cartopy" description (the notebook
  uses a plain equirectangular image), and smaller inaccuracies in
  `examples/index.md`, `ci-with-setup-gmat.md`, and `known-limitations.md`.

**Notebooks**

- Update prose in notebooks 01, 03, and 05 for v0.5.
- Re-execute all six example notebooks against GMAT R2026a — every committed
  cell output refreshed, verified free of warnings and machine-local paths.

**Follow-up additions (from review)**

- `summary.py` — pluralise the command count in the mission-summary text and
  HTML reprs; a single-command mission rendered "(1 commands)". Surfaced by
  re-executing notebook 01.
- `ci.yml` — smoke-execute notebooks 03 and 06; the step previously ran only
  01, 02, 04, and 05, so notebook 06 had never been CI-exercised since #113.
- Drop "future" from the `gmat-sweep` scope-boundary notes (README, docs
  index, CONTRIBUTING, notebook 02) — gmat-sweep is publicly released.

The annotated `v0.5.0` tag, GitHub release notes, and the Discussions
announcement are post-merge steps, not part of this PR.

## Test plan

- [x] `uv run pytest -m "not integration"` — 786 passed
- [x] `uv run ruff check` / `uv run ruff format --check` — clean
- [x] `uv run mypy` — clean
- [x] `uv run mkdocs build --strict` — builds; all cross-references resolve
- [x] All six notebooks re-execute end-to-end against GMAT R2026a, with no
  warnings or machine-local paths in any committed output
- [ ] CI green

Closes #108
