### PR TITLE
Add CITATION.cff and a cffconvert validation CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,3 +148,18 @@ jobs:
       - uses: actions/checkout@v4
       - run: pip install .
       - run: python tests/canonical_image_smoke.py
+
+  # Validate CITATION.cff against the Citation File Format v1.2.0 schema.
+  # cffconvert is installed standalone (not via uv sync) because it is a
+  # CI-only schema check, not part of the dev or runtime dependency graph.
+  citation:
+    name: citation file (cffconvert)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install cffconvert==2.0.0
+      - run: cffconvert --validate -i CITATION.cff

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,25 @@
+cff-version: 1.2.0
+message: "If you use gmat-run in academic work, please cite it using the metadata below."
+title: gmat-run
+abstract: >-
+  gmat-run is a Python library for running NASA General Mission Analysis
+  Tool (GMAT) mission scripts and harvesting their output as analysis-ready
+  data. It discovers a local GMAT install, loads a .script into GMAT's
+  object model, applies field overrides from Python, and runs the mission
+  headlessly. ReportFile, ephemeris, ContactLocator, and solver-log output
+  are parsed into typed pandas DataFrames.
+type: software
+authors:
+  - given-names: Dimitrije
+    family-names: Jankovic
+version: 0.5.0
+date-released: "2026-05-20"
+license: MIT
+repository-code: "https://github.com/astro-tools/gmat-run"
+url: "https://github.com/astro-tools/gmat-run"
+keywords:
+  - gmat
+  - astrodynamics
+  - orbital-mechanics
+  - mission-analysis
+  - space


### PR DESCRIPTION
## Summary
- Add a Citation File Format v1.2.0 `CITATION.cff` at the repo root — GitHub renders the "Cite this repository" sidebar, and the joint JOSS paper's `paper.bib` plus the planned Zenodo deposit get one consistent source of citation metadata.
- Add a standalone `citation` CI job that validates the file with `cffconvert` on every PR, mirroring the `gmat-sweep` setup.
- The `abstract` deliberately avoids "thin wrapper" framing; the README rewrite is tracked separately in #132.

## Test plan
- [x] `cffconvert --validate -i CITATION.cff` passes locally (valid against schema v1.2.0)
- [x] `citation` CI job passes on this PR
- [ ] "Cite this repository" sidebar renders on the repo homepage after merge

Closes #130
