### PR TITLE
Reframe the gmat-run description, dropping "thin wrapper"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ Run GMAT mission scripts from Python and get results as pandas DataFrames.
 
 ## What this is
 
-A thin, Pythonic wrapper around NASA GMAT's own `gmatpy` runtime. You bring a working `.script`;
-gmat-run loads it, lets you override fields from Python, runs the mission headlessly, and returns
-`ReportFile` / ephemeris / `ContactLocator` output as pandas DataFrames.
+gmat-run drives NASA's General Mission Analysis Tool (GMAT) from Python. You bring a working
+`.script`; gmat-run discovers your GMAT install, loads the mission, lets you override fields from
+Python with type coercion, runs it headlessly, and parses GMAT's `ReportFile`, ephemeris,
+`ContactLocator`, and solver-log output into typed pandas DataFrames.
 
 ## What this is not
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,9 +4,10 @@ Run GMAT mission scripts from Python and get results as pandas DataFrames.
 
 ## What this is
 
-A thin, Pythonic wrapper around NASA GMAT's own `gmatpy` runtime. You bring a working
-`.script`; gmat-run loads it, lets you override fields from Python, runs the mission
-headlessly, and returns `ReportFile` / ephemeris / `ContactLocator` output as pandas
+gmat-run drives NASA's General Mission Analysis Tool (GMAT) from Python. You bring a
+working `.script`; gmat-run discovers your GMAT install, loads the mission, lets you
+override fields from Python with type coercion, runs it headlessly, and parses GMAT's
+`ReportFile`, ephemeris, `ContactLocator`, and solver-log output into typed pandas
 DataFrames.
 
 ```python


### PR DESCRIPTION
## Summary
- `README.md` and `docs/index.md` opened "What this is" with *"A thin, Pythonic wrapper"* — self-diminishing framing that reads like the "thin API client" category JOSS explicitly excludes.
- Rewrite the shared paragraph to lead actively ("drives GMAT from Python") and surface the real engineering: install discovery, type-coerced field overrides, and multi-format output parsing into typed DataFrames. The output list is corrected to four (adds solver-log, accurate since v0.5).
- The JOSS review-criteria audit for the repo is recorded as a comment on #132 — all green (MIT license file, README overview, install docs, 6 example notebooks, mkdocstrings API reference, `CONTRIBUTING.md` + org community-health files; GitHub community health 100%).

## Test plan
- [x] No "thin" wording remains in `README.md` / `docs/` (grep)
- [x] `mkdocs build --strict` passes with no warnings
- [ ] README and docs index render correctly after merge

Closes #132
