### PR TITLE
Pin ModJulian epoch columns to datetime64[ns]

### DIFF
--- a/src/gmat_run/parsers/epoch.py
+++ b/src/gmat_run/parsers/epoch.py
@@ -188,7 +188,13 @@ def _convert_modjulian(series: "pd.Series[float]", column: str) -> "pd.Series[pd
             _synthetic_path(column),
         )
     try:
-        return _GMAT_MJD_EPOCH + pd.to_timedelta(series, unit="D")
+        # The epoch Timestamp and the timedelta each resolve at a precision
+        # pandas picks per-value (whole-day columns land coarser than [ns]), so
+        # normalise to the [ns] precision the contract promises — matching
+        # _convert_gregorian. astype also raises OutOfBoundsDatetime for a value
+        # representable at a wider resolution but outside the [ns] range; the
+        # except below funnels that into a typed parse error.
+        return (_GMAT_MJD_EPOCH + pd.to_timedelta(series, unit="D")).astype("datetime64[ns]")
     except (ValueError, OverflowError, pd.errors.OutOfBoundsDatetime) as exc:
         raise GmatOutputParseError(
             f"column {column!r} has a ModJulian value outside the "

--- a/tests/test_parsers_epoch.py
+++ b/tests/test_parsers_epoch.py
@@ -113,6 +113,28 @@ def test_modjulian_overflow_raises() -> None:
     assert "Sat.TAIModJulian" in str(excinfo.value)
 
 
+@pytest.mark.parametrize(
+    "values",
+    [
+        pytest.param([21545.0, 21546.0], id="all-whole-day"),
+        pytest.param([21545, 21546], id="integer-typed"),
+        pytest.param([21545.0, 21545.5], id="fractional"),
+    ],
+)
+def test_modjulian_dtype_is_ns_regardless_of_value_shape(values: list[float]) -> None:
+    """ModJulian promotion pins datetime64[ns] for every value shape (#136).
+
+    pandas resolves a whole-day-only (or integer-typed) ModJulian column
+    coarser than [ns]; the promoter must still honour the documented [ns]
+    contract. A fractional value forces [ns] on its own, so the whole-day and
+    integer cases are the ones that actually guard the regression.
+    """
+    col = "Sat.TAIModJulian"
+    df = pd.DataFrame({col: values})
+    promote_epochs(df)
+    assert df[col].dtype == np.dtype("datetime64[ns]")
+
+
 # --- non-epoch columns -------------------------------------------------------
 
 

--- a/tests/test_parsers_reportfile.py
+++ b/tests/test_parsers_reportfile.py
@@ -72,6 +72,25 @@ def test_modjulian_column_parses_end_to_end(tmp_path: Path) -> None:
     assert df.attrs["epoch_scales"]["Sat.TAIModJulian"] == "TAI"
 
 
+def test_modjulian_whole_day_column_is_ns(tmp_path: Path) -> None:
+    """A whole-day-valued ModJulian column comes out datetime64[ns] (#136).
+
+    pandas resolves an all-whole-day column coarser than [ns] unless the
+    promoter pins it; reportfile.parse must still satisfy the [ns] contract.
+    The sibling test above happens to dodge this because its 21545.5 row
+    forces [ns] on its own.
+    """
+    content = (
+        "Sat.TAIModJulian          Sat.Earth.SMA\n"
+        "21545.0                   6578.136\n"
+        "21546.0                   6578.137\n"
+    )
+    df = parse(_write(tmp_path / "mjd_whole.report", content))
+    assert df["Sat.TAIModJulian"].dtype == np.dtype("datetime64[ns]")
+    assert df["Sat.TAIModJulian"].iloc[0] == pd.Timestamp("2000-01-01 12:00:00")
+    assert df["Sat.TAIModJulian"].iloc[1] == pd.Timestamp("2000-01-02 12:00:00")
+
+
 def test_float_column_is_float64(tmp_path: Path) -> None:
     df = parse(_write(tmp_path / "basic.report", _BASIC))
     assert df["Sat.Earth.SMA"].dtype == np.float64


### PR DESCRIPTION
## Summary
- `epoch._convert_modjulian` now normalises its result to `datetime64[ns]` via `.astype`, matching `_convert_gregorian` and the documented epoch-column dtype contract. Under pandas 3.x a ModJulian column whose values were all whole days (or integer-typed) otherwise resolved to `datetime64[us]`, leaving the column dtype data-dependent.
- The `.astype` sits inside the existing `try`, so a ModJulian epoch outside the `[ns]` range (~1677–2262) now raises a typed `GmatOutputParseError` instead of silently returning a wider-resolution datetime — matching the function's docstring and `test_modjulian_overflow_raises`.

## Test plan
- [x] Added `test_modjulian_dtype_is_ns_regardless_of_value_shape` (epoch) — parametrised over whole-day / integer / fractional values
- [x] Added `test_modjulian_whole_day_column_is_ns` (reportfile end-to-end)
- [x] Confirmed both new tests fail without the fix (whole-day and integer cases)
- [x] `uv run pytest` — 790 passed
- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run mypy` — clean

Closes #136
