### PR TITLE
Make ephemeris format sniffers tolerate binary files

### DIFF
--- a/src/gmat_run/parsers/aem_ephemeris.py
+++ b/src/gmat_run/parsers/aem_ephemeris.py
@@ -425,7 +425,8 @@ def is_aem_ephemeris(path: str | os.PathLike[str]) -> bool:
 
     Sniffs the first non-blank, non-comment line for a ``CCSDS_AEM_VERS = …``
     header. Cheap enough to run on every candidate file when classifying a
-    directory's worth of attitude artefacts.
+    directory's worth of attitude artefacts. An unreadable or non-UTF-8 file
+    (e.g. a binary ephemeris) returns ``False`` rather than raising.
     """
     try:
         with Path(path).open(encoding="utf-8-sig", newline=None) as fh:
@@ -434,6 +435,8 @@ def is_aem_ephemeris(path: str | os.PathLike[str]) -> bool:
                 if not line or line.startswith(_COMMENT_PREFIX):
                     continue
                 return bool(_AEM_VERS_RE.match(line))
-    except OSError:
+    except (OSError, UnicodeDecodeError):
+        # OSError: unreadable / missing. UnicodeDecodeError: a binary file
+        # (e.g. a Code-500 ephemeris) — not AEM text, so report no match.
         return False
     return False

--- a/src/gmat_run/parsers/stk_ephemeris.py
+++ b/src/gmat_run/parsers/stk_ephemeris.py
@@ -400,7 +400,8 @@ def is_stk_ephemeris(path: str | os.PathLike[str]) -> bool:
 
     Sniffs the file's first non-blank, non-comment line for an ``stk.v.X.Y``
     banner. Used by :mod:`gmat_run.results` to dispatch to the right parser
-    without relying on file extension.
+    without relying on file extension. An unreadable or non-UTF-8 file (e.g. a
+    binary ephemeris) returns ``False`` rather than raising.
     """
     try:
         with Path(path).open(encoding="utf-8-sig", newline=None) as fh:
@@ -409,6 +410,8 @@ def is_stk_ephemeris(path: str | os.PathLike[str]) -> bool:
                 if not line or line.startswith("#"):
                     continue
                 return bool(_VERSION_BANNER_RE.match(line))
-    except OSError:
+    except (OSError, UnicodeDecodeError):
+        # OSError: unreadable / missing. UnicodeDecodeError: a binary file
+        # (e.g. a Code-500 ephemeris) — not STK text, so report no match.
         return False
     return False

--- a/tests/test_parsers_aem_ephemeris.py
+++ b/tests/test_parsers_aem_ephemeris.py
@@ -539,6 +539,13 @@ def test_is_aem_ephemeris_strips_bom(tmp_path: Path) -> None:
     assert is_aem_ephemeris(path) is True
 
 
+def test_is_aem_ephemeris_false_for_binary_file(tmp_path: Path) -> None:
+    """A binary file (e.g. a Code-500 ephemeris) sniffs False, not UnicodeDecodeError."""
+    path = tmp_path / "binary.eph"
+    path.write_bytes(bytes(range(256)) * 8)
+    assert is_aem_ephemeris(path) is False
+
+
 # --- convert_to -------------------------------------------------------------
 
 

--- a/tests/test_parsers_stk_ephemeris.py
+++ b/tests/test_parsers_stk_ephemeris.py
@@ -418,6 +418,13 @@ def test_is_stk_ephemeris_false_for_empty_file(tmp_path: Path) -> None:
     assert is_stk_ephemeris(path) is False
 
 
+def test_is_stk_ephemeris_false_for_binary_file(tmp_path: Path) -> None:
+    """A binary file (e.g. a Code-500 ephemeris) sniffs False, not UnicodeDecodeError."""
+    path = tmp_path / "binary.eph"
+    path.write_bytes(bytes(range(256)) * 8)
+    assert is_stk_ephemeris(path) is False
+
+
 # --- convert_to -------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary
- `is_stk_ephemeris` and `is_aem_ephemeris` widen their exception guard from `OSError` to `(OSError, UnicodeDecodeError)`, so a binary / non-UTF-8 file (e.g. a GMAT Code-500 binary ephemeris) sniffs as `False` instead of letting a raw `UnicodeDecodeError` escape. `UnicodeDecodeError` subclasses `ValueError`, not `OSError`, so it slipped past the old guard.
- The STK sniffer is on the `Results._LazyEphemerides` dispatch path, so the leak was reachable from `Results.ephemerides[...]` for any non-SPK ephemeris file.

## Test plan
- [x] Added `test_is_stk_ephemeris_false_for_binary_file` and `test_is_aem_ephemeris_false_for_binary_file`
- [x] Confirmed both new tests fail without the fix (raw `UnicodeDecodeError`)
- [x] `uv run pytest` — 792 passed
- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run mypy` — clean

Closes #137
