### PR TITLE
Surface parser file-read failures as GmatOutputParseError

### DIFF
--- a/src/gmat_run/parsers/_io.py
+++ b/src/gmat_run/parsers/_io.py
@@ -1,0 +1,38 @@
+"""Shared file-reading helper for the output-file parsers.
+
+Every parser in this package opens its input the same way — UTF-8 with an
+optional BOM stripped and universal-newline translation — and must surface a
+read failure as a typed :class:`~gmat_run.errors.GmatOutputParseError` rather
+than leaking a raw ``OSError`` / ``UnicodeDecodeError`` to the caller.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from gmat_run.errors import GmatOutputParseError
+
+__all__ = ["read_text_lines"]
+
+
+def read_text_lines(path: Path) -> list[str]:
+    """Read ``path`` as UTF-8 text and return its universal-newline-split lines.
+
+    ``utf-8-sig`` strips an optional BOM; ``newline=None`` gives universal-
+    newline translation so CRLF and LF inputs split identically.
+
+    Raises:
+        GmatOutputParseError: ``path`` is missing or unreadable, or its bytes
+            are not valid UTF-8 text (e.g. a binary ephemeris). The underlying
+            ``OSError`` / ``UnicodeDecodeError`` is wrapped so callers see the
+            typed error the rest of the parser surface raises, never a raw one.
+    """
+    try:
+        with path.open(encoding="utf-8-sig", newline=None) as fh:
+            return fh.read().splitlines()
+    except OSError as exc:
+        raise GmatOutputParseError(f"could not read '{path}': {exc}", path) from exc
+    except UnicodeDecodeError as exc:
+        raise GmatOutputParseError(
+            f"'{path}' is not valid UTF-8 text (a binary file?): {exc}", path
+        ) from exc

--- a/src/gmat_run/parsers/aem_ephemeris.py
+++ b/src/gmat_run/parsers/aem_ephemeris.py
@@ -47,6 +47,7 @@ from typing import Any, Final
 import pandas as pd
 
 from gmat_run.errors import GmatOutputParseError
+from gmat_run.parsers._io import read_text_lines
 from gmat_run.parsers.epoch import promote_epochs
 
 __all__ = ["is_aem_ephemeris", "parse"]
@@ -170,8 +171,7 @@ def parse(path: str | os.PathLike[str], *, convert_to: str | None = None) -> pd.
             required, and ``astropy`` is not installed.
     """
     path = Path(path)
-    with path.open(encoding="utf-8-sig", newline=None) as fh:
-        lines = fh.read().splitlines()
+    lines = read_text_lines(path)
 
     if not any(line.strip() for line in lines):
         raise GmatOutputParseError("file is empty", path)

--- a/src/gmat_run/parsers/contact.py
+++ b/src/gmat_run/parsers/contact.py
@@ -42,6 +42,7 @@ from typing import Final
 import pandas as pd
 
 from gmat_run.errors import GmatOutputParseError
+from gmat_run.parsers._io import read_text_lines
 
 __all__ = ["parse"]
 
@@ -195,12 +196,7 @@ def parse(path: str | os.PathLike[str]) -> pd.DataFrame:
             does not parse.
     """
     path = Path(path)
-
-    # ``utf-8-sig`` strips an optional UTF-8 BOM; ``newline=None`` activates
-    # universal-newline translation so CRLF and LF files produce identical
-    # token streams.
-    with path.open(encoding="utf-8-sig", newline=None) as fh:
-        lines = fh.read().splitlines()
+    lines = read_text_lines(path)
 
     if not any(line.strip() for line in lines):
         raise GmatOutputParseError("file is empty", path)

--- a/src/gmat_run/parsers/ephemeris.py
+++ b/src/gmat_run/parsers/ephemeris.py
@@ -40,6 +40,7 @@ from typing import Any, Final
 import pandas as pd
 
 from gmat_run.errors import GmatOutputParseError
+from gmat_run.parsers._io import read_text_lines
 from gmat_run.parsers.epoch import promote_epochs
 
 __all__ = ["parse"]
@@ -131,8 +132,7 @@ def parse(path: str | os.PathLike[str], *, convert_to: str | None = None) -> pd.
             required, and ``astropy`` is not installed.
     """
     path = Path(path)
-    with path.open(encoding="utf-8-sig", newline=None) as fh:
-        lines = fh.read().splitlines()
+    lines = read_text_lines(path)
 
     if not any(line.strip() for line in lines):
         raise GmatOutputParseError("file is empty", path)

--- a/src/gmat_run/parsers/reportfile.py
+++ b/src/gmat_run/parsers/reportfile.py
@@ -26,6 +26,7 @@ from typing import Any
 import pandas as pd
 
 from gmat_run.errors import GmatOutputParseError
+from gmat_run.parsers._io import read_text_lines
 from gmat_run.parsers.epoch import promote_epochs
 
 __all__ = ["parse"]
@@ -62,11 +63,7 @@ def parse(path: str | os.PathLike[str], *, convert_to: str | None = None) -> pd.
             required, and ``astropy`` is not installed.
     """
     path = Path(path)
-
-    # utf-8-sig strips an optional UTF-8 BOM; newline=None gives universal-newline
-    # translation so CRLF and LF files produce identical splits.
-    with path.open(encoding="utf-8-sig", newline=None) as fh:
-        lines = fh.read().splitlines()
+    lines = read_text_lines(path)
 
     header_lineno, header_line = _find_header(lines, path)
     header_stripped = header_line.strip()

--- a/src/gmat_run/parsers/solver_log.py
+++ b/src/gmat_run/parsers/solver_log.py
@@ -47,6 +47,7 @@ from typing import Final
 import pandas as pd
 
 from gmat_run.errors import GmatOutputParseError
+from gmat_run.parsers._io import read_text_lines
 
 __all__ = ["parse"]
 
@@ -156,11 +157,7 @@ def parse(
             line, or a non-numeric value).
     """
     path = Path(path)
-
-    # ``utf-8-sig`` strips an optional BOM; ``newline=None`` activates
-    # universal-newline translation so CRLF and LF files parse identically.
-    with path.open(encoding="utf-8-sig", newline=None) as fh:
-        lines = fh.read().splitlines()
+    lines = read_text_lines(path)
 
     if not any(line.strip() for line in lines):
         raise GmatOutputParseError("file is empty", path)

--- a/src/gmat_run/parsers/stk_ephemeris.py
+++ b/src/gmat_run/parsers/stk_ephemeris.py
@@ -42,6 +42,7 @@ from typing import Any, Final
 import pandas as pd
 
 from gmat_run.errors import GmatOutputParseError
+from gmat_run.parsers._io import read_text_lines
 from gmat_run.parsers.epoch import promote_epochs
 
 __all__ = ["is_stk_ephemeris", "parse"]
@@ -139,8 +140,7 @@ def parse(path: str | os.PathLike[str], *, convert_to: str | None = None) -> pd.
             required, and ``astropy`` is not installed.
     """
     path = Path(path)
-    with path.open(encoding="utf-8-sig", newline=None) as fh:
-        lines = fh.read().splitlines()
+    lines = read_text_lines(path)
 
     if not any(line.strip() for line in lines):
         raise GmatOutputParseError("file is empty", path)

--- a/tests/test_parsers_io.py
+++ b/tests/test_parsers_io.py
@@ -1,0 +1,92 @@
+"""The typed-error contract every output-file parser shares.
+
+A missing or non-UTF-8 input must surface as ``GmatOutputParseError`` — never a
+raw ``FileNotFoundError`` / ``UnicodeDecodeError`` — from both the shared reader
+:func:`gmat_run.parsers._io.read_text_lines` and every parser's ``parse`` entry
+point.
+"""
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from gmat_run.errors import GmatOutputParseError
+from gmat_run.parsers._io import read_text_lines
+from gmat_run.parsers.aem_ephemeris import parse as parse_aem
+from gmat_run.parsers.contact import parse as parse_contact
+from gmat_run.parsers.ephemeris import parse as parse_oem
+from gmat_run.parsers.reportfile import parse as parse_reportfile
+from gmat_run.parsers.solver_log import parse as parse_solver_log
+from gmat_run.parsers.stk_ephemeris import parse as parse_stk
+
+# Every byte value, so a strict UTF-8 decode fails. Stands in for a binary
+# ephemeris (e.g. GMAT's Code-500 format) reaching a text parser.
+_BINARY = bytes(range(256)) * 8
+
+
+# --- read_text_lines ---------------------------------------------------------
+
+
+def test_read_text_lines_universal_newline_split(tmp_path: Path) -> None:
+    path = tmp_path / "ok.txt"
+    path.write_bytes(b"alpha\r\nbeta\n")
+    assert read_text_lines(path) == ["alpha", "beta"]
+
+
+def test_read_text_lines_strips_bom(tmp_path: Path) -> None:
+    path = tmp_path / "bom.txt"
+    path.write_bytes(b"\xef\xbb\xbfalpha\n")
+    assert read_text_lines(path) == ["alpha"]
+
+
+def test_read_text_lines_missing_file_raises_typed(tmp_path: Path) -> None:
+    missing = tmp_path / "does-not-exist.txt"
+    with pytest.raises(GmatOutputParseError) as excinfo:
+        read_text_lines(missing)
+    assert excinfo.value.path == missing
+    assert isinstance(excinfo.value.__cause__, FileNotFoundError)
+
+
+def test_read_text_lines_binary_file_raises_typed(tmp_path: Path) -> None:
+    path = tmp_path / "binary.bin"
+    path.write_bytes(_BINARY)
+    with pytest.raises(GmatOutputParseError) as excinfo:
+        read_text_lines(path)
+    assert excinfo.value.path == path
+    assert isinstance(excinfo.value.__cause__, UnicodeDecodeError)
+
+
+# --- every parser surfaces the typed error -----------------------------------
+
+# One entry per text parser that reads via read_text_lines. spk.parse is
+# excluded — it is a binary format with its own typed missing-file handling.
+_PARSERS = [
+    pytest.param(parse_reportfile, id="reportfile"),
+    pytest.param(parse_oem, id="ephemeris"),
+    pytest.param(parse_stk, id="stk_ephemeris"),
+    pytest.param(parse_aem, id="aem_ephemeris"),
+    pytest.param(parse_contact, id="contact"),
+    pytest.param(parse_solver_log, id="solver_log"),
+]
+
+
+@pytest.mark.parametrize("parse_fn", _PARSERS)
+def test_parser_missing_file_raises_typed_error(
+    parse_fn: Callable[..., pd.DataFrame], tmp_path: Path
+) -> None:
+    """A missing path surfaces GmatOutputParseError, not raw FileNotFoundError."""
+    with pytest.raises(GmatOutputParseError):
+        parse_fn(tmp_path / "missing-output.txt")
+
+
+@pytest.mark.parametrize("parse_fn", _PARSERS)
+def test_parser_binary_file_raises_typed_error(
+    parse_fn: Callable[..., pd.DataFrame], tmp_path: Path
+) -> None:
+    """A binary file surfaces GmatOutputParseError, not raw UnicodeDecodeError."""
+    path = tmp_path / "binary-output.bin"
+    path.write_bytes(_BINARY)
+    with pytest.raises(GmatOutputParseError):
+        parse_fn(path)

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -12,6 +12,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
+from gmat_run.errors import GmatOutputParseError
 from gmat_run.results import Results
 
 # --- helpers -----------------------------------------------------------------
@@ -148,13 +149,16 @@ def test_construction_does_not_read_files(tmp_path: Path) -> None:
 
 
 def test_value_access_on_missing_file_raises(tmp_path: Path) -> None:
-    """First access is where the parser actually runs — and where I/O fails."""
+    """First access is where the parser runs — a declared ReportFile GMAT never
+    wrote surfaces a typed GmatOutputParseError there, not a raw
+    FileNotFoundError. Output paths are recorded for every declared resource,
+    whether or not the engine produced the file."""
     result = Results(
         output_dir=tmp_path,
         log="",
         report_paths={"R1": tmp_path / "never_written.txt"},
     )
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(GmatOutputParseError):
         _ = result.reports["R1"]
 
 


### PR DESCRIPTION
## Summary
- New shared reader `gmat_run.parsers._io.read_text_lines` opens a file as UTF-8 (BOM-stripped, universal newlines) and wraps `OSError` / `UnicodeDecodeError` as `GmatOutputParseError`.
- All six text parsers (`reportfile`, `ephemeris`, `stk_ephemeris`, `aem_ephemeris`, `contact`, `solver_log`) route through it, so a missing or binary input surfaces the typed error instead of a raw `FileNotFoundError` / `UnicodeDecodeError`. `Results` records an output path for every declared resource, so a declared `ReportFile`/`EphemerisFile` GMAT never wrote previously leaked `FileNotFoundError` on lazy access.

## Test plan
- [x] New `tests/test_parsers_io.py` — `read_text_lines` (happy path, BOM, missing, binary) + parametrised typed-error check across all six `parse` entry points
- [x] Updated `test_value_access_on_missing_file_raises` to the typed contract (it pinned the old raw-`FileNotFoundError` behaviour)
- [x] Confirmed the cross-parser tests fail without the fix
- [x] `uv run pytest` — 808 passed
- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run mypy` — clean
- [x] Downstream check — gmat-sweep absorbs the change via its broad `except Exception` in `worker.py`; paper-tle-divergence-atlas does not call gmat-run parsers directly. No `except FileNotFoundError`/`UnicodeDecodeError` exists downstream.

Closes #138
