### PR TITLE
Reject multi-segment OEM/AEM with mixed TIME_SYSTEM

### DIFF
--- a/src/gmat_run/parsers/aem_ephemeris.py
+++ b/src/gmat_run/parsers/aem_ephemeris.py
@@ -189,6 +189,15 @@ def parse(path: str | os.PathLike[str], *, convert_to: str | None = None) -> pd.
             "cannot concatenate heterogeneous attitude data",
             path,
         )
+    # Segments must likewise agree on TIME_SYSTEM: the concatenated Epoch
+    # column is tagged with a single scale, correct only when it is shared.
+    time_systems = {seg.meta.get("TIME_SYSTEM", "") for seg in segments}
+    if len(time_systems) != 1:
+        raise GmatOutputParseError(
+            f"segments declare different TIME_SYSTEM values {sorted(time_systems)}; "
+            "cannot concatenate epochs across incompatible time scales",
+            path,
+        )
     (attitude_type,) = types
     columns = _resolve_columns(attitude_type, path)
 

--- a/src/gmat_run/parsers/ephemeris.py
+++ b/src/gmat_run/parsers/ephemeris.py
@@ -141,6 +141,17 @@ def parse(path: str | os.PathLike[str], *, convert_to: str | None = None) -> pd.
     if not segments:
         raise GmatOutputParseError("no META_START block found; not a CCSDS-OEM ephemeris?", path)
 
+    # Every segment must agree on TIME_SYSTEM: the data records concatenate
+    # into one Epoch column, and tagging it with a single scale is correct
+    # only when that scale is shared. Mismatched scales cannot be merged.
+    time_systems = {seg.meta.get("TIME_SYSTEM", "") for seg in segments}
+    if len(time_systems) != 1:
+        raise GmatOutputParseError(
+            f"segments declare different TIME_SYSTEM values {sorted(time_systems)}; "
+            "cannot concatenate epochs across incompatible time scales",
+            path,
+        )
+
     frames: list[pd.DataFrame] = []
     metas: list[dict[str, str]] = []
     for segment in segments:
@@ -150,9 +161,9 @@ def parse(path: str | os.PathLike[str], *, convert_to: str | None = None) -> pd.
 
     result = pd.concat(frames, ignore_index=True) if len(frames) > 1 else frames[0]
 
-    # Tag epoch scale per the epoch.py convention. Use the first segment's
-    # TIME_SYSTEM — _consensus already validates that all segments agree on
-    # any flat-attr key (and TIME_SYSTEM is one of those).
+    # Tag epoch scale per the epoch.py convention. Every segment shares the
+    # same TIME_SYSTEM (checked above), so the first segment's value is the
+    # scale for the whole concatenated Epoch column.
     time_scale = metas[0].get("TIME_SYSTEM", "")
     if time_scale:
         result.attrs["epoch_scales"] = {"Epoch": time_scale}

--- a/tests/test_parsers_aem_ephemeris.py
+++ b/tests/test_parsers_aem_ephemeris.py
@@ -238,6 +238,15 @@ def test_multi_segment_concatenates(tmp_path: Path) -> None:
     assert df["Epoch"].iloc[-1] == pd.Timestamp("2026-01-01 12:04:00")
 
 
+def test_multi_segment_mixed_time_system_raises(tmp_path: Path) -> None:
+    """Segments with different TIME_SYSTEM values cannot be concatenated — the
+    Epoch column would otherwise mix scales under one label (#139)."""
+    seg_2_tdb = _QUAT_SEG_2_META.replace("TIME_SYSTEM          = UTC", "TIME_SYSTEM          = TDB")
+    mixed = _HEADER + _QUAT_META_BASE + _QUAT_DATA_BASE + seg_2_tdb + _QUAT_SEG_2_DATA
+    with pytest.raises(GmatOutputParseError, match="different TIME_SYSTEM"):
+        parse(_write(tmp_path / "mixed.aem", mixed))
+
+
 def test_multi_segment_records_per_segment_metadata(tmp_path: Path) -> None:
     df = parse(_write(tmp_path / "multi.aem", _QUAT_MULTI))
     segments = df.attrs["segments"]

--- a/tests/test_parsers_ephemeris.py
+++ b/tests/test_parsers_ephemeris.py
@@ -147,6 +147,15 @@ def test_multi_segment_concatenates(tmp_path: Path) -> None:
     assert df["Epoch"].iloc[-1] == pd.Timestamp("2026-01-01 12:04:00")
 
 
+def test_multi_segment_mixed_time_system_raises(tmp_path: Path) -> None:
+    """Segments with different TIME_SYSTEM values cannot be concatenated — the
+    Epoch column would otherwise mix scales under one label (#139)."""
+    seg_2_tdb = _SEG_2_META.replace("TIME_SYSTEM          = UTC", "TIME_SYSTEM          = TDB")
+    mixed = _HEADER + _META_BASE + _DATA_BASE + seg_2_tdb + _SEG_2_DATA
+    with pytest.raises(GmatOutputParseError, match="different TIME_SYSTEM"):
+        parse(_write(tmp_path / "mixed.oem", mixed))
+
+
 def test_multi_segment_records_per_segment_metadata(tmp_path: Path) -> None:
     df = parse(_write(tmp_path / "multi.oem", _MULTI_SEGMENT))
     segments = df.attrs["segments"]


### PR DESCRIPTION
## Summary
- `ephemeris.parse` and `aem_ephemeris.parse` now reject a multi-segment file whose segments declare different `TIME_SYSTEM` values, raising `GmatOutputParseError` — mirroring `aem_ephemeris.parse`'s existing `ATTITUDE_TYPE` agreement check. Previously such a file parsed silently: the concatenated `Epoch` column mixed scales while `df.attrs["epoch_scales"]` was tagged from segment 0 alone, so a later `convert_to=` mistranslated the non-segment-0 rows.
- Corrected the stale comment in `ephemeris.parse` claiming `_consensus` validates segment agreement — it only omits a flat attr on disagreement.

## Test plan
- [x] Added `test_multi_segment_mixed_time_system_raises` to the OEM and AEM parser suites
- [x] Confirmed both fail without the fix
- [x] Existing `test_multi_segment_concatenates` (agreeing segments) still passes — the regression guard
- [x] `uv run pytest` — 810 passed
- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run mypy` — clean

Closes #139
