### PR TITLE
Handle ReportFiles with duplicate column names

### DIFF
--- a/src/gmat_run/parsers/epoch.py
+++ b/src/gmat_run/parsers/epoch.py
@@ -106,9 +106,13 @@ def promote_epochs(df: pd.DataFrame, *, convert_to: str | None = None) -> pd.Dat
             required, and ``astropy`` is not installed. The message points at
             the ``gmat-run[astropy]`` extra.
     """
-    for column in df.columns:
+    # Iterate positionally: a report can repeat a column name (a Report command
+    # writes a parameter once per mention), and df[<dup-name>] would return a
+    # DataFrame rather than the Series the converters expect.
+    for index, column in enumerate(df.columns):
         suffix = _suffix(str(column))
-        if pd.api.types.is_datetime64_any_dtype(df[column]):
+        series = df.iloc[:, index]
+        if pd.api.types.is_datetime64_any_dtype(series):
             # Already promoted (idempotence). Tag the name-derived scale only
             # when nothing recorded one yet — a caller that built the frame by
             # hand still gets consistent attrs — but never overwrite a scale an
@@ -120,10 +124,10 @@ def promote_epochs(df: pd.DataFrame, *, convert_to: str | None = None) -> pd.Dat
                 _tag_scale(df, column, scale)
             continue
         if suffix in _GREGORIAN_SUFFIXES:
-            df[column] = _convert_gregorian(df[column], column)
+            df.isetitem(index, _convert_gregorian(series, column).array)
             _tag_scale(df, column, _GREGORIAN_SUFFIXES[suffix])
         elif suffix in _MODJULIAN_SUFFIXES:
-            df[column] = _convert_modjulian(df[column], column)
+            df.isetitem(index, _convert_modjulian(series, column).array)
             _tag_scale(df, column, _MODJULIAN_SUFFIXES[suffix])
         elif _UNKNOWN_EPOCH_SUFFIX_RE.match(suffix):
             warnings.warn(
@@ -139,18 +143,28 @@ def promote_epochs(df: pd.DataFrame, *, convert_to: str | None = None) -> pd.Dat
 
 
 def _convert_all_to(df: pd.DataFrame, target: str) -> None:
-    """Convert every entry in ``df.attrs["epoch_scales"]`` to ``target`` in place.
+    """Convert every column in ``df.attrs["epoch_scales"]`` to ``target`` in place.
 
     Imports :mod:`gmat_run.time` lazily so the default ``promote_epochs`` path
-    stays astropy-free. ``convert_column`` validates ``target`` and each
-    source scale, and surfaces the ``[astropy]`` install hint when needed.
+    stays astropy-free. Iterates positionally rather than delegating to
+    ``time.convert_column`` so a frame that repeats a column name still
+    converts every matching column — ``df[<dup-name>]`` would yield a
+    DataFrame. ``convert`` validates ``target`` and each source scale and
+    surfaces the ``[astropy]`` install hint when needed.
     """
-    from gmat_run.time import convert_column
+    from gmat_run.time import convert
 
     scales: dict[str, str] = df.attrs.get("epoch_scales", {})
-    # Snapshot the keys: ``convert_column`` mutates this dict as it goes.
+    # Convert each column against the scale recorded for its name. Read the
+    # source scale fresh per column before any update — duplicate-named columns
+    # share one scales entry, so updating it mid-loop would make the second
+    # column convert from the already-applied target.
+    for index, column in enumerate(df.columns):
+        from_scale = scales.get(column)
+        if from_scale is not None:
+            df.isetitem(index, convert(df.iloc[:, index], from_scale, target).array)
     for column in list(scales):
-        convert_column(df, column, target)
+        scales[column] = target
 
 
 def _suffix(column: str) -> str:

--- a/src/gmat_run/parsers/reportfile.py
+++ b/src/gmat_run/parsers/reportfile.py
@@ -20,6 +20,7 @@ the datetime-parsing layer (see issue #7).
 
 import os
 import re
+import warnings
 from pathlib import Path
 from typing import Any
 
@@ -42,6 +43,9 @@ def parse(path: str | os.PathLike[str], *, convert_to: str | None = None) -> pd.
     Column names are taken verbatim from the header row (dots preserved, e.g.
     ``Sat.Earth.SMA``). Each column is coerced to ``int64`` or ``float64`` if
     every value parses as numeric; otherwise the column stays ``object``/``str``.
+    A header that repeats a column name (GMAT's ``Report`` command does not
+    de-duplicate) is still parsed — every column typed independently — and a
+    :class:`UserWarning` flags the repeat.
 
     Args:
         path: Path to the ``ReportFile`` on disk.
@@ -84,9 +88,14 @@ def parse(path: str | os.PathLike[str], *, convert_to: str | None = None) -> pd.
             )
         rows.append(tokens)
 
+    _warn_on_duplicate_columns(column_names)
     df = pd.DataFrame(rows, columns=column_names)
-    for column in df.columns:
-        df[column] = _coerce_numeric(df[column])
+    # Coerce each column positionally: addressing by df[name] would shred a
+    # report that repeats a column name (a Report command can list the same
+    # parameter twice) — df[<dup-name>] returns a DataFrame, not a Series.
+    # .array hands isetitem the column's ExtensionArray, its accepted input.
+    for index in range(len(column_names)):
+        df.isetitem(index, _coerce_numeric(df.iloc[:, index]).array)
     return promote_epochs(df, convert_to=convert_to)
 
 
@@ -114,3 +123,30 @@ def _coerce_numeric(series: "pd.Series[Any]") -> "pd.Series[Any]":
         return pd.to_numeric(series)
     except (ValueError, TypeError):
         return series
+
+
+def _warn_on_duplicate_columns(column_names: list[str]) -> None:
+    """Emit a ``UserWarning`` when the header repeats a column name.
+
+    GMAT's ``Report`` command writes a parameter once per mention, so a
+    repeated parameter yields duplicate header tokens (identical, redundant
+    columns) — almost always an unintended repeat. Parsing still proceeds and
+    every column is typed correctly, but the caller is told: a DataFrame with
+    repeated labels is awkward downstream (``df[name]`` returns a frame, and a
+    Parquet round-trip rejects it).
+    """
+    seen: set[str] = set()
+    duplicates: list[str] = []
+    for name in column_names:
+        if name in seen and name not in duplicates:
+            duplicates.append(name)
+        seen.add(name)
+    if duplicates:
+        listing = ", ".join(repr(name) for name in duplicates)
+        warnings.warn(
+            f"report header repeats column name(s): {listing}; the duplicate "
+            "columns are parsed but a DataFrame with repeated labels is "
+            "awkward to index",
+            UserWarning,
+            stacklevel=3,
+        )

--- a/tests/test_parsers_epoch.py
+++ b/tests/test_parsers_epoch.py
@@ -135,6 +135,36 @@ def test_modjulian_dtype_is_ns_regardless_of_value_shape(values: list[float]) ->
     assert df[col].dtype == np.dtype("datetime64[ns]")
 
 
+# --- duplicate column names --------------------------------------------------
+
+
+def test_duplicate_epoch_column_both_promoted() -> None:
+    """A frame repeating an epoch column name promotes every matching column,
+    not just the first (#140)."""
+    df = pd.DataFrame(
+        [["26 Nov 2026 12:00:00.000", "26 Nov 2026 12:00:00.000"]],
+        columns=["Sat.UTCGregorian", "Sat.UTCGregorian"],
+    )
+    promote_epochs(df)
+    assert list(df.dtypes) == [
+        np.dtype("datetime64[ns]"),
+        np.dtype("datetime64[ns]"),
+    ]
+
+
+def test_duplicate_epoch_column_both_converted() -> None:
+    """convert_to= converts every matching column when a name repeats (#140)."""
+    df = pd.DataFrame(
+        [["26 Nov 2026 12:00:00.000", "26 Nov 2026 12:00:00.000"]],
+        columns=["Sat.TAIGregorian", "Sat.TAIGregorian"],
+    )
+    promote_epochs(df, convert_to="UTC")
+    # Both columns shift from TAI to UTC (37 s in 2026); neither left in TAI.
+    expected = pd.Timestamp("2026-11-26 12:00:00") - pd.Timedelta(seconds=37)
+    assert df.iloc[:, 0].iloc[0] == expected
+    assert df.iloc[:, 1].iloc[0] == expected
+
+
 # --- non-epoch columns -------------------------------------------------------
 
 

--- a/tests/test_parsers_reportfile.py
+++ b/tests/test_parsers_reportfile.py
@@ -147,6 +147,25 @@ def test_duplicate_data_row_is_preserved(tmp_path: Path) -> None:
     assert df["Sat.UTCGregorian"].iloc[0] == df["Sat.UTCGregorian"].iloc[1]
 
 
+def test_duplicate_column_name_warns_and_types_each(tmp_path: Path) -> None:
+    """A header repeating a column name (GMAT's Report command does not
+    de-duplicate) parses — each repeated column typed independently — with a
+    UserWarning, never silently left as strings (#140)."""
+    content = (
+        "Sat.UTCGregorian          Sat.X                     Sat.X\n"
+        "26 Nov 2026 12:00:00.000  1.0                       2.0\n"
+        "26 Nov 2026 12:01:00.000  3.0                       4.0\n"
+    )
+    with pytest.warns(UserWarning, match="repeats column name"):
+        df = parse(_write(tmp_path / "dupcol.report", content))
+    assert list(df.columns) == ["Sat.UTCGregorian", "Sat.X", "Sat.X"]
+    # Both repeated columns are coerced to float64 — not left string-typed.
+    assert df.iloc[:, 1].dtype == np.float64
+    assert df.iloc[:, 2].dtype == np.float64
+    assert df.iloc[:, 1].tolist() == [1.0, 3.0]
+    assert df.iloc[:, 2].tolist() == [2.0, 4.0]
+
+
 # --- edge cases --------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary
- GMAT's `Report` command writes a parameter once per mention, so a ReportFile can carry duplicate header column names (the `RF.Add` field de-duplicates; the `Report` command does not — confirmed empirically against GMAT R2026a). Such a report previously had its repeated columns silently left string-typed, because the coercion loop addressed columns by label and `df[<dup-name>]` returns a DataFrame, not a Series.
- `reportfile.parse` now coerces columns positionally and emits a `UserWarning` naming the duplicate(s). `epoch.promote_epochs` and `epoch._convert_all_to` iterate positionally too, so a duplicated *epoch* column is promoted and converted correctly (the `convert_to=` path included).

## Test plan
- [x] Added a duplicate-numeric-column test (both columns `float64`, `UserWarning` emitted) and a duplicate-epoch-column test (both promoted; both converted under `convert_to=`)
- [x] Confirmed all three fail without the fix
- [x] `uv run pytest` — 813 passed
- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run mypy` — clean

Closes #140
