### PR TITLE
Write RMATRIX fields via SetMatrix, not SetField

### DIFF
--- a/src/gmat_run/mission.py
+++ b/src/gmat_run/mission.py
@@ -325,11 +325,19 @@ class Mission:
         pid = self._resolve_field(obj, field, dotted, value=value)
         type_code = obj.GetParameterType(pid)
         coerced = self._coerce(type_code, value, dotted)
+        kind = self._type_map.get(type_code, "string")
         # No preemptive `IsParameterReadOnly` gate: it raises for calculated
         # parameters (e.g. Spacecraft.SMA) and false-positives for delegated
         # fields on PropSetup. Let the engine reject the write itself.
         try:
-            obj.SetField(field, coerced)
+            if kind == "rmatrix":
+                # gmatpy's SetField has no matrix overload (only RealArray /
+                # StringArray / scalars), so an RMATRIX field is written via
+                # SetMatrix with a gmat Rmatrix — symmetric with _read's
+                # GetMatrix. A nested list passed to SetField is rejected.
+                obj.SetMatrix(field, self._build_rmatrix(coerced))
+            else:
+                obj.SetField(field, coerced)
         except Exception as exc:
             raise GmatFieldError(
                 f"GMAT rejected write to '{dotted}': {exc}",
@@ -944,6 +952,21 @@ class Mission:
             dotted,
             value,
         )
+
+    def _build_rmatrix(self, rows: list[list[float]]) -> Any:
+        """Build a gmat ``Rmatrix`` from a coerced nested list of floats.
+
+        gmatpy's ``SetField`` has no matrix overload, so an RMATRIX field is
+        written through ``SetMatrix`` with a real ``Rmatrix``. ``_coerce`` has
+        already validated ``rows`` as a non-empty list of numeric rows.
+        """
+        n_rows = len(rows)
+        n_cols = len(rows[0])
+        matrix = self._gmat.Rmatrix(n_rows, n_cols)
+        for i, row in enumerate(rows):
+            for j, element in enumerate(row):
+                matrix.SetElement(i, j, element)
+        return matrix
 
 
 # --- module-level helpers -----------------------------------------------------

--- a/tests/integration/test_vector_matrix_fields.py
+++ b/tests/integration/test_vector_matrix_fields.py
@@ -1,0 +1,55 @@
+"""Integration coverage for RVECTOR / RMATRIX dotted-path field access.
+
+Issue #141: gmatpy's ``SetField`` has no matrix overload (only ``RealArray`` /
+``StringArray`` / scalars), so an RMATRIX write of a nested list is rejected.
+``Mission.__setitem__`` therefore routes RMATRIX writes through ``SetMatrix``
+with a gmat ``Rmatrix`` (see ``Mission._build_rmatrix``). These tests pin that
+round-trip — and the RVECTOR write path — against real gmatpy, which the
+fake-backed unit tests in ``test_mission.py`` cannot.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gmat_run import Mission
+
+pytestmark = pytest.mark.integration
+
+_SCRIPT = Path(__file__).parent / "fixtures" / "Ex_MinimalLEO.script"
+
+
+def test_rmatrix_field_reads_as_nested_list(gmat_available: None) -> None:
+    """``Sat.Covariance`` (RMATRIX_TYPE) reads back as a nested list of floats."""
+    mission = Mission.load(_SCRIPT)
+    cov = mission["Sat.Covariance"]
+    assert isinstance(cov, list)
+    assert len(cov) == 6
+    assert all(isinstance(row, list) and len(row) == 6 for row in cov)
+    assert all(isinstance(value, float) for row in cov for value in row)
+
+
+def test_rmatrix_field_write_round_trips(gmat_available: None) -> None:
+    """An RMATRIX field written through the dotted-path setter round-trips.
+
+    Regression for issue #141: gmatpy ``SetField`` rejects a nested list, so
+    ``Mission.__setitem__`` writes RMATRIX fields via ``SetMatrix``.
+    """
+    mission = Mission.load(_SCRIPT)
+    target = [[float(i * 6 + j) for j in range(6)] for i in range(6)]
+    mission["Sat.Covariance"] = target
+    assert mission["Sat.Covariance"] == target
+
+
+def test_rvector_field_write_is_accepted(gmat_available: None) -> None:
+    """An RVECTOR field accepts a list write through the dotted-path setter.
+
+    ``ReportFile.UpperLeft`` is RVECTOR_TYPE; a flat list maps to ``SetField``'s
+    ``RealArray`` overload. Read-back is not asserted: the only RVECTOR fields
+    in a headless mission are Subscriber GUI fields, which are unsized headless
+    and raise on ``GetVector`` — so this confirms the write path only.
+    """
+    mission = Mission.load(_SCRIPT)
+    mission["RF.UpperLeft"] = [0.1, 0.2]  # must not raise

--- a/tests/test_mission.py
+++ b/tests/test_mission.py
@@ -50,10 +50,15 @@ _TYPE_CODES = {
 
 
 class _FakeRmatrix:
-    """Minimal Rmatrix stand-in supporting the read path Mission uses."""
+    """Minimal Rmatrix stand-in for the read and write paths Mission uses."""
 
     def __init__(self, rows: list[list[float]]) -> None:
-        self._rows = rows
+        self._rows = [list(row) for row in rows]
+
+    @classmethod
+    def zeros(cls, n_rows: int, n_cols: int) -> _FakeRmatrix:
+        """``gmat.Rmatrix(rows, cols)`` — a zero matrix the write path fills."""
+        return cls([[0.0] * n_cols for _ in range(n_rows)])
 
     def GetNumRows(self) -> int:
         return len(self._rows)
@@ -63,6 +68,9 @@ class _FakeRmatrix:
 
     def GetElement(self, i: int, j: int) -> float:
         return self._rows[i][j]
+
+    def SetElement(self, i: int, j: int, value: float) -> None:
+        self._rows[i][j] = value
 
 
 class _FakeObject:
@@ -145,8 +153,28 @@ class _FakeObject:
         type_code, _, read_only = self._fields[name]
         if read_only:
             raise RuntimeError(f"field '{name}' is read-only")
+        if isinstance(value, (list, tuple)) and any(
+            isinstance(element, (list, tuple)) for element in value
+        ):
+            # Mirror gmatpy: SetField has only RealArray / StringArray / scalar
+            # overloads — a nested array cannot be routed and is rejected.
+            # RMATRIX writes must go through SetMatrix instead.
+            raise RuntimeError(f"SetField('{name}', ...): no overload for a nested array")
         self._fields[name] = (type_code, value, read_only)
         self.set_calls.append((name, value))
+
+    def SetMatrix(self, name: str, matrix: _FakeRmatrix) -> None:
+        # The RMATRIX write path: Mission builds a gmat Rmatrix and hands it
+        # here. Store it as a nested list so GetMatrix round-trips it.
+        type_code, _, read_only = self._fields[name]
+        if read_only:
+            raise RuntimeError(f"field '{name}' is read-only")
+        rows = [
+            [matrix.GetElement(i, j) for j in range(matrix.GetNumColumns())]
+            for i in range(matrix.GetNumRows())
+        ]
+        self._fields[name] = (type_code, rows, read_only)
+        self.set_calls.append((name, rows))
 
     def Initialize(self) -> None:
         self.init_calls += 1
@@ -294,6 +322,7 @@ def _make_fake_gmat(
     module._moderator = _FakeModerator()  # type: ignore[attr-defined]
     module.Moderator = _ModeratorProxy  # type: ignore[attr-defined]
     module.APIException = _FakeAPIException  # type: ignore[attr-defined]
+    module.Rmatrix = _FakeRmatrix.zeros  # type: ignore[attr-defined]
 
     module.GetObject = get_object  # type: ignore[attr-defined]
     module.LoadScript = load_script  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary
- gmatpy's `SetField` has no matrix overload (only `RealArray` / `StringArray` / scalars), so `Mission.__setitem__` passing a nested Python list for an `RMATRIX_TYPE` field (e.g. `Sat.Covariance`) was rejected by the engine — confirmed against GMAT R2026a. Every unit test passed only because the test fake's `SetField` accepted anything; no integration test exercised vector/matrix fields against real gmatpy.
- `Mission.__setitem__` now routes RMATRIX writes through `SetMatrix` with a gmat `Rmatrix` (`Mission._build_rmatrix`), symmetric with the read path's `GetMatrix`. RVECTOR writes (flat list → `RealArray`) and all other types still use `SetField`.
- The `test_mission.py` fake is made faithful to gmatpy (`SetField` rejects nested lists; adds `SetMatrix` / `Rmatrix`), so the existing RMATRIX unit tests genuinely exercise the new path.

## Test plan
- [x] New `tests/integration/test_vector_matrix_fields.py` — RMATRIX read, RMATRIX write round-trip, RVECTOR write, against real gmatpy
- [x] Confirmed the RMATRIX write test fails without the fix (engine "no SetField overload" error)
- [x] `uv run pytest` — 813 passed; full integration suite — 37 passed (real GMAT R2026a)
- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run mypy` — clean

Closes #141
