### PR TITLE
Add Yukon max-iteration solver-log golden fixture

### DIFF
--- a/tests/fixtures/solver_log/yukon_maxiter_R2026a.data
+++ b/tests/fixtures/solver_log/yukon_maxiter_R2026a.data
@@ -1,0 +1,64 @@
+********************************************************
+*** Performing Yukon Optimization (using "Yukon1")
+*** 2 variables; 0 equality constraints; 1 inequality constraints
+   Variables:  X1, X2
+   Inequality Constraints:  G
+********************************************************
+Yukon1 Iteration 0; Function Evaluation 1; Nominal Pass
+   Variables:  X1 = 0, X2 = 0
+   Cost Function Value: 1
+   Yukon1 State: Optimization ready to start.
+
+
+
+   Inequality Constraint Variances:
+      Delta G = -8
+
+Yukon1 Iteration 1; Function Evaluation 2; Nominal Pass
+   Variables:  X1 = 1.99999989903, X2 = -1.00008890058e-05
+   Cost Function Value: 1601.00767741
+   Yukon1 State: Optimization is proceeding as expected.
+
+
+
+   Inequality Constraint Variances:
+      Delta G = -6.00001010186
+
+Yukon1 Iteration 1; Function Evaluation 3; Nominal Pass
+   Variables:  X1 = 0.199999989903, X2 = -1.00008890058e-06
+   Cost Function Value: 0.800007984655
+   Yukon1 State: Optimization is proceeding as expected.
+
+
+
+   Inequality Constraint Variances:
+      Delta G = -7.80000101019
+
+Yukon1 Iteration 2; Function Evaluation 4; Nominal Pass
+   Variables:  X1 = 5.54110337593, X2 = 2.45889660219
+   Cost Function Value: 79798.2288067
+   Yukon1 State: Optimization is proceeding as expected.
+
+
+
+   Inequality Constraint Variances:
+      Delta G = -2.18736460056e-08
+
+Yukon1 Iteration 3; Function Evaluation 5; Nominal Pass
+   Variables:  X1 = 0.209665563906, X2 = 0.105307376277
+   Cost Function Value: 1.0009828889
+   Yukon1 State: Optimization is proceeding as expected.
+
+
+
+   Inequality Constraint Variances:
+      Delta G = -7.68502705982
+
+
+*** Optimization did not converge in 3 iterations
+Final Variable values:
+   X1 = 0.209665563906
+   X2 = 0.105307376277
+Yukon1 failed to converge: Maximum number of iterations exceeded.
+
+

--- a/tests/test_parsers_solver_log.py
+++ b/tests/test_parsers_solver_log.py
@@ -180,6 +180,24 @@ def test_yukon_converged_fixture_attrs() -> None:
     assert df.attrs["source_path"].endswith("yukon_converged_R2026a.data")
 
 
+# --- Yukon: max-iter fixture -------------------------------------------------
+
+
+def test_yukon_maxiter_fixture_ends_max_iter() -> None:
+    df = parse(_FIXTURES / "yukon_maxiter_R2026a.data", max_iterations=3)
+    assert df["status"].iloc[-1] == "max_iter"
+    assert df.attrs["solver_type"] == "Yukon"
+    assert df.attrs["converged"] is False
+    assert df.attrs["n_iterations"] == 3
+
+
+def test_yukon_maxiter_without_max_iterations_falls_back_to_failed() -> None:
+    # Without the MaximumIterations hint a non-converged run cannot be told
+    # apart from a generic failure.
+    df = parse(_FIXTURES / "yukon_maxiter_R2026a.data")
+    assert df["status"].iloc[-1] == "failed"
+
+
 # --- minimal-template happy paths --------------------------------------------
 
 


### PR DESCRIPTION
## Summary
- The Yukon `max_iter` terminal-status branch of `solver_log._status_column` was covered only for `DifferentialCorrector` (`dc_maxiter_R2026a.data`); no Yukon fixture exercised a non-converged, max-iteration optimize run.
- Adds `tests/fixtures/solver_log/yukon_maxiter_R2026a.data` — a real GMAT R2026a Yukon `.data` capture from an `Optimize` run that stops at `MaximumIterations` without converging (a Rosenbrock cost capped at `MaximumIterations = 3`).
- Adds two parser tests mirroring the DifferentialCorrector max-iter pair.

## Test plan
- [x] `test_yukon_maxiter_fixture_ends_max_iter` — `status` ends `max_iter`, `converged is False`, `solver_type == "Yukon"`
- [x] `test_yukon_maxiter_without_max_iterations_falls_back_to_failed` — `status` ends `failed`
- [x] `uv run pytest` — 815 passed
- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run mypy` — clean

Closes #142
