### PR TITLE
Make Results.converged tolerate an unparseable solver log

### DIFF
--- a/src/gmat_run/results.py
+++ b/src/gmat_run/results.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import os
 import shutil
 import tempfile
+import warnings
 from collections.abc import Iterator, Mapping
 from pathlib import Path
 from types import MappingProxyType
@@ -32,6 +33,7 @@ from types import MappingProxyType
 import pandas as pd
 
 from gmat_run._path_utils import resolve_user_path
+from gmat_run.errors import GmatOutputParseError
 from gmat_run.parsers.contact import parse as _parse_contact
 from gmat_run.parsers.ephemeris import parse as _parse_oem_ephemeris
 from gmat_run.parsers.reportfile import parse as _parse_reportfile
@@ -315,15 +317,35 @@ class Results:
         """``{solver name: bool}`` — did each solver run reach its goal?
 
         A convenience view over :attr:`solver_runs` for the common branching
-        case (``if not result.converged["DC"]: ...``). Same keys as
-        :attr:`solver_runs`; ``{}`` when the mission declared no solvers.
+        case (``if not result.converged["DC"]: ...``). ``{}`` when the mission
+        declared no solvers.
+
+        Keys are the solvers whose ``.data`` log parsed successfully. A solver
+        whose log cannot be parsed — an unsupported solver type, a malformed
+        file — is omitted with a :class:`UserWarning` rather than failing the
+        whole property, so one bad log does not hide every other solver's
+        status. Use ``name in result.converged`` to tell an omitted solver
+        apart from a converged/diverged one.
 
         Reading this materialises every solver run (it inspects each
         DataFrame's ``attrs["converged"]``), so the lazy-parse cost is paid on
         first access — the same trade-off as iterating :attr:`solver_runs`
         values directly.
         """
-        return {name: bool(self.solver_runs[name].attrs["converged"]) for name in self.solver_runs}
+        statuses: dict[str, bool] = {}
+        for name in self.solver_runs:
+            try:
+                df = self.solver_runs[name]
+            except GmatOutputParseError as exc:
+                warnings.warn(
+                    f"solver run {name!r} could not be parsed; omitting it from "
+                    f"Results.converged: {exc}",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                continue
+            statuses[name] = bool(df.attrs["converged"])
+        return statuses
 
     def persist(self, path: str | os.PathLike[str]) -> Results:
         """Copy every output artefact under :attr:`output_dir` into ``path``.

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -427,6 +427,16 @@ Goals and achieved values:
 # Same file with the achieved value far from the goal — does not converge.
 _SOLVER_DC_DIVERGED = _SOLVER_DC_CONVERGED.replace("6999.9995", "5000.0")
 
+# A solver-log header that is neither DifferentialCorrector nor Yukon — the
+# solver_log parser raises GmatOutputParseError on it (unsupported solver type).
+_SOLVER_UNRECOGNISED = """\
+********************************************************
+*** Performing SNOPT Optimization (using "Opt1")
+********************************************************
+
+Iteration 1
+"""
+
 
 def _write_solver(path: Path, content: str = _SOLVER_DC_CONVERGED) -> Path:
     path.write_text(content, encoding="utf-8")
@@ -494,6 +504,19 @@ def test_converged_reflects_each_solver(tmp_path: Path) -> None:
     bad = _write_solver(tmp_path / "DC2.data", _SOLVER_DC_DIVERGED)
     result = Results(output_dir=tmp_path, log="", solver_paths={"DC": ok, "DC2": bad})
     assert result.converged == {"DC": True, "DC2": False}
+
+
+def test_converged_omits_unparseable_solver_with_warning(tmp_path: Path) -> None:
+    """A solver whose .data log cannot be parsed (an unsupported solver type)
+    is omitted from converged with a UserWarning — one bad log must not fail
+    the whole property and hide every other solver's status (#143)."""
+    ok = _write_solver(tmp_path / "DC.data", _SOLVER_DC_CONVERGED)
+    bad = _write_solver(tmp_path / "Opt1.data", _SOLVER_UNRECOGNISED)
+    result = Results(output_dir=tmp_path, log="", solver_paths={"DC": ok, "Opt1": bad})
+    with pytest.warns(UserWarning, match="Opt1"):
+        converged = result.converged
+    # The parseable solver's status survives; the unparseable one is absent.
+    assert converged == {"DC": True}
 
 
 def test_solver_max_iterations_threaded_to_parser(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- `Results.converged` built a dict comprehension over `solver_runs`, so the first solver whose `.data` log raised `GmatOutputParseError` (an unsupported solver type, a malformed file) aborted the whole property — hiding the convergence status of every other, parseable solver.
- `converged` now loops, catching `GmatOutputParseError` per solver: an unparseable log is omitted from the returned dict and a `UserWarning` names it. Keys are now the solvers whose log parsed (`name in result.converged` distinguishes an omitted one).

## Test plan
- [x] Added `test_converged_omits_unparseable_solver_with_warning` — a parseable DC + an unrecognised-header solver → `converged == {"DC": True}` with a `UserWarning`
- [x] Confirmed it fails without the fix (the property raised instead of warning)
- [x] `uv run pytest` — 816 passed
- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run mypy` — clean

Closes #143
