### PR TITLE
Cut v0.6.0: version bump, CHANGELOG, docs review pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,55 @@ All notable changes to gmat-run are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] — 2026-05-22
+
+### Added
+
+- `CITATION.cff` — Citation File Format 1.2.0 metadata at the repository
+  root, so GitHub renders the "Cite this repository" sidebar and the
+  academic citation path has one canonical source. A `citation` CI job
+  validates the file with `cffconvert` on every PR (#130, #134).
+
+### Changed
+
+- Parser file-read failures are now typed. All six text parsers —
+  `reportfile`, `ephemeris`, `stk_ephemeris`, `aem_ephemeris`, `contact`,
+  and `solver_log` — route through a shared UTF-8 reader that wraps
+  `OSError` and `UnicodeDecodeError` as
+  [`GmatOutputParseError`][gmat_run.GmatOutputParseError]. A missing or
+  binary input — including a declared `ReportFile` or `EphemerisFile` that
+  GMAT never wrote — now surfaces the typed error on lazy `Results` access
+  instead of a raw `FileNotFoundError` or `UnicodeDecodeError` (#138, #146).
+
+### Fixed
+
+- `*ModJulian` epoch columns are now always `datetime64[ns]`. Under
+  pandas 3.x a ModJulian column of whole-day or integer-typed values
+  resolved to `datetime64[us]`, leaving the column dtype data-dependent and
+  in breach of the documented epoch-column contract (#136, #144).
+- The STK and AEM ephemeris format sniffers no longer leak
+  `UnicodeDecodeError` on a binary or non-UTF-8 file (for example a GMAT
+  Code-500 binary ephemeris). Such a file now sniffs as "not this format"
+  and format dispatch continues instead of raising (#137, #145).
+- Multi-segment OEM and AEM ephemeris files whose segments declare
+  conflicting `TIME_SYSTEM` values are now rejected with
+  `GmatOutputParseError`. Previously they parsed silently into a single
+  epoch column mixing time scales, which a later `convert_to=` then
+  mistranslated (#139, #147).
+- `ReportFile` parsing coerces columns positionally, so a report carrying
+  duplicate header column names — which GMAT's `Report` command can emit —
+  has every column typed and every epoch column promoted, instead of
+  leaving the repeated columns string-typed. A `UserWarning` names the
+  duplicate (#140, #148).
+- `RMATRIX`-typed field writes (for example `Sat.Covariance`) now go
+  through gmatpy's `SetMatrix`, which the engine accepts. They previously
+  used `SetField`, which has no matrix overload and rejected the nested
+  list (#141, #149).
+- [`Results.converged`][gmat_run.Results] no longer aborts when a single
+  solver's log is unparseable. An unreadable log is omitted from the
+  returned mapping and named in a `UserWarning`, rather than hiding the
+  convergence status of every other solver (#143, #151).
+
 ## [0.5.0] — 2026-05-20
 
 ### Added
@@ -207,6 +256,7 @@ Initial public release.
 - Release workflow: build, PyPI trusted publishing, and
   `gh release create --generate-notes` on `v*` tags (#31).
 
+[0.6.0]: https://github.com/astro-tools/gmat-run/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/astro-tools/gmat-run/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/astro-tools/gmat-run/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/astro-tools/gmat-run/compare/v0.2.0...v0.3.0

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,8 +12,8 @@ type: software
 authors:
   - given-names: Dimitrije
     family-names: Jankovic
-version: 0.5.0
-date-released: "2026-05-20"
+version: 0.6.0
+date-released: "2026-05-22"
 license: MIT
 repository-code: "https://github.com/astro-tools/gmat-run"
 url: "https://github.com/astro-tools/gmat-run"

--- a/docs/known-limitations.md
+++ b/docs/known-limitations.md
@@ -117,16 +117,18 @@ GMAT actually emits; uncommon variants raise
 
 - **CCSDS-OEM ephemeris**: covariance blocks (`COVARIANCE_START` …
   `COVARIANCE_STOP`) are skipped; acceleration columns past the mandatory six
-  state components are rejected.
+  state components are rejected. A multi-segment file whose segments declare
+  conflicting `TIME_SYSTEM` values is rejected, since the concatenated epoch
+  column would mix time scales.
 - **STK-TimePosVel ephemeris**: the `EphemerisTimePosVelAcc` (with
   acceleration) and `EphemerisTimePos` (position-only) data-section variants
   are rejected.
 - **CCSDS-AEM attitude**: only `QUATERNION` and `EULER_ANGLE` segment types
   parse. Rate/derivative/spin variants
   (`QUATERNION/DERIVATIVE`, `QUATERNION/RATE`, `EULER_ANGLE/RATE`, `SPIN`,
-  `SPIN/NUTATION`) are rejected, and multi-segment files mixing different
-  `ATTITUDE_TYPE` values are rejected (the column shapes are not
-  concatenable).
+  `SPIN/NUTATION`) are rejected. Multi-segment files are rejected when their
+  segments mix different `ATTITUDE_TYPE` values (the column shapes are not
+  concatenable) or conflicting `TIME_SYSTEM` values.
 - **SPK ephemeris**: the parser assumes one spacecraft per file (which
   matches GMAT's writer behaviour). Multi-target SPKs are rejected.
 - **Code-500 binary ephemeris**: not implemented. No public tooling decodes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gmat-run"
-version = "0.5.0"
+version = "0.6.0"
 description = "Run GMAT mission scripts from Python and get results as pandas DataFrames."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/gmat_run/__init__.py
+++ b/src/gmat_run/__init__.py
@@ -14,7 +14,7 @@ from gmat_run.results import Results
 from gmat_run.runtime import bootstrap
 from gmat_run.summary import CommandOutline, MissionSummary, ResourceGroup
 
-__version__ = "0.5.0"
+__version__ = "0.6.0"
 
 __all__ = [
     "CommandOutline",

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -4,4 +4,4 @@ import gmat_run
 
 
 def test_import() -> None:
-    assert gmat_run.__version__ == "0.5.0"
+    assert gmat_run.__version__ == "0.6.0"

--- a/uv.lock
+++ b/uv.lock
@@ -861,7 +861,7 @@ wheels = [
 
 [[package]]
 name = "gmat-run"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
## Summary

- Bump the version to `0.6.0` across `pyproject.toml`, the package `__init__`, the smoke test, `uv.lock`, and `CITATION.cff` (`version` + `date-released`).
- Add the `CHANGELOG.md` `[0.6.0]` section — `CITATION.cff` under Added, the typed parser file-read contract under Changed, and six parser-robustness fixes under Fixed — aggregated from the 10 PRs merged since v0.5.0, plus the `[0.6.0]` compare link.
- Docs review pass: enumerate the new multi-segment mixed-`TIME_SYSTEM` rejection (#147) in `known-limitations.md`; the rest of the docs were already accurate for v0.6.

## Test plan

- [x] `uv run pytest` — 816 passed (the smoke test now pins `0.6.0`)
- [x] `uv run ruff check` / `uv run ruff format --check` — clean
- [x] `uv run mypy` — clean
- [x] `uv run mkdocs build --strict` — clean
- [ ] `pip install gmat-run==0.6.0` works across the supported Python / OS matrix after the PyPI publish

Closes #133